### PR TITLE
配布サイト用に静的コンテンツのビルドを実行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ terraform.tfstate
 terraform.tfstate.backup
 build_docs/site
 terraform-for-sakuracloud-docker
+releases-terraform

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_deploy:
 deploy:
 - provider: script
   script: scripts/release.pl --task=upload-to-github-release && scripts/release.pl
-    --task=upload-master-to-github-release && scripts/release_homebrew.sh && scripts/release_docker_image.sh
+    --task=upload-master-to-github-release && scripts/release_homebrew.sh && scripts/release_docker_image.sh && scripts/release_website.sh
   skip_cleanup: true
   on:
     branch: master

--- a/scripts/release_docker_image.sh
+++ b/scripts/release_docker_image.sh
@@ -10,7 +10,7 @@ git fetch origin
 # check version
 CURRENT_VERSION=`git tag -l --sort=-v:refname | perl -ne 'if(/^v([0-9\.]+)$/){print $1;exit}'`
 if [ "$CURRENT_VERSION" = "$VERSION" ] ; then
-    echo "v$VERSION is already released."
+    echo "terraform-for-sakuracloud-docker v$VERSION is already released."
     exit 0
 fi
 
@@ -44,6 +44,5 @@ echo "Cleanup tag ${VERSION} on github.com/sacloud/terraform-for-sakuracloud-doc
 git push --quiet -u "https://${GITHUB_TOKEN}@github.com/sacloud/terraform-for-sakuracloud-docker.git" :${VERSION} >& /dev/null
 
 echo "Tagging ${VERSION} on github.com/sacloud/terraform-for-sakuracloud-docker.git"
-git tag ${VERSION} 2>&1 >/dev/null
 git push --quiet -u "https://${GITHUB_TOKEN}@github.com/sacloud/terraform-for-sakuracloud-docker.git" ${VERSION} >& /dev/null
 exit 0

--- a/scripts/release_homebrew.sh
+++ b/scripts/release_homebrew.sh
@@ -10,7 +10,7 @@ cd homebrew-terraform-provider-sakuracloud
 # check version
 CURRENT_VERSION=`git log --oneline | perl -ne 'if(/^.+ v([0-9\.]+)/){print $1;exit}'`
 if [ "$CURRENT_VERSION" = "$VERSION" ] ; then
-    echo "v$VERSION is already released."
+    echo "homebrew-terraform-provider-sakuracloud v$VERSION is already released."
     exit 0
 fi
 

--- a/scripts/release_website.sh
+++ b/scripts/release_website.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+VERSION=`git log --merges --oneline | perl -ne 'if(m/^.+Merge pull request \#[0-9]+ from .+\/bump-version-([0-9\.]+)/){print $1;exit}'`
+
+# clone
+git clone --depth=50 --branch=master https://github.com/sacloud/releases-terraform.git releases-terraform
+cd releases-terraform
+git fetch origin
+
+# check version
+CURRENT_VERSION=`git tag -l --sort=-v:refname | perl -ne 'if(/^v([0-9\.]+)$/){print $1;exit}'`
+if [ "$CURRENT_VERSION" = "$VERSION" ] ; then
+    echo "sacloud/releases-terraform v$VERSION is already released."
+    exit 0
+fi
+
+# build website static contents
+rm -rf bin/
+cp -r ../bin ./
+cat << EOL > status.html
+OK(current version: v${VERSION})
+EOL
+
+# commit and push to github.com
+git config --global push.default matching
+git config user.email 'yamamoto.febc@gmail.com'
+git config user.name 'usacloud'
+git add .
+git commit -m "v${VERSION}"
+git tag "${VERSION}"
+
+echo "Push ${VERSION} to github.com/sacloud/releases-terraform.git"
+git push --quiet -u "https://${GITHUB_TOKEN}@github.com/sacloud/releases-terraform.git" >& /dev/null
+
+echo "Cleanup tag ${VERSION} on github.com/sacloud/releases-terraform.git"
+git push --quiet -u "https://${GITHUB_TOKEN}@github.com/sacloud/releases-terraform.git" :${VERSION} >& /dev/null
+
+echo "Tagging ${VERSION} on github.com/sacloud/releases-terraform.git"
+git push --quiet -u "https://${GITHUB_TOKEN}@github.com/sacloud/releases-terraform.git" ${VERSION} >& /dev/null
+exit 0


### PR DESCRIPTION
TravisCI上でのビルド/デプロイ時、releases.usacloud.jpで配布するための静的コンテンツ用Dockerイメージのビルド(ソースリポジトリへのコミット)を行う。