### PR TITLE
パケットフィルタ更新時のリソース再生成判定を修正

### DIFF
--- a/builtin/providers/sakuracloud/resource_sakuracloud_packet_filter.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_packet_filter.go
@@ -34,7 +34,6 @@ func resourceSakuraCloudPacketFilter() *schema.Resource {
 						"protocol": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ForceNew:     true,
 							ValidateFunc: validateStringInWord(sacloud.AllowPacketFilterProtocol()),
 						},
 

--- a/builtin/providers/sakuracloud/resource_sakuracloud_server_test.go
+++ b/builtin/providers/sakuracloud/resource_sakuracloud_server_test.go
@@ -487,7 +487,7 @@ resource "sakuracloud_packet_filter" "foobar1" {
     name = "mypacket_filter1"
     description = "PacketFilter from TerraForm for SAKURA CLOUD"
     expressions = {
-    	protocol = "tcp"
+    	protocol = "udp"
     	source_nw = "0.0.0.0"
     	source_port = "0-65535"
     	dest_port = "80"
@@ -498,7 +498,7 @@ resource "sakuracloud_packet_filter" "foobar2" {
     name = "mypacket_filter2"
     description = "PacketFilter from TerraForm for SAKURA CLOUD"
     expressions = {
-    	protocol = "tcp"
+    	protocol = "udp"
     	source_nw = "0.0.0.0"
     	source_port = "0-65535"
     	dest_port = "80"


### PR DESCRIPTION
To fix #160 

## 概要

パケットフィルタのルールを変更した際、意図せずリソースが再生成されてしまう。  
サーバに接続した状態のパケットフィルタリソースが再生成されてしまうと、パケットフィルタを削除した段階でエラーが発生してしまう。

このため、リソース再生成の判定部分を修正する。  

## 再現手順

1. 以下のtfファイルで`terraform apply`実施

```hcl
resource "sakuracloud_server" "sv" {
  name              = "sv"
  packet_filter_ids = ["${sakuracloud_packet_filter.pf.id}"]
}

resource "sakuracloud_packet_filter" "pf" {
  name = "pf"

  expressions = {
    protocol = "fragment"
  }

  expressions = {
    protocol = "ip"
    allow    = false
  }
}
```

2. `expressions`を一部削除して再度`terraform apply`を実行

```hcl
resource "sakuracloud_server" "sv" {
  name              = "sv"
  packet_filter_ids = ["${sakuracloud_packet_filter.pf.id}"]
}

resource "sakuracloud_packet_filter" "pf" {
  name = "pf"

  expressions = {
    protocol = "ip"
    allow    = false
  }
}
```