### PR TITLE
[WIP]terraform import対応の改善

### DIFF
--- a/sakuracloud/import_test.go
+++ b/sakuracloud/import_test.go
@@ -1,0 +1,41 @@
+package sakuracloud
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func compareState(s *terraform.InstanceState, key, value string) error {
+	actual := s.Attributes[key]
+	if actual != value {
+		return fmt.Errorf("expected state[%s] is %q, but %q received",
+			key, value, actual)
+	}
+	return nil
+}
+
+func compareStateMulti(s *terraform.InstanceState, expects map[string]string) error {
+	for k, v := range expects {
+		err := compareState(s, k, v)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func stateNotEmpty(s *terraform.InstanceState, key string) error {
+	if v, ok := s.Attributes[key]; !ok || v == "" {
+		return fmt.Errorf("state[%s] is expected not empty", key)
+	}
+	return nil
+}
+
+func stateNotEmptyMulti(s *terraform.InstanceState, keys ...string) error {
+	for _, key := range keys {
+		if err := stateNotEmpty(s, key); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/sakuracloud/resource_sakuracloud_archive_test.go
+++ b/sakuracloud/resource_sakuracloud_archive_test.go
@@ -23,10 +23,7 @@ func TestAccResourceSakuraCloudArchive(t *testing.T) {
 					testAccCheckSakuraCloudArchiveExists("sakuracloud_archive.foobar", &archive),
 					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "name", "myarchive"),
 					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "size", "20"),
-					resource.TestCheckResourceAttrPair(
-						"sakuracloud_archive.foobar", "icon_id",
-						"sakuracloud_icon.foobar", "id",
-					),
+					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "icon_id", ""),
 					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "archive_file", "test/dummy.raw"),
 					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "description", "description"),
 					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "tags.0", "tag1"),
@@ -38,7 +35,10 @@ func TestAccResourceSakuraCloudArchive(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "name", "myarchive-upd"),
 					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "size", "20"),
-					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "icon_id", ""),
+					resource.TestCheckResourceAttrPair(
+						"sakuracloud_archive.foobar", "icon_id",
+						"sakuracloud_icon.foobar", "id",
+					),
 					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "archive_file", "test/dummy-upd.raw"),
 					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "description", "description-upd"),
 					resource.TestCheckResourceAttr("sakuracloud_archive.foobar", "tags.0", "tag1-upd"),
@@ -96,6 +96,49 @@ func testAccCheckSakuraCloudArchiveDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccImportSakuraCloudArchive(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+
+		expects := map[string]string{
+			"name":         "myarchive",
+			"size":         "20",
+			"icon_id":      "",
+			"archive_file": "",
+			"description":  "description",
+			"tags.0":       "tag1",
+			"tags.1":       "tag2",
+		}
+
+		return compareStateMulti(s[0], expects)
+	}
+
+	resourceName := "sakuracloud_archive.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSakuraCloudArchiveDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckSakuraCloudArchiveConfig_basic,
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"archive_file",
+					"hash",
+				},
+			},
+		},
+	})
+}
+
 var testAccCheckSakuraCloudArchiveConfig_basic = `
 resource "sakuracloud_archive" "foobar" {
     name = "myarchive"
@@ -104,12 +147,6 @@ resource "sakuracloud_archive" "foobar" {
     hash = "${md5(file("test/dummy.raw"))}"
     description = "description"
     tags = ["tag1" , "tag2"]
-    icon_id = "${sakuracloud_icon.foobar.id}"
-}
-
-resource "sakuracloud_icon" "foobar" {
-    name = "myicon"
-    base64content = "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAACdBJREFUWMPNmHtw1NUVx8+5v9/+9rfJPpJNNslisgmIiCCgDQZR5GWnilUDPlpUqjOB2mp4qGM7tVOn/yCWh4AOVUprHRVB2+lMa0l88Kq10iYpNYPWkdeAmFjyEJPN7v5+v83ec/rH3Q1J2A2Z1hnYvz755ZzzvXPPveeee/GbC24FJmZGIYD5QgPpTBIAAICJLgJAwUQMAIDMfOEBUQchgJmAEC8CINLPThpfFCAG5orhogCBQiAAEyF8PQCATEQyxQzMzFIi4Ojdv86UEVF/f38ymezv7yciANR0zXAZhuHSdR0RRxNHZyJEBERmQvhfAAABIJlMJhIJt9t9TXX11GlTffleQGhvbz/4YeuRw4c13ZWfnycQR9ACQEShAyIxAxEKMXoAIVQ6VCzHcSzLmj937qqVK8aNrYKhv4bGxue3bvu8rc3n9+ualisyMzOltMjYccBqWanKdD5gBgAppZNMJhKJvlgs1heLxWL3fPfutU8/VVhYoGx7e3uJyOVyAcCEyy6bN2d266FDbW3thsuFI0gA4qy589PTOJC7EYEBbNu2ElYg4J9e/Y3p1dWBgN+l67csWKBC/mrbth07dnafOSMQp0y58pEVK2tm1ABAW9vn93zvgYRl5+XlAXMuCbxh3o3MDMyIguE8wADRaJ/H7Vp873119y8JBALDsrN8xcpXX3utoKDQNE1iiEV7ieSzmzYuXrwYAH7z4m83bNocDAZ1Tc8hQThrzjwYxY8BmCjaF/P78n+xZs0Ns64f+Ndnn53yevOLioo2btq8bsOGsvAYn9eHAoFZStnR0aFpWsObfxw/fvzp06fvXnyvZVmmx4M5hHQa3S4DwIRlm4Zr7dNPz7r+OgDo6el5bsuWtxrf6u7u9njygsHC9i/+U1Ia9ubnMzATA7MQIlRS8tnJk3/e1fDoI6vKysoqK8pbP/q323RDdi2hq/0ysHGyAwopU4lEfNXKlWo0Hx069MDSZcePHy8MBk3Tk0ylTnd1+wsKTNMERLUGlLtA1A3jyNEjagIKgsFk0gEM5NCSOst0+wEjAEvHtktKSuoeWAIAX3311f11Szs7OydcPtFwGYDp0sagWhoa7K4G5/f71TfHskEVdHXMn6M16CzLDcRkWfaM6dWm6QGAjZs2t7W1X1JeYRgGMzERMxOnNYa5O8mkrmkzr50JAKlUqq29Le2VQ0sACmYmIvU1OwAmLKt6ejUAyJTcu3dfQTCoaZqUkgEoY0ODvKRMSWbLsjo6O2fPmbuw9nYAOHjw4KdHjhqGoRqgLFpS6oNOE84JRDLVX1FeDgBd3V0pIrfLxZn5GGLMrE40y7YTCcula7W3167++c+UzfNbtzGRK+ObxR1RZyJARPUpNxBzPBYDAE3ThCYkETMjIPMQdwCwbNttGItqb6uqrJo2deqMGTVK8qWXX969+92SsjAi5hRF1BkQKJ3REUDXtE+PHL3ppptCoVBpcXFXVzdJqerFWWNmKaVt2T9YWldf//Dg6rL52efWrV/vCxQYLhdJmV2LmaUUkEkZZGbvXGBm0+P563vvqT/vW7LEcRwnmUxv7wFjZiYyDJdabQCQSsnt27d/6+YFT61Z4/UHBvZadi1mQBRERMwEMAIwkdttNh/8V2trKwB85647a2tv7+npTfb3y6HGKLREIvHKK6+my66ubd/x+p69+0KlZf5AQKV+BC0G0MaURwZGlxMAiam9vf3YsWNL7rsXAL694Oa2tvZPPvnEZRiozBABAIE1XfvggwMfffzxnXcsAoBrZ8zYs3+/pmm6ECNJIKrto4UvueQ8pxiRZduxWKympuauRQsnT56saRoAlIRCbzbsYmYhxGB7TdPcHk9LS3O4LHz1VVcFg8HmpubjJ0643W44/w8FS6kqW1YgKROW5VjWivr6P/3h93V1dYZhKNeD/2zp7elVjfAQLyKP2+0PFG5/NZ242XNm25bNRCNrKUjfy5gIzwXE/mQyEYs98dMnHnrw+yr6hx+2/qOp6djRo43vvGu4XJquZ3X3mO7OL8+cOnUqEolURSpUx53LeDDolDlE+ByQRNG+vlmzZ6vROI69fMWqN954Ix5PBAoLC4PBfK+XMqfSEHdEQJRS2ratyl1KSmLG3FoDoKcXFCIQDQOZTCLAQ8uWKtNlD/5w546dkaqqKq8XERDFQIkb7g6QSqUK/f5wOAwA0WgUiM+u/WxaChBRJxSgzsXhK5+sZDISiVxTUwMAjY2Nu3Y1RMZd6vXmAzCAIOB0uHP2SyqVisViCxcu9Pl8ANDc0oK6xswkxMg7mon0dGHMUqkg6Tjh0lLTdAPABwf+niKZ5zFRtRmQ8RrqyACyv783Gi0vL390eb0qqm+/szvPNNMzNGIFRnUvA0SAzOwNAiLJmU4zHo8DCgAgZgAETtswyX4pk8lkehP0pywrUTV27JaNGyqrKgHgha1bT548WRYOMwDk1hrIna46gbTAUBBCUwcqAFw6frwuRCqV0nUdmFB1MCRtx9E0bWwkEresRDzu9/nm3Th/Vf3DoVAIAJqbmtauXZfv9WpCpBd7Dq00EOGkKdNylCi0EgkhxP4971ZUVJw8ceK2RXd0dX9ZUFCgCaFyYTtOrC/22CMrf/LjH3V0dvX1RSsjEVemUDU3NS1d9uAXHR2lpaVqV4+iMIJWXFKKiEpgCCAKxI6OjuLioutmziwoLBxTFn7r7Xei0WhKSsdxYvF4PJ649Zabn1m/DhC93vxgMKiKuGUlntm46bHHHz/T0xsqKdEEZpYKZ9caJIpXTJmWfuVDofpPBcAMKKLRXoHwl727x106HgAOHDiw5ZcvHD5ymBiCwcJFtbXLM21GQ0ODZVm90ej77/9t3779XV2dBcEifyCgIcLQyCMBMU6cNCX3wQIkqbOzY+LlE373+s6KSER97untdSy7tKx0wHD16tVPPvkkAIDQvV6fz+fNz/emXzyAYVS5yqSsqLh4UM8GwwAFmqZ54sSJXY2NJSUlkyZNAgDTNL1er/Jvb29/uL7+1y++VFQcKg2PCYVCfr/XND1C01QnnytydkDECVdcqdpqtXGGgcqulHTmy+54PH71VdNunD+/sqoSEaPRaEtzy569exO2UxQM5nm9ynpQgrIEPA8w42UTJ6dLEkNWUI0KMTu2E4v3xftiSccGAKHpnrw8v8/vyfPoug4Zv1xxRgOIoDNJQAEMmfo9HNT9DxFN03QbRrCwCNQjHAp1gVc2mQKbM86oAFCA0GDQnSEXqMcGwPQjmND1zGgEAFBmNOeNMzIQSZ0GXvJHuJedPXRkLhiN+2hAVxUdz77yXWDQUdMGFUa40DC4Y/ya5vz/BMEkmVm9dl94QPwvNJB+oilXgHEAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTYtMDItMTBUMjE6MDg6MzMtMDg6MDB4P0OtAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTAyLTEwVDIxOjA4OjMzLTA4OjAwCWL7EQAAAABJRU5ErkJggg=="
 }
 `
 
@@ -121,4 +158,10 @@ resource "sakuracloud_archive" "foobar" {
     hash = "${md5(file("test/dummy-upd.raw"))}"
     description = "description-upd"
     tags = ["tag1-upd" , "tag2-upd"]
-}`
+    icon_id = "${sakuracloud_icon.foobar.id}"
+}
+resource "sakuracloud_icon" "foobar" {
+    name = "myicon"
+    base64content = "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAACdBJREFUWMPNmHtw1NUVx8+5v9/+9rfJPpJNNslisgmIiCCgDQZR5GWnilUDPlpUqjOB2mp4qGM7tVOn/yCWh4AOVUprHRVB2+lMa0l88Kq10iYpNYPWkdeAmFjyEJPN7v5+v83ec/rH3Q1J2A2Z1hnYvz755ZzzvXPPveeee/GbC24FJmZGIYD5QgPpTBIAAICJLgJAwUQMAIDMfOEBUQchgJmAEC8CINLPThpfFCAG5orhogCBQiAAEyF8PQCATEQyxQzMzFIi4Ojdv86UEVF/f38ymezv7yciANR0zXAZhuHSdR0RRxNHZyJEBERmQvhfAAABIJlMJhIJt9t9TXX11GlTffleQGhvbz/4YeuRw4c13ZWfnycQR9ACQEShAyIxAxEKMXoAIVQ6VCzHcSzLmj937qqVK8aNrYKhv4bGxue3bvu8rc3n9+ualisyMzOltMjYccBqWanKdD5gBgAppZNMJhKJvlgs1heLxWL3fPfutU8/VVhYoGx7e3uJyOVyAcCEyy6bN2d266FDbW3thsuFI0gA4qy589PTOJC7EYEBbNu2ElYg4J9e/Y3p1dWBgN+l67csWKBC/mrbth07dnafOSMQp0y58pEVK2tm1ABAW9vn93zvgYRl5+XlAXMuCbxh3o3MDMyIguE8wADRaJ/H7Vp873119y8JBALDsrN8xcpXX3utoKDQNE1iiEV7ieSzmzYuXrwYAH7z4m83bNocDAZ1Tc8hQThrzjwYxY8BmCjaF/P78n+xZs0Ns64f+Ndnn53yevOLioo2btq8bsOGsvAYn9eHAoFZStnR0aFpWsObfxw/fvzp06fvXnyvZVmmx4M5hHQa3S4DwIRlm4Zr7dNPz7r+OgDo6el5bsuWtxrf6u7u9njygsHC9i/+U1Ia9ubnMzATA7MQIlRS8tnJk3/e1fDoI6vKysoqK8pbP/q323RDdi2hq/0ysHGyAwopU4lEfNXKlWo0Hx069MDSZcePHy8MBk3Tk0ylTnd1+wsKTNMERLUGlLtA1A3jyNEjagIKgsFk0gEM5NCSOst0+wEjAEvHtktKSuoeWAIAX3311f11Szs7OydcPtFwGYDp0sagWhoa7K4G5/f71TfHskEVdHXMn6M16CzLDcRkWfaM6dWm6QGAjZs2t7W1X1JeYRgGMzERMxOnNYa5O8mkrmkzr50JAKlUqq29Le2VQ0sACmYmIvU1OwAmLKt6ejUAyJTcu3dfQTCoaZqUkgEoY0ODvKRMSWbLsjo6O2fPmbuw9nYAOHjw4KdHjhqGoRqgLFpS6oNOE84JRDLVX1FeDgBd3V0pIrfLxZn5GGLMrE40y7YTCcula7W3167++c+UzfNbtzGRK+ObxR1RZyJARPUpNxBzPBYDAE3ThCYkETMjIPMQdwCwbNttGItqb6uqrJo2deqMGTVK8qWXX969+92SsjAi5hRF1BkQKJ3REUDXtE+PHL3ppptCoVBpcXFXVzdJqerFWWNmKaVt2T9YWldf//Dg6rL52efWrV/vCxQYLhdJmV2LmaUUkEkZZGbvXGBm0+P563vvqT/vW7LEcRwnmUxv7wFjZiYyDJdabQCQSsnt27d/6+YFT61Z4/UHBvZadi1mQBRERMwEMAIwkdttNh/8V2trKwB85647a2tv7+npTfb3y6HGKLREIvHKK6+my66ubd/x+p69+0KlZf5AQKV+BC0G0MaURwZGlxMAiam9vf3YsWNL7rsXAL694Oa2tvZPPvnEZRiozBABAIE1XfvggwMfffzxnXcsAoBrZ8zYs3+/pmm6ECNJIKrto4UvueQ8pxiRZduxWKympuauRQsnT56saRoAlIRCbzbsYmYhxGB7TdPcHk9LS3O4LHz1VVcFg8HmpubjJ0643W44/w8FS6kqW1YgKROW5VjWivr6P/3h93V1dYZhKNeD/2zp7elVjfAQLyKP2+0PFG5/NZ242XNm25bNRCNrKUjfy5gIzwXE/mQyEYs98dMnHnrw+yr6hx+2/qOp6djRo43vvGu4XJquZ3X3mO7OL8+cOnUqEolURSpUx53LeDDolDlE+ByQRNG+vlmzZ6vROI69fMWqN954Ix5PBAoLC4PBfK+XMqfSEHdEQJRS2ratyl1KSmLG3FoDoKcXFCIQDQOZTCLAQ8uWKtNlD/5w546dkaqqKq8XERDFQIkb7g6QSqUK/f5wOAwA0WgUiM+u/WxaChBRJxSgzsXhK5+sZDISiVxTUwMAjY2Nu3Y1RMZd6vXmAzCAIOB0uHP2SyqVisViCxcu9Pl8ANDc0oK6xswkxMg7mon0dGHMUqkg6Tjh0lLTdAPABwf+niKZ5zFRtRmQ8RrqyACyv783Gi0vL390eb0qqm+/szvPNNMzNGIFRnUvA0SAzOwNAiLJmU4zHo8DCgAgZgAETtswyX4pk8lkehP0pywrUTV27JaNGyqrKgHgha1bT548WRYOMwDk1hrIna46gbTAUBBCUwcqAFw6frwuRCqV0nUdmFB1MCRtx9E0bWwkEresRDzu9/nm3Th/Vf3DoVAIAJqbmtauXZfv9WpCpBd7Dq00EOGkKdNylCi0EgkhxP4971ZUVJw8ceK2RXd0dX9ZUFCgCaFyYTtOrC/22CMrf/LjH3V0dvX1RSsjEVemUDU3NS1d9uAXHR2lpaVqV4+iMIJWXFKKiEpgCCAKxI6OjuLioutmziwoLBxTFn7r7Xei0WhKSsdxYvF4PJ649Zabn1m/DhC93vxgMKiKuGUlntm46bHHHz/T0xsqKdEEZpYKZ9caJIpXTJmWfuVDofpPBcAMKKLRXoHwl727x106HgAOHDiw5ZcvHD5ymBiCwcJFtbXLM21GQ0ODZVm90ej77/9t3779XV2dBcEifyCgIcLQyCMBMU6cNCX3wQIkqbOzY+LlE373+s6KSER97untdSy7tKx0wHD16tVPPvkkAIDQvV6fz+fNz/emXzyAYVS5yqSsqLh4UM8GwwAFmqZ54sSJXY2NJSUlkyZNAgDTNL1er/Jvb29/uL7+1y++VFQcKg2PCYVCfr/XND1C01QnnytydkDECVdcqdpqtXGGgcqulHTmy+54PH71VdNunD+/sqoSEaPRaEtzy569exO2UxQM5nm9ynpQgrIEPA8w42UTJ6dLEkNWUI0KMTu2E4v3xftiSccGAKHpnrw8v8/vyfPoug4Zv1xxRgOIoDNJQAEMmfo9HNT9DxFN03QbRrCwCNQjHAp1gVc2mQKbM86oAFCA0GDQnSEXqMcGwPQjmND1zGgEAFBmNOeNMzIQSZ0GXvJHuJedPXRkLhiN+2hAVxUdz77yXWDQUdMGFUa40DC4Y/ya5vz/BMEkmVm9dl94QPwvNJB+oilXgHEAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTYtMDItMTBUMjE6MDg6MzMtMDg6MDB4P0OtAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTAyLTEwVDIxOjA4OjMzLTA4OjAwCWL7EQAAAABJRU5ErkJggg=="
+}
+`

--- a/sakuracloud/resource_sakuracloud_bridge_test.go
+++ b/sakuracloud/resource_sakuracloud_bridge_test.go
@@ -109,6 +109,43 @@ func testAccCheckSakuraCloudBridgeDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccImportSakuraCloudBridge(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"name":        "mybridge",
+			"description": "Bridge from TerraForm for SAKURA CLOUD",
+			"zone":        "is1b",
+		}
+
+		if err := compareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return stateNotEmptyMulti(s[0], "switch_ids.0")
+	}
+
+	resourceName := "sakuracloud_bridge.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSakuraCloudBridgeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckSakuraCloudBridgeConfig_withSwitch,
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 var testAccCheckSakuraCloudBridgeConfig_withSwitch = `
 resource "sakuracloud_switch" "foobar" {
     name = "myswitch"

--- a/sakuracloud/resource_sakuracloud_database.go
+++ b/sakuracloud/resource_sakuracloud_database.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sacloud/libsacloud/api"
 	"github.com/sacloud/libsacloud/sacloud"
+	"strconv"
 	"strings"
 )
 
@@ -357,7 +358,8 @@ func setDatabaseResourceData(d *schema.ResourceData, client *APIClient, data *sa
 	}
 
 	d.Set("allow_networks", data.Settings.DBConf.Common.SourceNetwork)
-	d.Set("port", data.Settings.DBConf.Common.ServicePort)
+	port, _ := strconv.Atoi(data.Settings.DBConf.Common.ServicePort)
+	d.Set("port", port)
 
 	d.Set("backup_rotate", data.Settings.DBConf.Backup.Rotate)
 	d.Set("backup_time", data.Settings.DBConf.Backup.Time)
@@ -376,6 +378,7 @@ func setDatabaseResourceData(d *schema.ResourceData, client *APIClient, data *sa
 		}
 	}
 	d.Set("tags", realTags(client, tags))
+	setPowerManageTimeoutValueToState(d)
 
 	d.Set("zone", client.Zone)
 	d.SetId(data.GetStrID())

--- a/sakuracloud/resource_sakuracloud_disk.go
+++ b/sakuracloud/resource_sakuracloud_disk.go
@@ -432,6 +432,12 @@ func setDiskResourceData(d *schema.ResourceData, client *APIClient, data *saclou
 
 	}
 
+	if data.SourceDisk != nil {
+		d.Set("source_disk_id", data.SourceDisk.GetStrID())
+	} else if data.SourceArchive != nil {
+		d.Set("source_archive_id", data.SourceArchive.GetStrID())
+	}
+
 	d.Set("connector", fmt.Sprintf("%s", data.Connection))
 	d.Set("size", toSizeGB(data.SizeMB))
 	d.Set("icon_id", data.GetIconStrID())
@@ -443,6 +449,8 @@ func setDiskResourceData(d *schema.ResourceData, client *APIClient, data *saclou
 	} else {
 		d.Set("server_id", data.Server.GetStrID())
 	}
+
+	setPowerManageTimeoutValueToState(d)
 
 	d.Set("zone", client.Zone)
 	d.SetId(data.GetStrID())

--- a/sakuracloud/resource_sakuracloud_dns_test.go
+++ b/sakuracloud/resource_sakuracloud_dns_test.go
@@ -95,6 +95,44 @@ func testAccCheckSakuraCloudDNSDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccImportSakuraCloudDNS(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"zone":        "terraform.io",
+			"description": "DNS from TerraForm for SAKURA CLOUD",
+			"tags.0":      "tag1",
+			"tags.1":      "tag2",
+		}
+
+		if err := compareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return stateNotEmptyMulti(s[0], "icon_id", "dns_servers.0")
+	}
+
+	resourceName := "sakuracloud_dns.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSakuraCloudDNSDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckSakuraCloudDNSConfig_basic,
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 var testAccCheckSakuraCloudDNSConfig_basic = `
 resource "sakuracloud_dns" "foobar" {
     zone = "terraform.io"

--- a/sakuracloud/resource_sakuracloud_gslb.go
+++ b/sakuracloud/resource_sakuracloud_gslb.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sacloud/libsacloud/api"
 	"github.com/sacloud/libsacloud/sacloud"
+	"strings"
 )
 
 func resourceSakuraCloudGSLB() *schema.Resource {
@@ -312,7 +313,7 @@ func setGSLBResourceData(d *schema.ResourceData, client *APIClient, data *saclou
 	d.Set("icon_id", data.GetIconStrID())
 	d.Set("description", data.Description)
 	d.Set("tags", realTags(client, data.Tags))
-	d.Set("weighted", data.Settings.GSLB.Weighted == "True")
+	d.Set("weighted", strings.ToLower(data.Settings.GSLB.Weighted) == "true")
 
 	d.SetId(data.GetStrID())
 	return nil

--- a/sakuracloud/resource_sakuracloud_icon_test.go
+++ b/sakuracloud/resource_sakuracloud_icon_test.go
@@ -116,6 +116,47 @@ func testAccCheckSakuraCloudIconDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccImportSakuraCloudIcon(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"name":   "myicon",
+			"tags.0": "tag1",
+			"tags.1": "tag2",
+		}
+
+		if err := compareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return stateNotEmptyMulti(s[0], "body", "url")
+	}
+
+	resourceName := "sakuracloud_icon.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSakuraCloudIconDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckSakuraCloudIconConfig_basic,
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"source",
+					"base64content",
+				},
+			},
+		},
+	})
+}
+
 const testAccCheckSakuraCloudIconConfig_basic = `
 resource "sakuracloud_icon" "foobar" {
   name = "myicon"

--- a/sakuracloud/resource_sakuracloud_internet.go
+++ b/sakuracloud/resource_sakuracloud_internet.go
@@ -362,6 +362,8 @@ func setInternetResourceData(d *schema.ResourceData, client *APIClient, data *sa
 		d.Set("ipv6_nw_address", nwAddress)
 	}
 
+	setPowerManageTimeoutValueToState(d)
+
 	d.Set("zone", client.Zone)
 	d.SetId(data.GetStrID())
 	return nil

--- a/sakuracloud/resource_sakuracloud_internet_test.go
+++ b/sakuracloud/resource_sakuracloud_internet_test.go
@@ -143,6 +143,60 @@ resource "sakuracloud_icon" "foobar" {
 }
 `
 
+func TestAccImportSakuraCloudInternet(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"name":                      "myinternet_upd",
+			"nw_mask_len":               "28",
+			"band_width":                "500",
+			"enable_ipv6":               "true",
+			"graceful_shutdown_timeout": "60",
+			"description":               "description",
+			"tags.0":                    "tag1",
+			"tags.1":                    "tag2",
+			"icon_id":                   "",
+		}
+
+		if err := compareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return stateNotEmptyMulti(s[0],
+			"switch_id",
+			"server_ids.0",
+			"nw_address",
+			"gateway",
+			"min_ipaddress",
+			"max_ipaddress",
+			"ipaddresses.0",
+			"ipv6_prefix",
+			"ipv6_prefix_len",
+			"ipv6_nw_address",
+		)
+	}
+
+	resourceName := "sakuracloud_internet.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSakuraCloudInternetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckSakuraCloudInternetConfig_update,
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 var testAccCheckSakuraCloudInternetConfig_update = `
 resource "sakuracloud_server" "foobar" {
     name = "myserver"
@@ -165,6 +219,8 @@ resource "sakuracloud_internet" "foobar" {
     name = "myinternet_upd"
     band_width = 500
     enable_ipv6 = true
+    description = "description"
+    tags = ["tag1", "tag2"]
 }`
 
 var testAccCheckSakuraCloudInternetConfig_with_server = `

--- a/sakuracloud/resource_sakuracloud_loadbalancer.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer.go
@@ -288,6 +288,14 @@ func setLoadBalancerResourceData(d *schema.ResourceData, client *APIClient, data
 		d.Set("ipaddress1", data.Remark.Servers[0].(map[string]interface{})["IPAddress"])
 		d.Set("ipaddress2", "")
 	}
+
+	switch data.GetPlanID() {
+	case int64(sacloud.LoadBalancerPlanStandard):
+		d.Set("plan", "standard")
+	case int64(sacloud.LoadBalancerPlanPremium):
+		d.Set("plan", "highspec")
+	}
+
 	d.Set("nw_mask_len", data.Remark.Network.NetworkMaskLen)
 	d.Set("default_route", data.Remark.Network.DefaultRoute)
 
@@ -307,6 +315,7 @@ func setLoadBalancerResourceData(d *schema.ResourceData, client *APIClient, data
 		}
 	}
 
+	setPowerManageTimeoutValueToState(d)
 	d.Set("zone", client.Zone)
 	d.SetId(data.GetStrID())
 	return nil

--- a/sakuracloud/resource_sakuracloud_nfs.go
+++ b/sakuracloud/resource_sakuracloud_nfs.go
@@ -242,6 +242,8 @@ func setNFSResourceData(d *schema.ResourceData, client *APIClient, data *sacloud
 	d.Set("description", data.Description)
 	d.Set("tags", realTags(client, data.Tags))
 
+	setPowerManageTimeoutValueToState(d)
+
 	d.Set("zone", client.Zone)
 	d.SetId(data.GetStrID())
 	return nil

--- a/sakuracloud/resource_sakuracloud_private_host.go
+++ b/sakuracloud/resource_sakuracloud_private_host.go
@@ -214,6 +214,8 @@ func setPrivateHostResourceData(d *schema.ResourceData, client *APIClient, data 
 	d.Set("assigned_core", data.GetAssignedCPU())
 	d.Set("assigned_memory", data.GetAssignedMemoryGB())
 
+	setPowerManageTimeoutValueToState(d)
+
 	d.Set("zone", client.Zone)
 	d.SetId(data.GetStrID())
 	return nil

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -751,9 +751,8 @@ func setServerResourceData(d *schema.ResourceData, client *APIClient, data *sacl
 		}
 	}
 
+	setPowerManageTimeoutValueToState(d)
 	d.Set("zone", client.Zone)
-	// プラン変更時はサーバIDが変更となるためRead時にもID設定しておく
-	d.SetId(data.GetStrID())
 	return nil
 }
 

--- a/sakuracloud/resource_sakuracloud_server_connector.go
+++ b/sakuracloud/resource_sakuracloud_server_connector.go
@@ -202,6 +202,7 @@ func resourceSakuraCloudServerConnectorRead(d *schema.ResourceData, meta interfa
 		d.Set("cdrom_id", data.Instance.CDROM.GetStrID())
 	}
 	d.Set("packet_filter_ids", flattenPacketFilters(data.Interfaces))
+	setPowerManageTimeoutValueToState(d)
 
 	d.Set("zone", client.Zone)
 	return nil

--- a/sakuracloud/resource_sakuracloud_switch.go
+++ b/sakuracloud/resource_sakuracloud_switch.go
@@ -277,7 +277,8 @@ func setSwitchResourceData(d *schema.ResourceData, client *APIClient, data *sacl
 		d.Set("bridge_id", "")
 	}
 
+	setPowerManageTimeoutValueToState(d)
+
 	d.Set("zone", client.Zone)
-	d.SetId(data.GetStrID())
 	return nil
 }

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -264,8 +264,9 @@ func setVPCRouterResourceData(d *schema.ResourceData, client *APIClient, data *s
 		d.Set("global_address", data.Settings.Router.Interfaces[0].VirtualIPAddress)
 	}
 
+	setPowerManageTimeoutValueToState(d)
+
 	d.Set("zone", client.Zone)
-	d.SetId(data.GetStrID())
 	return nil
 }
 

--- a/sakuracloud/shutdown_handler.go
+++ b/sakuracloud/shutdown_handler.go
@@ -16,14 +16,15 @@ var (
 	powerManageTimeoutParam = &schema.Schema{
 		Type:     schema.TypeInt,
 		Optional: true,
-		Default:  60,
+		Default:  defaultPowerManageTimeout,
 	}
 	powerManageTimeoutParamForceNew = &schema.Schema{
 		Type:     schema.TypeInt,
 		Optional: true,
-		Default:  60,
+		Default:  defaultPowerManageTimeout,
 		ForceNew: true,
 	}
+	defaultPowerManageTimeout = 60
 )
 
 func handleShutdown(handler shutdownHandler, id int64, d *schema.ResourceData, defaultTimeOut time.Duration) error {
@@ -49,4 +50,10 @@ func handleShutdown(handler shutdownHandler, id int64, d *schema.ResourceData, d
 	}
 
 	return handler.SleepUntilDown(id, timeout)
+}
+
+func setPowerManageTimeoutValueToState(d *schema.ResourceData) {
+	if _, ok := d.GetOk(powerManageTimeoutKey); !ok {
+		d.Set(powerManageTimeoutKey, defaultPowerManageTimeout)
+	}
 }

--- a/sakuracloud/structure.go
+++ b/sakuracloud/structure.go
@@ -259,3 +259,31 @@ func (d *resourceDataWrapper) HasChange(key string) bool {
 func (d *resourceDataWrapper) RawResourceData() *schema.ResourceData {
 	return d.ResourceData
 }
+
+func expandSubResourceID(id string) (string, int) {
+	tokens := strings.Split(id, "-")
+	if len(tokens) != 2 {
+		return "", -1
+	}
+	index, err := strconv.Atoi(tokens[1])
+	if err != nil {
+		return "", -1
+	}
+	return tokens[0], index
+}
+
+func expandSubResourceID2(id string) (string, int, int) {
+	tokens := strings.Split(id, "-")
+	if len(tokens) != 3 {
+		return "", -1, -1
+	}
+	index1, err := strconv.Atoi(tokens[1])
+	if err != nil {
+		return "", -1, -1
+	}
+	index2, err := strconv.Atoi(tokens[2])
+	if err != nil {
+		return "", -1, -1
+	}
+	return tokens[0], index1, index2
+}


### PR DESCRIPTION
`terraform import`でインポートできていない属性やインポートをサポートしていなかったサブリソース(gslb_serverやdns_recrodなど)についてインポート可能にする。

オブジェクトストレージ(bucket_object)については現状ユースケースが思い浮かばないため今回は対象外とする。