### PR TITLE
テスト用のゾーン検証スキップオプション追加

### DIFF
--- a/sakuracloud/data_source_sakuracloud_archive.go
+++ b/sakuracloud/data_source_sakuracloud_archive.go
@@ -80,7 +80,7 @@ func dataSourceSakuraCloudArchive() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_bridge.go
+++ b/sakuracloud/data_source_sakuracloud_bridge.go
@@ -56,7 +56,7 @@ func dataSourceSakuraCloudBridge() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_cdrom.go
+++ b/sakuracloud/data_source_sakuracloud_cdrom.go
@@ -69,7 +69,7 @@ func dataSourceSakuraCloudCDROM() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_database.go
+++ b/sakuracloud/data_source_sakuracloud_database.go
@@ -112,7 +112,7 @@ func dataSourceSakuraCloudDatabase() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"tk1a", "is1b"}),
+				ValidateFunc: validateZone([]string{"tk1a", "is1b"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_disk.go
+++ b/sakuracloud/data_source_sakuracloud_disk.go
@@ -81,7 +81,7 @@ func dataSourceSakuraCloudDisk() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_internet.go
+++ b/sakuracloud/data_source_sakuracloud_internet.go
@@ -119,7 +119,7 @@ func dataSourceSakuraCloudInternet() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_loadbalancer.go
+++ b/sakuracloud/data_source_sakuracloud_loadbalancer.go
@@ -102,7 +102,7 @@ func dataSourceSakuraCloudLoadBalancer() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_nfs.go
+++ b/sakuracloud/data_source_sakuracloud_nfs.go
@@ -85,7 +85,7 @@ func dataSourceSakuraCloudNFS() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_packet_filter.go
+++ b/sakuracloud/data_source_sakuracloud_packet_filter.go
@@ -85,7 +85,7 @@ func dataSourceSakuraCloudPacketFilter() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_private_host.go
+++ b/sakuracloud/data_source_sakuracloud_private_host.go
@@ -73,7 +73,7 @@ func dataSourceSakuraCloudPrivateHost() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"tk1a"}),
+				ValidateFunc: validateZone([]string{"tk1a"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_server.go
+++ b/sakuracloud/data_source_sakuracloud_server.go
@@ -108,7 +108,7 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 			"macaddresses": {
 				Type:     schema.TypeList,

--- a/sakuracloud/data_source_sakuracloud_subnet.go
+++ b/sakuracloud/data_source_sakuracloud_subnet.go
@@ -57,7 +57,7 @@ func dataSourceSakuraCloudSubnet() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_switch.go
+++ b/sakuracloud/data_source_sakuracloud_switch.go
@@ -75,7 +75,7 @@ func dataSourceSakuraCloudSwitch() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -31,7 +31,7 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc:  schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_ZONE"}, nil),
 				Description:  "Target SakuraCloud Zone(is1a | is1b | tk1a | tk1v)",
 				InputDefault: DefaultZone,
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 			"timeout": {
 				Type:        schema.TypeInt,

--- a/sakuracloud/resource_sakuracloud_auto_backup.go
+++ b/sakuracloud/resource_sakuracloud_auto_backup.go
@@ -60,7 +60,7 @@ func resourceSakuraCloudAutoBackup() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1b", "tk1a"}),
+				ValidateFunc: validateZone([]string{"is1b", "tk1a"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_bridge.go
+++ b/sakuracloud/resource_sakuracloud_bridge.go
@@ -40,7 +40,7 @@ func resourceSakuraCloudBridge() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_cdrom.go
+++ b/sakuracloud/resource_sakuracloud_cdrom.go
@@ -77,7 +77,7 @@ func resourceSakuraCloudCDROM() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_database.go
+++ b/sakuracloud/resource_sakuracloud_database.go
@@ -113,7 +113,7 @@ func resourceSakuraCloudDatabase() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"tk1a", "is1b"}),
+				ValidateFunc: validateZone([]string{"tk1a", "is1b"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_disk.go
+++ b/sakuracloud/resource_sakuracloud_disk.go
@@ -86,7 +86,7 @@ func resourceSakuraCloudDisk() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 			"hostname": {
 				Type:         schema.TypeString,

--- a/sakuracloud/resource_sakuracloud_internet.go
+++ b/sakuracloud/resource_sakuracloud_internet.go
@@ -62,7 +62,7 @@ func resourceSakuraCloudInternet() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 			"switch_id": {
 				Type:     schema.TypeString,

--- a/sakuracloud/resource_sakuracloud_loadbalancer.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer.go
@@ -90,7 +90,7 @@ func resourceSakuraCloudLoadBalancer() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 			"vip_ids": {
 				Type:     schema.TypeList,

--- a/sakuracloud/resource_sakuracloud_loadbalancer_server.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer_server.go
@@ -61,7 +61,7 @@ func resourceSakuraCloudLoadBalancerServer() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_loadbalancer_vip.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer_vip.go
@@ -49,7 +49,7 @@ func resourceSakuraCloudLoadBalancerVIP() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 			"servers": {
 				Type:     schema.TypeList,

--- a/sakuracloud/resource_sakuracloud_nfs.go
+++ b/sakuracloud/resource_sakuracloud_nfs.go
@@ -80,7 +80,7 @@ func resourceSakuraCloudNFS() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_packet_filter.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter.go
@@ -74,7 +74,7 @@ func resourceSakuraCloudPacketFilter() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_packet_filter_rule.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter_rule.go
@@ -68,7 +68,7 @@ func resourceSakuraCloudPacketFilterRule() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_private_host.go
+++ b/sakuracloud/resource_sakuracloud_private_host.go
@@ -55,7 +55,7 @@ func resourceSakuraCloudPrivateHost() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1b", "tk1a"}),
+				ValidateFunc: validateZone([]string{"is1b", "tk1a"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -111,7 +111,7 @@ func resourceSakuraCloudServer() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 			"macaddresses": {
 				Type:     schema.TypeList,

--- a/sakuracloud/resource_sakuracloud_server_connector.go
+++ b/sakuracloud/resource_sakuracloud_server_connector.go
@@ -54,7 +54,7 @@ func resourceSakuraCloudServerConnector() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_subnet.go
+++ b/sakuracloud/resource_sakuracloud_subnet.go
@@ -42,7 +42,7 @@ func resourceSakuraCloudSubnet() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 			"switch_id": {
 				Type:     schema.TypeString,

--- a/sakuracloud/resource_sakuracloud_switch.go
+++ b/sakuracloud/resource_sakuracloud_switch.go
@@ -54,7 +54,7 @@ func resourceSakuraCloudSwitch() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -94,7 +94,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router_dhcp_server.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_dhcp_server.go
@@ -53,7 +53,7 @@ func resourceSakuraCloudVPCRouterDHCPServer() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router_dhcp_static_mapping.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_dhcp_static_mapping.go
@@ -43,7 +43,7 @@ func resourceSakuraCloudVPCRouterDHCPStaticMapping() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router_firewall.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_firewall.go
@@ -95,7 +95,7 @@ func resourceSakuraCloudVPCRouterFirewall() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router_interface.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_interface.go
@@ -62,7 +62,7 @@ func resourceSakuraCloudVPCRouterInterface() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router_l2tp.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_l2tp.go
@@ -49,7 +49,7 @@ func resourceSakuraCloudVPCRouterL2TP() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router_port_forwarding.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_port_forwarding.go
@@ -63,7 +63,7 @@ func resourceSakuraCloudVPCRouterPortForwarding() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router_pptp.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_pptp.go
@@ -43,7 +43,7 @@ func resourceSakuraCloudVPCRouterPPTP() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router_site_to_site_vpn.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_site_to_site_vpn.go
@@ -57,7 +57,7 @@ func resourceSakuraCloudVPCRouterSiteToSiteIPsecVPN() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 			// HACK : terraform not supported nested structure yet
 			// see: https://github.com/hashicorp/terraform/issues/6215

--- a/sakuracloud/resource_sakuracloud_vpc_router_static_nat.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_static_nat.go
@@ -50,7 +50,7 @@ func resourceSakuraCloudVPCRouterStaticNAT() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router_static_route.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_static_route.go
@@ -43,7 +43,7 @@ func resourceSakuraCloudVPCRouterStaticRoute() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_vpc_router_user.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_user.go
@@ -40,7 +40,7 @@ func resourceSakuraCloudVPCRouterRemoteAccessUser() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateStringInWord([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
 		},
 	}

--- a/sakuracloud/validators.go
+++ b/sakuracloud/validators.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -219,4 +220,11 @@ func validateList(validator schema.SchemaValidateFunc) schema.SchemaValidateFunc
 		}
 		return
 	}
+}
+
+func validateZone(allowZones []string) schema.SchemaValidateFunc {
+	if os.Getenv("SAKURACLOUD_FORCE_USE_ZONES") != "" {
+		return func(interface{}, string) (ws []string, errors []error) { return }
+	}
+	return validateStringInWord(allowZones)
 }


### PR DESCRIPTION
テストのために環境変数`SAKURACLOUD_FORCE_USE_ZONES`という隠しパラメータを新設する。

この環境変数が空文字でない場合はプロバイダー/各リソース(データリソース含む)での`zone`パラメータの検証を行わず設定値をそのまま利用するようにする。

#### 利用例

```bash
#コマンド実行ごとに設定
$ SAKURACLOUD_FORCE_USE_ZONES=1 terraform apply

# またはexportしておく
$ export SAKURACLOUD_FORCE_USE_ZONES=1
$ terraform apply
```
