### PR TITLE
逆引きレコード登録機能

### DIFF
--- a/build_docs/docs/configuration/resources/ipv4_ptr.md
+++ b/build_docs/docs/configuration/resources/ipv4_ptr.md
@@ -1,0 +1,51 @@
+# IPv4逆引きレコード(sakuracloud_ipv4_ptr)
+
+---
+
+### 設定例
+
+```hcl
+# 逆引きレコードの定義
+resource "sakuracloud_ipv4_prt" "foobar" {
+  ipaddress = "${sakuracloud_server.server.ipaddress}"
+  hostname  = "ptr.example.com"
+}
+
+# 対象ゾーンの参照
+data sakuracloud_dns "dns" {
+  name_selectors = ["example.com"]
+}
+
+# Aレコードの定義
+resource sakuracloud_dns_record "record01" {
+  dns_id = "${data.sakuracloud_dns.dns.id}"
+  name   = "ptr"
+  type   = "A"
+  value  = "${sakuracloud_server.server.ipaddress}"
+}
+
+# Aレコード/PTRレコード登録対象のサーバ
+resource sakuracloud_server "server" {
+  name = "example"
+}
+```
+
+逆引きレコードを登録するには対応するAレコードがあらかじめ登録されている必要があります。  
+詳細は[さくらのクラウド マニュアル](https://manual.sakura.ad.jp/cloud/server/reverse-hostname.html)を参照ください。
+
+
+### パラメーター
+
+|パラメーター         |必須  |名称                |初期値     |設定値                    |補足                                          |
+|-------------------|:---:|--------------------|:--------:|------------------------|----------------------------------------------|
+|`ipaddress`       | ◯   | IPアドレス           | -        | 文字列                  | - |
+|`hostname`        | ◯   | ホスト名           | -        | 文字列                  | - |
+|`retry_max`      | -   | リトライ回数         | `30`     | 数値 | -  |
+|`retry_interval` | -   | リトライ時待機時間    | `10`     |数値(秒)| - |
+| `zone`            | -   | ゾーン | - | `is1a`<br />`is1b`<br />`tk1a`<br />`tk1v` | 指定のIPアドレスを持つリソースが所属するゾーン |
+
+### 属性
+
+|属性名                | 名称                    | 補足                                        |
+|---------------------|------------------------|--------------------------------------------|
+| `id`                | ID               | IPアドレスと同値                                          |

--- a/build_docs/docs/index.md
+++ b/build_docs/docs/index.md
@@ -48,6 +48,7 @@
     - [アイコン](configuration/resources/icon/)
     - [専有ホスト](configuration/resources/private_host/)
     - [DNS](configuration/resources/dns/)
+    - [IPv4逆引きレコード](configuration/resources/ipv4_ptr/)
     - [GSLB](configuration/resources/gslb/)
     - [シンプル監視](configuration/resources/simple_monitor/)
     - [自動バックアップ](configuration/resources/auto_backup/)

--- a/build_docs/mkdocs.yml
+++ b/build_docs/mkdocs.yml
@@ -41,6 +41,7 @@ pages:
       - アイコン: configuration/resources/icon.md
       - 専有ホスト: configuration/resources/private_host.md
       - DNS: configuration/resources/dns.md
+      - IPv4逆引きレコード: configuration/resources/ipv4_ptr.md
       - GSLB: configuration/resources/gslb.md
       - シンプル監視: configuration/resources/simple_monitor.md
       - 自動バックアップ: configuration/resources/auto_backup.md

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -116,6 +116,7 @@ func Provider() terraform.ResourceProvider {
 			"sakuracloud_gslb_server":                    resourceSakuraCloudGSLBServer(),
 			"sakuracloud_icon":                           resourceSakuraCloudIcon(),
 			"sakuracloud_internet":                       resourceSakuraCloudInternet(),
+			"sakuracloud_ipv4_prt":                       resourceSakuraCloudIPv4Prt(),
 			"sakuracloud_load_balancer":                  resourceSakuraCloudLoadBalancer(),
 			"sakuracloud_load_balancer_vip":              resourceSakuraCloudLoadBalancerVIP(),
 			"sakuracloud_load_balancer_server":           resourceSakuraCloudLoadBalancerServer(),

--- a/sakuracloud/resource_sakuracloud_ipv4_prt.go
+++ b/sakuracloud/resource_sakuracloud_ipv4_prt.go
@@ -1,0 +1,138 @@
+package sakuracloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/sacloud/libsacloud/api"
+	"github.com/sacloud/libsacloud/sacloud"
+)
+
+func resourceSakuraCloudIPv4Prt() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSakuraCloudIPv4PrtUpdate,
+		Read:   resourceSakuraCloudIPv4PrtRead,
+		Update: resourceSakuraCloudIPv4PrtUpdate,
+		Delete: resourceSakuraCloudIPv4PrtDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		CustomizeDiff: hasTagResourceCustomizeDiff,
+		Schema: map[string]*schema.Schema{
+			"ipaddress": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateIPv4Address(),
+			},
+			"hostname": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"retry_max": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      30,
+				ValidateFunc: validateIntegerInRange(1, 100),
+			},
+			"retry_interval": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      10,
+				ValidateFunc: validateIntegerInRange(1, 600),
+			},
+			"zone": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				Description:  "target SakuraCloud zone",
+				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
+			},
+		},
+	}
+}
+
+func resourceSakuraCloudIPv4PrtUpdate(d *schema.ResourceData, meta interface{}) error {
+	var err error
+	client := getSacloudAPIClient(d, meta)
+
+	client.TraceMode = true
+	defer func() { client.TraceMode = false }()
+
+	ip := d.Get("ipaddress").(string)
+	hostName := d.Get("hostname").(string)
+
+	retryMax := d.Get("retry_max").(int)
+	retrySec := d.Get("retry_interval").(int)
+	interval := time.Duration(retrySec) * time.Second
+
+	// check IP exists
+	_, err = client.IPAddress.Read(ip)
+	if err != nil {
+		// includes 404 error
+		return fmt.Errorf("Couldn't find SakuraCloud IPv4Prt resource: %s", err)
+	}
+
+	i := 0
+	success := false
+	for i < retryMax {
+
+		// set
+		if _, err = client.IPAddress.Update(ip, hostName); err == nil {
+			success = true
+			break
+		}
+
+		time.Sleep(interval)
+		i++
+	}
+
+	if !success {
+		return fmt.Errorf("Couldn't update SakuraCloud IPv4Prt resource: %s", err)
+	}
+
+	d.SetId(ip)
+	return resourceSakuraCloudIPv4PrtRead(d, meta)
+}
+
+func resourceSakuraCloudIPv4PrtRead(d *schema.ResourceData, meta interface{}) error {
+	client := getSacloudAPIClient(d, meta)
+
+	prt, err := client.IPAddress.Read(d.Id())
+	if err != nil {
+		if sacloudErr, ok := err.(api.Error); ok && sacloudErr.ResponseCode() == 404 {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Couldn't find SakuraCloud IPv4Prt resource: %s", err)
+	}
+
+	return setIPv4PrtResourceData(d, client, prt)
+}
+
+func resourceSakuraCloudIPv4PrtDelete(d *schema.ResourceData, meta interface{}) error {
+	var err error
+	client := getSacloudAPIClient(d, meta)
+
+	_, err = client.IPAddress.Read(d.Id())
+	if err != nil {
+		d.SetId("")
+		return nil
+	}
+
+	_, err = client.IPAddress.Update(d.Id(), "")
+	if err != nil {
+		return fmt.Errorf("Couldn't update SakuraCloud IPv4Prt resource: %s", err)
+	}
+
+	return nil
+}
+
+func setIPv4PrtResourceData(d *schema.ResourceData, client *APIClient, data *sacloud.IPAddress) error {
+
+	d.Set("ipaddress", data.IPAddress)
+	d.Set("hostname", data.HostName)
+	d.Set("zone", client.Zone)
+	return nil
+}

--- a/sakuracloud/resource_sakuracloud_ipv4_prt_test.go
+++ b/sakuracloud/resource_sakuracloud_ipv4_prt_test.go
@@ -1,0 +1,151 @@
+package sakuracloud
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"testing"
+)
+
+const (
+	envTestDomain = "SAKURACLOUD_TEST_DOMAIN"
+)
+
+var (
+	testDomain string
+)
+
+func TestAccResourceSakuraCloudIPv4Prt(t *testing.T) {
+	var ip sacloud.IPAddress
+	if domain, ok := os.LookupEnv(envTestDomain); ok {
+		testDomain = domain
+	} else {
+		t.Skipf("ENV %q is requilred. skip", envTestDomain)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSakuraCloudIPv4PrtDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckSakuraCloudIPv4PrtConfig_basic, testDomain, testDomain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSakuraCloudIPv4PrtExists("sakuracloud_ipv4_prt.foobar", &ip),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_ipv4_prt.foobar", "hostname", fmt.Sprintf("terraform-test-domain01.%s", testDomain)),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckSakuraCloudIPv4PrtConfig_update, testDomain, testDomain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSakuraCloudIPv4PrtExists("sakuracloud_ipv4_prt.foobar", &ip),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_ipv4_prt.foobar", "hostname", fmt.Sprintf("terraform-test-domain02.%s", testDomain)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSakuraCloudIPv4PrtExists(n string, ip *sacloud.IPAddress) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No IPv4Prt ID is set")
+		}
+
+		client := testAccProvider.Meta().(*APIClient)
+
+		foundIPv4Prt, err := client.IPAddress.Read(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if foundIPv4Prt.IPAddress != rs.Primary.ID {
+			return errors.New("IPv4Prt not found")
+		}
+		if foundIPv4Prt.HostName == "" {
+			return errors.New("IPv4Prt hostname is empty")
+		}
+
+		*ip = *foundIPv4Prt
+
+		return nil
+	}
+}
+
+func testAccCheckSakuraCloudIPv4PrtDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*APIClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sakuracloud_ipv4_prt" {
+			continue
+		}
+
+		ip, err := client.IPAddress.Read(rs.Primary.ID)
+
+		if err == nil && ip.HostName != "" {
+			return errors.New("IPv4Prt still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccCheckSakuraCloudIPv4PrtConfig_basic = `
+data sakuracloud_dns "dns" {
+  name_selectors = ["%s"]
+}
+
+resource sakuracloud_dns_record "record01" {
+  dns_id = "${data.sakuracloud_dns.dns.id}"
+  name   = "terraform-test-domain01"
+  type   = "A"
+  value  = "${sakuracloud_server.server.ipaddress}"
+}
+
+resource sakuracloud_server "server" {
+  name = "server"
+  graceful_shutdown_timeout = 5
+}
+
+resource "sakuracloud_ipv4_prt" "foobar" {
+  ipaddress = "${sakuracloud_server.server.ipaddress}"
+  hostname  = "terraform-test-domain01.%s"
+}
+`
+
+var testAccCheckSakuraCloudIPv4PrtConfig_update = `
+data sakuracloud_dns "dns" {
+  name_selectors = ["%s"]
+}
+
+resource sakuracloud_dns_record "record01" {
+  dns_id = "${data.sakuracloud_dns.dns.id}"
+  name   = "terraform-test-domain02"
+  type   = "A"
+  value  = "${sakuracloud_server.server.ipaddress}"
+}
+
+resource sakuracloud_server "server" {
+  name = "server"
+  graceful_shutdown_timeout = 5
+}
+
+resource "sakuracloud_ipv4_prt" "foobar" {
+  ipaddress = "${sakuracloud_server.server.ipaddress}"
+  hostname  = "terraform-test-domain02.%s"
+}
+`

--- a/scripts/release.pl
+++ b/scripts/release.pl
@@ -446,6 +446,8 @@ sub create_pull_request {
     infof "Update AUTHORS.\n";
     system "scripts/generate-authors.sh";
 
+    system "git", "add", "docs/";
+
     if($ret || git_with_exit_code qw/diff --exit-code/){
         git qw/config --global push.default matching/;
         git qw/config user.email/, 'sacloud.users@gmail.com';


### PR DESCRIPTION
以下のように逆引きレコードを登録するためのリソースを追加する。

```hcl
resource sakuracloud_ipv4_ptr "example" {
  ip       = "${sakuracloud_server.example.ipaddress}"
  hostname = "example.example.com"
}
```