### PR TITLE
VPCルータでのインターネット接続 有効/無効 設定

### DIFF
--- a/build_docs/docs/configuration/resources/data/vpc_router.md
+++ b/build_docs/docs/configuration/resources/data/vpc_router.md
@@ -38,6 +38,7 @@ VPCルータ本体を表します。
 | `vrid`          | VRID           | - |
 | `aliases`       | IPエイリアス    | - |
 | `syslog_host`   | syslog転送先ホスト| - |
+| `internet_connection` | インターネット接続 | - |
 | `icon_id`       | アイコンID         | - |
 | `description`   | 説明           | - |
 | `tags`          | タグ           | - |

--- a/build_docs/docs/configuration/resources/vpc_router.md
+++ b/build_docs/docs/configuration/resources/vpc_router.md
@@ -17,15 +17,16 @@ resource sakuracloud_switch "sw01" {
 
 # VPCルータ本体の定義(プレミアム/ハイスペックプランの場合)
 resource sakuracloud_vpc_router "foobar" {
-  name        = "vpc_router_sample"
-  plan        = "premium"
-  switch_id   = "${sakuracloud_internet.router1.switch_id}"        # 上流のスイッチID
-  vip         = "${sakuracloud_internet.router1.ipaddresses[0]}"   # VIP
-  ipaddress1  = "${sakuracloud_internet.router1.ipaddresses[1]}"   # 実IP1
-  ipaddress2  = "${sakuracloud_internet.router1.ipaddresses[2]}"   # 実IP2
-  aliases     = ["${sakuracloud_internet.router1.ipaddresses[3]}"] # IPエイリアス
-  vrid        = 1
-  syslog_host = "192.168.11.1"                                     # syslog転送先ホスト
+  name                = "vpc_router_sample"
+  plan                = "premium"
+  switch_id           = "${sakuracloud_internet.router1.switch_id}"        # 上流のスイッチID
+  vip                 = "${sakuracloud_internet.router1.ipaddresses[0]}"   # VIP
+  ipaddress1          = "${sakuracloud_internet.router1.ipaddresses[1]}"   # 実IP1
+  ipaddress2          = "${sakuracloud_internet.router1.ipaddresses[2]}"   # 実IP2
+  aliases             = ["${sakuracloud_internet.router1.ipaddresses[3]}"] # IPエイリアス
+  vrid                = 1
+  syslog_host         = "192.168.11.1"                                     # syslog転送先ホスト
+  internet_connection = true # インターネット接続 有効/無効
 }
 
 # VPCルータ本体の定義(スタンダードプランの場合)
@@ -211,6 +212,7 @@ VPCルータ本体を表します。
 | `vrid`          | △   | VRID           | -        | 数値                          | プランが`premium`、`highspec`の場合必須 |
 | `aliases`       | -   | IPエイリアス    | -        | リスト(文字列)                  | プランが`premium`、`highspec`の場合のみ有効 |
 | `syslog_host`   | -   | syslog転送先ホスト| -      | 文字列                         | - |
+| `internet_connection` | -   | インターネット接続  | `true` | `true`<br />`false`| - |
 | `icon_id`       | -   | アイコンID         | - | 文字列| - |
 | `description`   | -   | 説明           | -        | 文字列                         | - |
 | `tags`          | -   | タグ           | -        | リスト(文字列)                  | - |

--- a/sakuracloud/data_source_sakuracloud_vpc_router.go
+++ b/sakuracloud/data_source_sakuracloud_vpc_router.go
@@ -96,6 +96,10 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"internet_connection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"zone": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/sakuracloud/resource_sakuracloud_vpc_router_test.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_test.go
@@ -33,6 +33,8 @@ func TestAccResourceSakuraCloudVPCRouter(t *testing.T) {
 						"sakuracloud_vpc_router.foobar", "tags.1", "hoge2"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_vpc_router.foobar", "plan", "standard"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_vpc_router.foobar", "internet_connection", "true"),
 					resource.TestCheckNoResourceAttr(
 						"sakuracloud_vpc_router.foobar", "switch_id"),
 					resource.TestCheckNoResourceAttr(
@@ -63,6 +65,8 @@ func TestAccResourceSakuraCloudVPCRouter(t *testing.T) {
 						"sakuracloud_vpc_router.foobar", "tags.1", "hoge2_after"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_vpc_router.foobar", "plan", "standard"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_vpc_router.foobar", "internet_connection", "false"),
 					resource.TestCheckNoResourceAttr(
 						"sakuracloud_vpc_router.foobar", "switch_id"),
 					resource.TestCheckNoResourceAttr(
@@ -134,6 +138,7 @@ resource "sakuracloud_vpc_router" "foobar" {
     description = "description_before"
     tags = ["hoge1" , "hoge2"]
     icon_id = "${sakuracloud_icon.foobar.id}"
+    internet_connection = true
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -148,4 +153,5 @@ resource "sakuracloud_vpc_router" "foobar" {
     description = "description_after"
     tags = ["hoge1_after" , "hoge2_after"]
     syslog_host = "192.168.0.2"
+    internet_connection = false
 }`

--- a/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router_setting.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router_setting.go
@@ -22,6 +22,7 @@ type VPCRouterSetting struct {
 	RemoteAccessUsers  *VPCRouterRemoteAccessUsers  `json:",omitempty"` // リモートアクセスユーザー設定
 	SiteToSiteIPsecVPN *VPCRouterSiteToSiteIPsecVPN `json:",omitempty"` // サイト間VPN設定
 	StaticRoutes       *VPCRouterStaticRoutes       `json:",omitempty"` // スタティックルート設定
+	InternetConnection *VPCRouterInternetConnection `json:",omitempty"` // インターネット接続
 	VRID               *int                         `json:",omitempty"` // VRID
 	SyslogHost         string                       `json:",omitempty"` // syslog転送先ホスト
 
@@ -1155,4 +1156,21 @@ func (s *VPCRouterSetting) FindStaticRoute(prefix string, nextHop string) (int, 
 		}
 	}
 	return -1, nil
+}
+
+// VPCRouterInternetConnection インターネット接続
+type VPCRouterInternetConnection struct {
+	Enabled string `json:",omitempty"` // 有効/無効
+}
+
+// SetInternetConnection インターネット接続 有効/無効 設定
+func (s *VPCRouterSetting) SetInternetConnection(enabled bool) {
+	if s.InternetConnection == nil {
+		s.InternetConnection = &VPCRouterInternetConnection{
+			Enabled: "False",
+		}
+	}
+	if enabled {
+		s.InternetConnection.Enabled = "True"
+	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -741,26 +741,26 @@
 		{
 			"checksumSHA1": "gRdvn3T7eKBVwJq571YqtZwdbOE=",
 			"path": "github.com/sacloud/libsacloud",
-			"revision": "2fd1b17a85c8ed7bf58ecdc103368a0c0cb3e631",
-			"revisionTime": "2018-07-02T13:57:57Z"
+			"revision": "30b4283b6fd10fea46802704cc0a3f33f30cdb39",
+			"revisionTime": "2018-07-05T05:50:15Z"
 		},
 		{
 			"checksumSHA1": "TwzNJdcXW7dPnPkNOaa95+U4I8I=",
 			"path": "github.com/sacloud/libsacloud/api",
-			"revision": "2fd1b17a85c8ed7bf58ecdc103368a0c0cb3e631",
-			"revisionTime": "2018-07-02T13:57:57Z"
+			"revision": "30b4283b6fd10fea46802704cc0a3f33f30cdb39",
+			"revisionTime": "2018-07-05T05:50:15Z"
 		},
 		{
-			"checksumSHA1": "2snUzxhTBsgXRUprXi0NfzEdkLQ=",
+			"checksumSHA1": "5+cLj7Ap1FNPAwOau8gnFnT9B5M=",
 			"path": "github.com/sacloud/libsacloud/sacloud",
-			"revision": "2fd1b17a85c8ed7bf58ecdc103368a0c0cb3e631",
-			"revisionTime": "2018-07-02T13:57:57Z"
+			"revision": "30b4283b6fd10fea46802704cc0a3f33f30cdb39",
+			"revisionTime": "2018-07-05T05:50:15Z"
 		},
 		{
 			"checksumSHA1": "9WZz5wVBDZldee34eTIakMSDqL0=",
 			"path": "github.com/sacloud/libsacloud/sacloud/ostype",
-			"revision": "2fd1b17a85c8ed7bf58ecdc103368a0c0cb3e631",
-			"revisionTime": "2018-07-02T13:57:57Z"
+			"revision": "30b4283b6fd10fea46802704cc0a3f33f30cdb39",
+			"revisionTime": "2018-07-05T05:50:15Z"
 		},
 		{
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",


### PR DESCRIPTION
VPCルータにてインターネット接続の有効/無効を設定可能とする。

> refs: https://cloud-news.sakura.ad.jp/2018/07/05/vpcrt-and-quertstring/

デフォルト値は`有効(true)`
(モバイルゲートウェイとデフォルト値が異なることに注意)

example:

```tf
resource sakuracloud_vpc_router "foobar" {
  name                = "example"
  plan                = "standard
  internet_connection = true # インターネット接続 有効/無効
}
```