### PR TITLE
DNSレコードでのスキーママイグレーション時インデックス取得

### DIFF
--- a/sakuracloud/structure.go
+++ b/sakuracloud/structure.go
@@ -11,11 +11,12 @@ import (
 	"time"
 )
 
-type resourceValueGetable interface {
+type resourceValueGettable interface {
+	Get(key string) interface{}
 	GetOk(key string) (interface{}, bool)
 }
 
-func getSacloudAPIClient(d resourceValueGetable, meta interface{}) *APIClient {
+func getSacloudAPIClient(d resourceValueGettable, meta interface{}) *APIClient {
 	c := meta.(*APIClient)
 	client := c.Clone()
 


### PR DESCRIPTION
To fix #261 

スキーママイグレーション(v0 -> v1)時のID設定処理のために`*terraform.InstanceState`の値から現在のレコードインデックスを取得する。