### PR TITLE
データベースアプライアンス作成APIパラメータの修正

### DIFF
--- a/vendor/github.com/sacloud/libsacloud/api/webaccel.go
+++ b/vendor/github.com/sacloud/libsacloud/api/webaccel.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/sacloud/libsacloud/sacloud"
+	"strings"
 )
 
 // WebAccelAPI ウェブアクセラレータAPI
@@ -28,6 +29,66 @@ func NewWebAccelAPI(client *Client) *WebAccelAPI {
 type WebAccelDeleteCacheResponse struct {
 	*sacloud.ResultFlagValue
 	Results []*sacloud.DeleteCacheResult
+}
+
+// Read サイト情報取得
+func (api *WebAccelAPI) Read(id string) (*sacloud.WebAccelSite, error) {
+
+	uri := fmt.Sprintf("%s/site/%s", api.getResourceURL(), id)
+
+	data, err := api.client.newRequest("GET", uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		Site sacloud.WebAccelSite
+	}
+	if err := json.Unmarshal(data, &res); err != nil {
+		return nil, err
+	}
+	return &res.Site, nil
+}
+
+// ReadCertificate 証明書 参照
+func (api *WebAccelAPI) ReadCertificate(id string) (*sacloud.WebAccelCertResponseBody, error) {
+	uri := fmt.Sprintf("%s/site/%s/certificate", api.getResourceURL(), id)
+
+	data, err := api.client.newRequest("GET", uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res sacloud.WebAccelCertResponse
+	if err := json.Unmarshal(data, &res); err != nil {
+		return nil, err
+	}
+	return res.Certificate, nil
+}
+
+// UpdateCertificate 証明書 更新
+func (api *WebAccelAPI) UpdateCertificate(id string, request *sacloud.WebAccelCertRequest) (*sacloud.WebAccelCertResponse, error) {
+	uri := fmt.Sprintf("%s/site/%s/certificate", api.getResourceURL(), id)
+
+	if request.CertificateChain != "" {
+		request.CertificateChain = strings.TrimRight(request.CertificateChain, "\n")
+	}
+	if request.Key != "" {
+		request.Key = strings.TrimRight(request.Key, "\n")
+	}
+
+	data, err := api.client.newRequest("PUT", uri, map[string]interface{}{
+		"Certificate": request,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res sacloud.WebAccelCertResponse
+	if err := json.Unmarshal(data, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
 }
 
 // DeleteCache キャッシュ削除

--- a/vendor/github.com/sacloud/libsacloud/api/webaccel_search.go
+++ b/vendor/github.com/sacloud/libsacloud/api/webaccel_search.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/sacloud/libsacloud/sacloud"
+	"net/url"
+	"strings"
+)
+
+// Reset 検索条件のリセット
+func (api *WebAccelAPI) Reset() *WebAccelAPI {
+	api.SetEmpty()
+	return api
+}
+
+// SetEmpty 検索条件のリセット
+func (api *WebAccelAPI) SetEmpty() {
+	api.reset()
+}
+
+// FilterBy 指定キーでのフィルター
+func (api *WebAccelAPI) FilterBy(key string, value interface{}) *WebAccelAPI {
+	api.filterBy(key, value, false)
+	return api
+}
+
+// WithNameLike 名称条件
+func (api *WebAccelAPI) WithNameLike(name string) *WebAccelAPI {
+	return api.FilterBy("Name", name)
+}
+
+// SetFilterBy 指定キーでのフィルター
+func (api *WebAccelAPI) SetFilterBy(key string, value interface{}) {
+	api.filterBy(key, value, false)
+}
+
+// SetNameLike 名称条件
+func (api *WebAccelAPI) SetNameLike(name string) {
+	api.FilterBy("Name", name)
+}
+
+// Find サイト一覧取得
+func (api *WebAccelAPI) Find() (*sacloud.SearchResponse, error) {
+
+	uri := fmt.Sprintf("%s/site", api.getResourceURL())
+
+	data, err := api.client.newRequest("GET", uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res sacloud.SearchResponse
+	if err := json.Unmarshal(data, &res); err != nil {
+		return nil, err
+	}
+
+	// handle filter(API側がFilterに対応していないためここでフィルタリング)
+	for key, filter := range api.getSearchState().Filter {
+		if key != "Name" {
+			continue
+		}
+		strNames, ok := filter.(string)
+		if !ok {
+			continue
+		}
+
+		names := strings.Split(strNames, " ")
+		filtered := []sacloud.WebAccelSite{}
+		for _, site := range res.WebAccelSites {
+			for _, name := range names {
+
+				u, _ := url.Parse(name)
+
+				if strings.Contains(site.Name, u.Path) {
+					filtered = append(filtered, site)
+					break
+				}
+			}
+		}
+		res.WebAccelSites = filtered
+	}
+
+	return &res, nil
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
@@ -140,65 +140,66 @@ type EDiskConnection string
 
 // SakuraCloudResources さくらのクラウド上のリソース種別一覧
 type SakuraCloudResources struct {
-	Server          *Server             `json:",omitempty"` // サーバー
-	Disk            *Disk               `json:",omitempty"` // ディスク
-	Note            *Note               `json:",omitempty"` // スタートアップスクリプト
-	Archive         *Archive            `json:",omitempty"` // アーカイブ
-	PacketFilter    *PacketFilter       `json:",omitempty"` // パケットフィルタ
-	PrivateHost     *PrivateHost        `json:",omitempty"` // 専有ホスト
-	Bridge          *Bridge             `json:",omitempty"` // ブリッジ
-	Icon            *Icon               `json:",omitempty"` // アイコン
-	Image           *Image              `json:",omitempty"` // 画像
-	Interface       *Interface          `json:",omitempty"` // インターフェース
-	Internet        *Internet           `json:",omitempty"` // ルーター
-	IPAddress       *IPAddress          `json:",omitempty"` // IPv4アドレス
-	IPv6Addr        *IPv6Addr           `json:",omitempty"` // IPv6アドレス
-	IPv6Net         *IPv6Net            `json:",omitempty"` // IPv6ネットワーク
-	License         *License            `json:",omitempty"` // ライセンス
-	Switch          *Switch             `json:",omitempty"` // スイッチ
-	CDROM           *CDROM              `json:",omitempty"` // ISOイメージ
-	SSHKey          *SSHKey             `json:",omitempty"` // 公開鍵
-	Subnet          *Subnet             `json:",omitempty"` // IPv4ネットワーク
-	DiskPlan        *ProductDisk        `json:",omitempty"` // ディスクプラン
-	InternetPlan    *ProductInternet    `json:",omitempty"` // ルータープラン
-	LicenseInfo     *ProductLicense     `json:",omitempty"` // ライセンス情報
-	ServerPlan      *ProductServer      `json:",omitempty"` // サーバープラン
-	PrivateHostPlan *ProductPrivateHost `json:",omitempty"` // 専有ホストプラン
-	Region          *Region             `json:",omitempty"` // リージョン
-	Zone            *Zone               `json:",omitempty"` // ゾーン
-	FTPServer       *FTPServer          `json:",omitempty"` // FTPサーバー情報
-
+	Server          *Server             `json:",omitempty"`     // サーバー
+	Disk            *Disk               `json:",omitempty"`     // ディスク
+	Note            *Note               `json:",omitempty"`     // スタートアップスクリプト
+	Archive         *Archive            `json:",omitempty"`     // アーカイブ
+	PacketFilter    *PacketFilter       `json:",omitempty"`     // パケットフィルタ
+	PrivateHost     *PrivateHost        `json:",omitempty"`     // 専有ホスト
+	Bridge          *Bridge             `json:",omitempty"`     // ブリッジ
+	Icon            *Icon               `json:",omitempty"`     // アイコン
+	Image           *Image              `json:",omitempty"`     // 画像
+	Interface       *Interface          `json:",omitempty"`     // インターフェース
+	Internet        *Internet           `json:",omitempty"`     // ルーター
+	IPAddress       *IPAddress          `json:",omitempty"`     // IPv4アドレス
+	IPv6Addr        *IPv6Addr           `json:",omitempty"`     // IPv6アドレス
+	IPv6Net         *IPv6Net            `json:",omitempty"`     // IPv6ネットワーク
+	License         *License            `json:",omitempty"`     // ライセンス
+	Switch          *Switch             `json:",omitempty"`     // スイッチ
+	CDROM           *CDROM              `json:",omitempty"`     // ISOイメージ
+	SSHKey          *SSHKey             `json:",omitempty"`     // 公開鍵
+	Subnet          *Subnet             `json:",omitempty"`     // IPv4ネットワーク
+	DiskPlan        *ProductDisk        `json:",omitempty"`     // ディスクプラン
+	InternetPlan    *ProductInternet    `json:",omitempty"`     // ルータープラン
+	LicenseInfo     *ProductLicense     `json:",omitempty"`     // ライセンス情報
+	ServerPlan      *ProductServer      `json:",omitempty"`     // サーバープラン
+	PrivateHostPlan *ProductPrivateHost `json:",omitempty"`     // 専有ホストプラン
+	Region          *Region             `json:",omitempty"`     // リージョン
+	Zone            *Zone               `json:",omitempty"`     // ゾーン
+	FTPServer       *FTPServer          `json:",omitempty"`     // FTPサーバー情報
+	WebAccelSite    *WebAccelSite       `json:"Site,omitempty"` // ウェブアクセラレータ サイト
 	//REMARK: CommonServiceItemとApplianceはapiパッケージにて別途定義
 }
 
 // SakuraCloudResourceList さくらのクラウド上のリソース種別一覧(複数形)
 type SakuraCloudResourceList struct {
-	Servers          []Server             `json:",omitempty"` // サーバー
-	Disks            []Disk               `json:",omitempty"` // ディスク
-	Notes            []Note               `json:",omitempty"` // スタートアップスクリプト
-	Archives         []Archive            `json:",omitempty"` // アーカイブ
-	PacketFilters    []PacketFilter       `json:",omitempty"` // パケットフィルタ
-	PrivateHosts     []PrivateHost        `json:",omitempty"` // 専有ホスト
-	Bridges          []Bridge             `json:",omitempty"` // ブリッジ
-	Icons            []Icon               `json:",omitempty"` // アイコン
-	Interfaces       []Interface          `json:",omitempty"` // インターフェース
-	Internet         []Internet           `json:",omitempty"` // ルーター
-	IPAddress        []IPAddress          `json:",omitempty"` // IPv4アドレス
-	IPv6Addrs        []IPv6Addr           `json:",omitempty"` // IPv6アドレス
-	IPv6Nets         []IPv6Net            `json:",omitempty"` // IPv6ネットワーク
-	Licenses         []License            `json:",omitempty"` // ライセンス
-	Switches         []Switch             `json:",omitempty"` // スイッチ
-	CDROMs           []CDROM              `json:",omitempty"` // ISOイメージ
-	SSHKeys          []SSHKey             `json:",omitempty"` // 公開鍵
-	Subnets          []Subnet             `json:",omitempty"` // IPv4ネットワーク
-	DiskPlans        []ProductDisk        `json:",omitempty"` // ディスクプラン
-	InternetPlans    []ProductInternet    `json:",omitempty"` // ルータープラン
-	LicenseInfo      []ProductLicense     `json:",omitempty"` // ライセンス情報
-	ServerPlans      []ProductServer      `json:",omitempty"` // サーバープラン
-	PrivateHostPlans []ProductPrivateHost `json:",omitempty"` // 専有ホストプラン
-	Regions          []Region             `json:",omitempty"` // リージョン
-	Zones            []Zone               `json:",omitempty"` // ゾーン
-	ServiceClasses   []PublicPrice        `json:",omitempty"` // サービスクラス(価格情報)
+	Servers          []Server             `json:",omitempty"`      // サーバー
+	Disks            []Disk               `json:",omitempty"`      // ディスク
+	Notes            []Note               `json:",omitempty"`      // スタートアップスクリプト
+	Archives         []Archive            `json:",omitempty"`      // アーカイブ
+	PacketFilters    []PacketFilter       `json:",omitempty"`      // パケットフィルタ
+	PrivateHosts     []PrivateHost        `json:",omitempty"`      // 専有ホスト
+	Bridges          []Bridge             `json:",omitempty"`      // ブリッジ
+	Icons            []Icon               `json:",omitempty"`      // アイコン
+	Interfaces       []Interface          `json:",omitempty"`      // インターフェース
+	Internet         []Internet           `json:",omitempty"`      // ルーター
+	IPAddress        []IPAddress          `json:",omitempty"`      // IPv4アドレス
+	IPv6Addrs        []IPv6Addr           `json:",omitempty"`      // IPv6アドレス
+	IPv6Nets         []IPv6Net            `json:",omitempty"`      // IPv6ネットワーク
+	Licenses         []License            `json:",omitempty"`      // ライセンス
+	Switches         []Switch             `json:",omitempty"`      // スイッチ
+	CDROMs           []CDROM              `json:",omitempty"`      // ISOイメージ
+	SSHKeys          []SSHKey             `json:",omitempty"`      // 公開鍵
+	Subnets          []Subnet             `json:",omitempty"`      // IPv4ネットワーク
+	DiskPlans        []ProductDisk        `json:",omitempty"`      // ディスクプラン
+	InternetPlans    []ProductInternet    `json:",omitempty"`      // ルータープラン
+	LicenseInfo      []ProductLicense     `json:",omitempty"`      // ライセンス情報
+	ServerPlans      []ProductServer      `json:",omitempty"`      // サーバープラン
+	PrivateHostPlans []ProductPrivateHost `json:",omitempty"`      // 専有ホストプラン
+	Regions          []Region             `json:",omitempty"`      // リージョン
+	Zones            []Zone               `json:",omitempty"`      // ゾーン
+	ServiceClasses   []PublicPrice        `json:",omitempty"`      // サービスクラス(価格情報)
+	WebAccelSites    []WebAccelSite       `json:"Sites,omitempty"` // ウェブアクセラレータ サイト
 
 	//REMARK:CommonServiceItemとApplianceはapiパッケージにて別途定義
 }

--- a/vendor/github.com/sacloud/libsacloud/sacloud/database.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/database.go
@@ -193,22 +193,16 @@ type CreateDatabaseValue struct {
 // NewCreatePostgreSQLDatabaseValue PostgreSQL作成用パラメーター
 func NewCreatePostgreSQLDatabaseValue() *CreateDatabaseValue {
 	return &CreateDatabaseValue{
-		DatabaseName:     "postgres",
-		DatabaseRevision: "9.6.2",
-		DatabaseTitle:    "PostgreSQL 9.6.2",
-		DatabaseVersion:  "9.6",
-		// ReplicaUser:      "replica",
+		DatabaseName:    "postgres",
+		DatabaseVersion: "9.6",
 	}
 }
 
 // NewCreateMariaDBDatabaseValue MariaDB作成用パラメーター
 func NewCreateMariaDBDatabaseValue() *CreateDatabaseValue {
 	return &CreateDatabaseValue{
-		DatabaseName:     "MariaDB",
-		DatabaseRevision: "10.1.21",
-		DatabaseTitle:    "MariaDB 10.1.21",
-		DatabaseVersion:  "10.1",
-		// ReplicaUser:      "replica",
+		DatabaseName:    "MariaDB",
+		DatabaseVersion: "10.1",
 	}
 }
 

--- a/vendor/github.com/sacloud/libsacloud/sacloud/disk.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/disk.go
@@ -24,9 +24,11 @@ type Disk struct {
 	ReinstallCount int `json:",omitempty"` // 再インストール回数
 
 	Storage struct { // ストレージ
-		*Resource         // ID
-		MountIndex int64  `json:",omitempty"` // マウント順
-		Class      string `json:",omitempty"` // クラス
+		*Resource              // ID
+		Name       string      `json:",omitempty"`  // 名称
+		DiskPlan   ProductDisk `json:",ommitempty"` // ディスクプラン
+		MountIndex int64       `json:",omitempty"`  // マウント順
+		Class      string      `json:",omitempty"`  // クラス
 	}
 }
 

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_timestamp.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_timestamp.go
@@ -14,11 +14,22 @@ func (p *propCreatedAt) GetCreatedAt() *time.Time {
 
 // PropModifiedAt 変更日時内包型
 type PropModifiedAt struct {
-	// CreatedAt 変更日時
+	// ModifiedAt 変更日時
 	ModifiedAt *time.Time `json:",omitempty"`
 }
 
 // GetModifiedAt 変更日時 取得
 func (p *PropModifiedAt) GetModifiedAt() *time.Time {
 	return p.ModifiedAt
+}
+
+// propUpdatedAt 変更日時内包型
+type propUpdatedAt struct {
+	// UpdatedAt 変更日時
+	UpdatedAt *time.Time `json:",omitempty"`
+}
+
+// GetModifiedAt 変更日時 取得
+func (p *propUpdatedAt) GetModifiedAt() *time.Time {
+	return p.UpdatedAt
 }

--- a/vendor/github.com/sacloud/libsacloud/sacloud/webaccel.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/webaccel.go
@@ -1,0 +1,201 @@
+package sacloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// EWebAccelDomainType ウェブアクセラレータ ドメイン種別
+type EWebAccelDomainType string
+
+const (
+	// EWebAccelDomainTypeOwn 独自ドメイン
+	EWebAccelDomainTypeOwn = EWebAccelDomainType("own_domain")
+	// EWebAccelDomainTypeSubDomain サブドメイン
+	EWebAccelDomainTypeSubDomain = EWebAccelDomainType("subdomain")
+)
+
+// EWebAccelStatus ウェブアクセラレータ ステータス
+type EWebAccelStatus string
+
+const (
+	// EWebAccelStatusEnabled 状態:有効
+	EWebAccelStatusEnabled = EWebAccelStatus("enabled")
+	// EWebAccelStatusDisabled 状態:無効
+	EWebAccelStatusDisabled = EWebAccelStatus("disabled")
+)
+
+// WebAccelSite ウェブアクセラレータ サイト
+type WebAccelSite struct {
+	ID                 string              // ID
+	Name               string              `json:",omitempty"`
+	DomainType         EWebAccelDomainType `json:",omitempty"`
+	Domain             string              `json:",omitempty"`
+	Subdomain          string              `json:",omitempty"`
+	ASCIIDomain        string              `json:",omitempty"`
+	Origin             string              `json:",omitempty"`
+	HostHeader         string
+	Status             EWebAccelStatus `json:",omitempty"`
+	HasCertificate     bool            `json:",omitempty"`
+	HasOldCertificate  bool            `json:",omitempty"`
+	GibSentInLastWeek  int64           `json:",omitempty"`
+	CertValidNotBefore int64           `json:",omitempty"`
+	CertValidNotAfter  int64           `json:",omitempty"`
+	*propCreatedAt
+}
+
+// SetID ID 設定
+func (n *WebAccelSite) SetID(id int64) {
+	n.ID = fmt.Sprintf("%d", id)
+}
+
+// GetID ID 取得
+func (n *WebAccelSite) GetID() int64 {
+	if n == nil {
+		return -1
+	}
+	i, err := strconv.ParseInt(n.ID, 10, 64)
+	if err != nil {
+		return -1
+	}
+	return i
+}
+
+// GetStrID 文字列でID取得
+func (n *WebAccelSite) GetStrID() string {
+	if n == nil {
+		return ""
+	}
+	return n.ID
+}
+
+// GetName 名称取得
+func (n *WebAccelSite) GetName() string {
+	if n == nil {
+		return ""
+	}
+	return n.Name
+}
+
+// SetName 名称取得
+func (n *WebAccelSite) SetName(name string) {
+	if n == nil {
+		return
+	}
+	n.Name = name
+}
+
+// WebAccelCert ウェブアクセラレータ証明書
+type WebAccelCert struct {
+	ID               string `json:",omitempty"`
+	SiteID           string `json:",omitempty"`
+	CertificateChain string `json:",omitempty"`
+	Key              string `json:",omitempty"`
+	*propCreatedAt   `json:",omitempty"`
+	*propUpdatedAt   `json:",omitempty"`
+
+	SerialNumber string `json:",omitempty"`
+	NotBefore    int64  `json:",omitempty"`
+	NotAfter     int64  `json:",omitempty"`
+	Issuer       *struct {
+		Country            string `json:",omitempty"`
+		Organization       string `json:",omitempty"`
+		OrganizationalUnit string `json:",omitempty"`
+		CommonName         string `json:",omitempty"`
+	} `json:",omitempty"`
+	Subject *struct {
+		Country            string `json:",omitempty"`
+		Organization       string `json:",omitempty"`
+		OrganizationalUnit string `json:",omitempty"`
+		Locality           string `json:",omitempty"`
+		Province           string `json:",omitempty"`
+		StreetAddress      string `json:",omitempty"`
+		PostalCode         string `json:",omitempty"`
+		SerialNumber       string `json:",omitempty"`
+		CommonName         string `json:",omitempty"`
+	} `json:",omitempty"`
+	DNSNames          []string `json:",omitempty"`
+	SHA256Fingerprint string   `json:",omitempty"`
+}
+
+// SetID ID 設定
+func (n *WebAccelCert) SetID(id int64) {
+	n.ID = fmt.Sprintf("%d", id)
+}
+
+// GetID ID 取得
+func (n *WebAccelCert) GetID() int64 {
+	if n == nil {
+		return -1
+	}
+	i, err := strconv.ParseInt(n.ID, 10, 64)
+	if err != nil {
+		return -1
+	}
+	return i
+}
+
+// GetStrID 文字列でID取得
+func (n *WebAccelCert) GetStrID() string {
+	if n == nil {
+		return ""
+	}
+	return n.ID
+}
+
+// WebAccelCertRequest ウェブアクセラレータ証明書API リクエスト
+type WebAccelCertRequest struct {
+	CertificateChain string
+	Key              string `json:",omitempty"`
+}
+
+// WebAccelCertResponse ウェブアクセラレータ証明書API レスポンス
+type WebAccelCertResponse struct {
+	Certificate *WebAccelCertResponseBody `json:",omitempty"`
+	ResultFlagValue
+}
+
+// WebAccelCertResponseBody ウェブアクセラレータ証明書API レスポンスボディ
+type WebAccelCertResponseBody struct {
+	Current *WebAccelCert   `json:",omitempty"`
+	Old     []*WebAccelCert `json:",omitempty"`
+}
+
+// UnmarshalJSON JSONアンマーシャル(配列、オブジェクトが混在するためここで対応)
+func (s *WebAccelCertResponse) UnmarshalJSON(data []byte) error {
+	tmp := &struct {
+		Certificate *WebAccelCertResponseBody `json:",omitempty"`
+		ResultFlagValue
+	}{}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	if tmp.Certificate.Current != nil || len(tmp.Certificate.Old) > 0 {
+		s.Certificate = tmp.Certificate
+	}
+	s.ResultFlagValue = tmp.ResultFlagValue
+	return nil
+}
+
+// UnmarshalJSON JSONアンマーシャル(配列、オブジェクトが混在するためここで対応)
+func (s *WebAccelCertResponseBody) UnmarshalJSON(data []byte) error {
+	targetData := strings.Replace(strings.Replace(string(data), " ", "", -1), "\n", "", -1)
+	if targetData == `[]` {
+		return nil
+	}
+
+	tmp := &struct {
+		Current *WebAccelCert   `json:",omitempty"`
+		Old     []*WebAccelCert `json:",omitempty"`
+	}{}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	s.Current = tmp.Current
+	s.Old = tmp.Old
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -725,26 +725,26 @@
 		{
 			"checksumSHA1": "W39zBUUG2o0JH6jL69krg272PwA=",
 			"path": "github.com/sacloud/libsacloud",
-			"revision": "d0ee4921851cb872d1b33446c3c225119c279be3",
-			"revisionTime": "2017-12-15T03:26:13Z"
+			"revision": "c4ff2d5b875457d8d7dfd890d24beb19ebb301fb",
+			"revisionTime": "2018-01-19T09:17:26Z"
 		},
 		{
-			"checksumSHA1": "jq0xnilfFF6jeZoNxE7ZddnupsI=",
+			"checksumSHA1": "eUPDhkXXXquFwevXXBePYa3ARxc=",
 			"path": "github.com/sacloud/libsacloud/api",
-			"revision": "d0ee4921851cb872d1b33446c3c225119c279be3",
-			"revisionTime": "2017-12-15T03:26:13Z"
+			"revision": "c4ff2d5b875457d8d7dfd890d24beb19ebb301fb",
+			"revisionTime": "2018-01-19T09:17:26Z"
 		},
 		{
-			"checksumSHA1": "tuR++GagSXggWEgCw+VM5gLu03M=",
+			"checksumSHA1": "0YtAUjTKm2QX5FK+1WSLzvZtd/I=",
 			"path": "github.com/sacloud/libsacloud/sacloud",
-			"revision": "d0ee4921851cb872d1b33446c3c225119c279be3",
-			"revisionTime": "2017-12-15T03:26:13Z"
+			"revision": "c4ff2d5b875457d8d7dfd890d24beb19ebb301fb",
+			"revisionTime": "2018-01-19T09:17:26Z"
 		},
 		{
 			"checksumSHA1": "TPskly51IHKVf2DAjV3Xs/Fiyx8=",
 			"path": "github.com/sacloud/libsacloud/sacloud/ostype",
-			"revision": "d0ee4921851cb872d1b33446c3c225119c279be3",
-			"revisionTime": "2017-12-15T03:26:13Z"
+			"revision": "c4ff2d5b875457d8d7dfd890d24beb19ebb301fb",
+			"revisionTime": "2018-01-19T09:17:26Z"
 		},
 		{
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",


### PR DESCRIPTION
MariaDB作成時に500エラーが発生することへの対応。

従来は以下のように `DatabaseRevision`パラメータを指定していたが、コントロールパネル上から確認したところ現在は不要なようなので除去。

```js
"DBConf": {
	"Common": {
		"DatabaseName": "MariaDB",
		"DatabaseVersion": "10.1",
		"DatabaseRevision": "10.1.21"
	}
},
```

修正は`libsacloud`のみでTerraform for さくらのクラウド側のソースコードの修正は行なっていない。