### PR TITLE
Add English documents compatible with terraform.io

### DIFF
--- a/website/.textlintrc
+++ b/website/.textlintrc
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "write-good": {
+      "passive": false
+    },
+    "common-misspellings": {
+      // Misspellings to be ignored (case-insensitive)
+      "ignore": []
+    }
+  }
+}

--- a/website/docs/d/archive.html.markdown
+++ b/website/docs/d/archive.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_archive"
 sidebar_current: "docs-sakuracloud-datasource-archive"
 description: |-
-  Get information on a SakuraCloud archive.
+  Get information on a SakuraCloud Archive.
 ---
 
 # sakuracloud\_archive
 
-Use this data source to retrieve information about a SakuraCloud archive.
+Use this data source to retrieve information about a SakuraCloud Archive.
 
 ## Example Usage
 

--- a/website/docs/d/archive.html.markdown
+++ b/website/docs/d/archive.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_archive"
+sidebar_current: "docs-sakuracloud-datasource-archive"
+description: |-
+  Get information on a SakuraCloud archive.
+---
+
+# sakuracloud\_archive
+
+Use this data source to retrieve information about a SakuraCloud archive.
+
+## Example Usage
+
+### Using `os_type` parameter
+
+```hcl
+data sakuracloud_archive "centos" {
+  os_type = "centos"
+}
+```
+
+### Using filter parameters
+
+```hcl
+data sakuracloud_archive "ubuntu" {
+  name_selectors = ["Ubuntu", "LTS"]
+  tag_selectors  = ["current-stable", "os-linux"]
+}
+```
+
+## Argument Reference
+
+ * `os_type` - (Optional) The slug of target public archive. Valid values are in [`os_type` section](#os_type-parameter-reference).
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `size` - The size of the resource(unit:`GB`)
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## `os_type` Parameter Reference
+
+* `centos` - CentOS 7
+* `centos6` - CentOS 6
+* `ubuntu` - Ubuntu 18.04
+* `debian` - Debian 
+* `vyos` - VyOS
+* `coreos` - CoreOS
+* `rancheros` - RancherOS
+* `kusanagi` - Kusanagi(CentOS7)
+* `sophos-utm` - Sophos-UTM
+* `freebsd` - FreeBSD
+* `windows2012` - Windows 2012
+* `windows2012-rds` - Windows 2012(RDS)
+* `windows2012-rds-office` - Windows 2012(RDS + Office)
+* `windows2016` - Windows 2016
+* `windows2016-rds` - Windows 2016(RDS)
+* `windows2016-rds-office` - Windows 2016(RDS + Office)
+* `windows2016-sql-web` - Windows 2016 SQLServer(Web)
+* `windows2016-sql-standard` - Windows 2016 SQLServer(Standard)
+* `windows2016-sql-standard-all` - Windows 2016 SQLServer(Standard,RDS + Office)

--- a/website/docs/d/archive.html.markdown
+++ b/website/docs/d/archive.html.markdown
@@ -51,7 +51,7 @@ data sakuracloud_archive "ubuntu" {
 
 * `centos` - CentOS 7
 * `centos6` - CentOS 6
-* `ubuntu` - Ubuntu 18.04
+* `ubuntu` - Ubuntu 
 * `debian` - Debian 
 * `vyos` - VyOS
 * `coreos` - CoreOS
@@ -67,4 +67,6 @@ data sakuracloud_archive "ubuntu" {
 * `windows2016-rds-office` - Windows 2016 (RDS + Office)
 * `windows2016-sql-web` - Windows 2016 SQLServer (Web)
 * `windows2016-sql-standard` - Windows 2016 SQLServer (Standard)
-* `windows2016-sql-standard-all` - Windows 2016 SQLServer (Standard,RDS + Office)
+* `windows2016-sql2017-standard` - Windows 2016 SQLServer 2017 (Standard)
+* `windows2016-sql-standard-all` - Windows 2016 SQLServer (Standard, RDS + Office)
+* `windows2016-sql2017-standard-all` - Windows 2016 SQLServer 2017 (Standard, RDS + Office)

--- a/website/docs/d/archive.html.markdown
+++ b/website/docs/d/archive.html.markdown
@@ -41,7 +41,7 @@ data sakuracloud_archive "ubuntu" {
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `size` - The size of the resource(unit:`GB`)
+* `size` - The size of the resource (unit:`GB`).
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
@@ -56,15 +56,15 @@ data sakuracloud_archive "ubuntu" {
 * `vyos` - VyOS
 * `coreos` - CoreOS
 * `rancheros` - RancherOS
-* `kusanagi` - Kusanagi(CentOS7)
+* `kusanagi` - Kusanagi (CentOS7)
 * `sophos-utm` - Sophos-UTM
 * `freebsd` - FreeBSD
 * `windows2012` - Windows 2012
-* `windows2012-rds` - Windows 2012(RDS)
-* `windows2012-rds-office` - Windows 2012(RDS + Office)
+* `windows2012-rds` - Windows 2012 (RDS)
+* `windows2012-rds-office` - Windows 2012 (RDS + Office)
 * `windows2016` - Windows 2016
-* `windows2016-rds` - Windows 2016(RDS)
-* `windows2016-rds-office` - Windows 2016(RDS + Office)
-* `windows2016-sql-web` - Windows 2016 SQLServer(Web)
-* `windows2016-sql-standard` - Windows 2016 SQLServer(Standard)
-* `windows2016-sql-standard-all` - Windows 2016 SQLServer(Standard,RDS + Office)
+* `windows2016-rds` - Windows 2016 (RDS)
+* `windows2016-rds-office` - Windows 2016 (RDS + Office)
+* `windows2016-sql-web` - Windows 2016 SQLServer (Web)
+* `windows2016-sql-standard` - Windows 2016 SQLServer (Standard)
+* `windows2016-sql-standard-all` - Windows 2016 SQLServer (Standard,RDS + Office)

--- a/website/docs/d/archive.html.markdown
+++ b/website/docs/d/archive.html.markdown
@@ -32,8 +32,8 @@ data sakuracloud_archive "ubuntu" {
 ## Argument Reference
 
  * `os_type` - (Optional) The slug of target public archive. Valid values are in [`os_type` section](#os_type-parameter-reference).
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -43,7 +43,7 @@ data sakuracloud_archive "ubuntu" {
 * `name` - The name of the resource.
 * `size` - The size of the resource(unit:`GB`)
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/d/bridge.html.markdown
+++ b/website/docs/d/bridge.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_bridge"
+sidebar_current: "docs-sakuracloud-datasource-bridge"
+description: |-
+  Get information on a SakuraCloud bridge.
+---
+
+# sakuracloud\_bridge
+
+Use this data source to retrieve information about a SakuraCloud bridge.
+
+## Example Usage
+
+```hcl
+data sakuracloud_bridge "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `switch_ids` - The IDs of the switch connected to the bridge.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/bridge.html.markdown
+++ b/website/docs/d/bridge.html.markdown
@@ -29,7 +29,7 @@ data sakuracloud_bridge "foobar" {
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `switch_ids` - The IDs of the switch connected to the bridge.
+* `switch_ids` - The ID list of the switches connected to the bridge.
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.

--- a/website/docs/d/bridge.html.markdown
+++ b/website/docs/d/bridge.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_bridge"
 sidebar_current: "docs-sakuracloud-datasource-bridge"
 description: |-
-  Get information on a SakuraCloud bridge.
+  Get information on a SakuraCloud Bridge.
 ---
 
 # sakuracloud\_bridge
 
-Use this data source to retrieve information about a SakuraCloud bridge.
+Use this data source to retrieve information about a SakuraCloud Bridge.
 
 ## Example Usage
 

--- a/website/docs/d/bridge.html.markdown
+++ b/website/docs/d/bridge.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_bridge "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -31,6 +31,6 @@ data sakuracloud_bridge "foobar" {
 * `name` - The name of the resource.
 * `switch_ids` - The IDs of the switch connected to the bridge.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/bucket_object.html.markdown
+++ b/website/docs/d/bucket_object.html.markdown
@@ -33,11 +33,11 @@ data "sakuracloud_bucket_object" "foobar" {
 * `content_type` - Content-Type header value of the bucket object.
 * `body` - String of the value of the bucket object. Set when Content-Type is `"text/*"` or `"application/json"`.
 * `etag` - ETag of the resource.
-* `size` - Size of the resource(unit: `byte`).
+* `size` - Size of the resource (unit:`byte`).
 * `last_modified` - Update date of the resource.
-* `http_url` - URL for accessing the object via HTTP(type: `subdomain`).
-* `https_url` - URL for accessing the object via HTTPS(type: `subdomain`).
-* `http_path_url` - URL for accessing the object via HTTP(type: `path`).
-* `http_cache_url` - URL for accessing the object via HTTP(type: `cache`).
-* `https_cache_url` - URL for accessing the object via HTTPS(type: `cache`)..
+* `http_url` - URL for accessing the object via HTTP (type:`subdomain`).
+* `https_url` - URL for accessing the object via HTTPS (type:`subdomain`).
+* `http_path_url` - URL for accessing the object via HTTP (type:`path`).
+* `http_cache_url` - URL for accessing the object via HTTP (type:`cache`).
+* `https_cache_url` - URL for accessing the object via HTTPS (type:`cache`)..
 

--- a/website/docs/d/bucket_object.html.markdown
+++ b/website/docs/d/bucket_object.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_bucket_object"
+sidebar_current: "docs-sakuracloud-datasource-bucket-object"
+description: |-
+  Get information on a SakuraCloud Bucket Object.
+---
+
+# sakuracloud\_bucket\_object
+
+Use this data source to retrieve information about a SakuraCloud Bucket Object.
+
+## Example Usage
+
+```hcl
+data "sakuracloud_bucket_object" "foobar" {
+   bucket = "your-bucket-name"
+   key    = "path/to/your/object"
+ }
+
+```
+
+## Argument Reference
+
+* `bucket` - (Required) The name of bucket.
+* `access_key` - (Required) The access key of bucket. It must be provided, but it can also be sourced from the `SACLOUD_OJS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY_ID` environment variable.
+* `secret_key` - (Required) The secret key of bucket. It must be provided, but it can also be sourced from the `SACLOUD_OJS_SECRET_ACCESS_KEY` or `AWS_SECRET_ACCESS_KEY` environment variable.
+* `key` - (Required) The key of the bucket object.
+
+## Attributes Reference
+
+* `id` - ID of the resource.
+* `content_type` - Content-Type header value of the bucket object.
+* `body` - String of the value of the bucket object. It is set only when Content-Type is `"text/*"` or `"application/json"`.
+* `etag` - ETag of the resource.
+* `size` - Size of the resource(unit: `byte`).
+* `last_modified` - Update date of the resource.
+* `http_url` - URL for accessing the object via HTTP(type: `subdomain`).
+* `https_url` - URL for accessing the object via HTTPS(type: `subdomain`).
+* `http_path_url` - URL for accessing the object via HTTP(type: `path`).
+* `http_cache_url` - URL for accessing the object via HTTP(type: `cache`).
+* `https_cache_url` - URL for accessing the object via HTTPS(type: `cache`)..
+

--- a/website/docs/d/bucket_object.html.markdown
+++ b/website/docs/d/bucket_object.html.markdown
@@ -31,7 +31,7 @@ data "sakuracloud_bucket_object" "foobar" {
 
 * `id` - ID of the resource.
 * `content_type` - Content-Type header value of the bucket object.
-* `body` - String of the value of the bucket object. It is set only when Content-Type is `"text/*"` or `"application/json"`.
+* `body` - String of the value of the bucket object. Set when Content-Type is `"text/*"` or `"application/json"`.
 * `etag` - ETag of the resource.
 * `size` - Size of the resource(unit: `byte`).
 * `last_modified` - Update date of the resource.

--- a/website/docs/d/cdrom.html.markdown
+++ b/website/docs/d/cdrom.html.markdown
@@ -29,7 +29,7 @@ data sakuracloud_cdrom "foobar" {
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `size` - Size of the resource(unit:`GB`).
+* `size` - Size of the resource (unit:`GB`).
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.

--- a/website/docs/d/cdrom.html.markdown
+++ b/website/docs/d/cdrom.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_cdrom"
+sidebar_current: "docs-sakuracloud-datasource-cdrom"
+description: |-
+  Get information on a SakuraCloud cdrom.
+---
+
+# sakuracloud\_cdrom
+
+Use this data source to retrieve information about a SakuraCloud cdrom.
+
+## Example Usage
+
+```hcl
+data sakuracloud_cdrom "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `size` - Size of the resource(unit:`GB`).
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/cdrom.html.markdown
+++ b/website/docs/d/cdrom.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_cdrom"
 sidebar_current: "docs-sakuracloud-datasource-cdrom"
 description: |-
-  Get information on a SakuraCloud cdrom.
+  Get information on a SakuraCloud CD-ROM.
 ---
 
 # sakuracloud\_cdrom
 
-Use this data source to retrieve information about a SakuraCloud cdrom.
+Use this data source to retrieve information about a SakuraCloud CD-ROM.
 
 ## Example Usage
 

--- a/website/docs/d/cdrom.html.markdown
+++ b/website/docs/d/cdrom.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_cdrom "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -31,6 +31,6 @@ data sakuracloud_cdrom "foobar" {
 * `name` - The name of the resource.
 * `size` - Size of the resource(unit:`GB`).
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_database"
+sidebar_current: "docs-sakuracloud-datasource-database"
+description: |-
+  Get information on a SakuraCloud database.
+---
+
+# sakuracloud\_database
+
+Use this data source to retrieve information about a SakuraCloud database.
+
+## Example Usage
+
+```hcl
+data sakuracloud_database "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `plan` - The name of the resource plan.
+* `user_name` - The username to access database.
+* `user_password` - The password to access database.
+* `allow_networks` - The network address list that allowed connections to the database.
+* `port` - The number of the port on which the database is listening.
+* `backup_time` - The time to perform backup.
+* `switch_id` - The ID of the switch connected to the database.
+* `ipaddress1` - The IP address of the database.
+* `nw_mask_len` - The network mask length of the database.
+* `default_route` - The default route IP address of the database.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_database"
 sidebar_current: "docs-sakuracloud-datasource-database"
 description: |-
-  Get information on a SakuraCloud database.
+  Get information on a SakuraCloud Database.
 ---
 
 # sakuracloud\_database
 
-Use this data source to retrieve information about a SakuraCloud database.
+Use this data source to retrieve information about a SakuraCloud Database.
 
 ## Example Usage
 

--- a/website/docs/d/database.html.markdown
+++ b/website/docs/d/database.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_database "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -40,7 +40,7 @@ data sakuracloud_database "foobar" {
 * `nw_mask_len` - The network mask length of the database.
 * `default_route` - The default route IP address of the database.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/d/disk.html.markdown
+++ b/website/docs/d/disk.html.markdown
@@ -29,9 +29,9 @@ data sakuracloud_disk "foobar" {
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `plan` - The plan of the resource(`ssd`/`hdd`).
-* `conector` - The disk connector of the resource(`virtio`/`ide`).
-* `size` - Size of the resource(unit:`GB`).
+* `plan` - The plan of the resource (`ssd`/`hdd`).
+* `conector` - The disk connector of the resource (`virtio`/`ide`).
+* `size` - Size of the resource (unit:`GB`).
 * `server_id` - The ID of the server connected to the disk.
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.

--- a/website/docs/d/disk.html.markdown
+++ b/website/docs/d/disk.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_disk"
+sidebar_current: "docs-sakuracloud-datasource-disk"
+description: |-
+  Get information on a SakuraCloud disk.
+---
+
+# sakuracloud\_disk
+
+Use this data source to retrieve information about a SakuraCloud disk.
+
+## Example Usage
+
+```hcl
+data sakuracloud_disk "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `plan` - The plan of the resource(`ssd`/`hdd`).
+* `conector` - The disk connector of the resource(`virtio`/`ide`).
+* `size` - Size of the resource(unit:`GB`).
+* `server_id` - The ID of the server connected to the disk.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/disk.html.markdown
+++ b/website/docs/d/disk.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_disk"
 sidebar_current: "docs-sakuracloud-datasource-disk"
 description: |-
-  Get information on a SakuraCloud disk.
+  Get information on a SakuraCloud Disk.
 ---
 
 # sakuracloud\_disk
 
-Use this data source to retrieve information about a SakuraCloud disk.
+Use this data source to retrieve information about a SakuraCloud Disk.
 
 ## Example Usage
 

--- a/website/docs/d/disk.html.markdown
+++ b/website/docs/d/disk.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_disk "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -34,6 +34,6 @@ data sakuracloud_disk "foobar" {
 * `size` - Size of the resource(unit:`GB`).
 * `server_id` - The ID of the server connected to the disk.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/dns.html.markdown
+++ b/website/docs/d/dns.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_dns "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
 
 ## Attributes Reference
@@ -30,5 +30,5 @@ data sakuracloud_dns "foobar" {
 * `zone` - The name of the zone.
 * `dns_servers` - List of host names of DNS servers.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.

--- a/website/docs/d/dns.html.markdown
+++ b/website/docs/d/dns.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_dns"
+sidebar_current: "docs-sakuracloud-datasource-dns"
+description: |-
+  Get information on a SakuraCloud dns.
+---
+
+# sakuracloud\_dns
+
+Use this data source to retrieve information about a SakuraCloud dns.
+
+## Example Usage
+
+```hcl
+data sakuracloud_dns "foobar" {
+  name_selectors = ["example.com"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `zone` - The name of the zone.
+* `dns_servers` - List of host names of DNS servers.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.

--- a/website/docs/d/dns.html.markdown
+++ b/website/docs/d/dns.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_dns"
 sidebar_current: "docs-sakuracloud-datasource-dns"
 description: |-
-  Get information on a SakuraCloud dns.
+  Get information on a SakuraCloud DNS.
 ---
 
 # sakuracloud\_dns
 
-Use this data source to retrieve information about a SakuraCloud dns.
+Use this data source to retrieve information about a SakuraCloud DNS.
 
 ## Example Usage
 

--- a/website/docs/d/gslb.html.markdown
+++ b/website/docs/d/gslb.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_gslb "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
 
 ## Attributes Reference
@@ -33,7 +33,7 @@ data sakuracloud_gslb "foobar" {
 * `weighted` - The flag for enable/disable weighting.
 * `sorry_server` - The hostname or IP address of sorry server.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 
 ### Health Check

--- a/website/docs/d/gslb.html.markdown
+++ b/website/docs/d/gslb.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_gslb"
 sidebar_current: "docs-sakuracloud-datasource-gslb"
 description: |-
-  Get information on a SakuraCloud gslb.
+  Get information on a SakuraCloud GSLB.
 ---
 
 # sakuracloud\_gslb
 
-Use this data source to retrieve information about a SakuraCloud gslb.
+Use this data source to retrieve information about a SakuraCloud GSLB.
 
 ## Example Usage
 

--- a/website/docs/d/gslb.html.markdown
+++ b/website/docs/d/gslb.html.markdown
@@ -41,7 +41,7 @@ data sakuracloud_gslb "foobar" {
 Attributes for Health Check:
 
 * `protocol` - Protocol used in health check.
-* `delay_loop` - Health check access interval(unit:`second`).
+* `delay_loop` - Health check access interval (unit:`second`).
 * `host_header` - The value of `Host` header used in http/https health check access.
 * `path` - The request path used in http/https health check access.
 * `status` - HTTP status code expected by health check access.

--- a/website/docs/d/gslb.html.markdown
+++ b/website/docs/d/gslb.html.markdown
@@ -29,7 +29,7 @@ data sakuracloud_gslb "foobar" {
 * `id` - The ID of the resource.
 * `name` - Name of the resource.
 * `fqdn` - FQDN to access this resource.
-* `health_check` - Health check rules. It contains several attributes to [Health Check](#health-check).
+* `health_check` - Health check rules. It contains some attributes to [Health Check](#health-check).
 * `weighted` - The flag for enable/disable weighting.
 * `sorry_server` - The hostname or IP address of sorry server.
 * `description` - The description of the resource.

--- a/website/docs/d/gslb.html.markdown
+++ b/website/docs/d/gslb.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_gslb"
+sidebar_current: "docs-sakuracloud-datasource-gslb"
+description: |-
+  Get information on a SakuraCloud gslb.
+---
+
+# sakuracloud\_gslb
+
+Use this data source to retrieve information about a SakuraCloud gslb.
+
+## Example Usage
+
+```hcl
+data sakuracloud_gslb "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - Name of the resource.
+* `fqdn` - FQDN to access this resource.
+* `health_check` - Health check rules. It contains several attributes to [Health Check](#health-check).
+* `weighted` - The flag for enable/disable weighting.
+* `sorry_server` - The hostname or IP address of sorry server.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+
+### Health Check
+
+Attributes for Health Check:
+
+* `protocol` - Protocol used in health check.
+* `delay_loop` - Health check access interval(unit:`second`).
+* `host_header` - The value of `Host` header used in http/https health check access.
+* `path` - The request path used in http/https health check access.
+* `status` - HTTP status code expected by health check access.
+* `port` - Port number used in tcp health check access.

--- a/website/docs/d/icon.html.markdown
+++ b/website/docs/d/icon.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_icon"
 sidebar_current: "docs-sakuracloud-datasource-icon"
 description: |-
-  Get information on a SakuraCloud icon.
+  Get information on a SakuraCloud Icon.
 ---
 
 # sakuracloud\_icon
 
-Use this data source to retrieve information about a SakuraCloud icon.
+Use this data source to retrieve information about a SakuraCloud Icon.
 
 ## Example Usage
 

--- a/website/docs/d/icon.html.markdown
+++ b/website/docs/d/icon.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_icon "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
 
 ## Attributes Reference
@@ -30,4 +30,4 @@ data sakuracloud_icon "foobar" {
 * `name` - The name of the resource.
 * `body` - Base64 encoded icon data(size:`small`).
 * `url` - URL to access this resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.

--- a/website/docs/d/icon.html.markdown
+++ b/website/docs/d/icon.html.markdown
@@ -28,6 +28,6 @@ data sakuracloud_icon "foobar" {
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `body` - Base64 encoded icon data(size:`small`).
+* `body` - Base64 encoded icon data (size:`small`).
 * `url` - URL to access this resource.
 * `tags` - The tag list of the resources.

--- a/website/docs/d/icon.html.markdown
+++ b/website/docs/d/icon.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_icon"
+sidebar_current: "docs-sakuracloud-datasource-icon"
+description: |-
+  Get information on a SakuraCloud icon.
+---
+
+# sakuracloud\_icon
+
+Use this data source to retrieve information about a SakuraCloud icon.
+
+## Example Usage
+
+```hcl
+data sakuracloud_icon "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `body` - Base64 encoded icon data(size:`small`).
+* `url` - URL to access this resource.
+* `tags` - The tag list of the resource.

--- a/website/docs/d/internet.html.markdown
+++ b/website/docs/d/internet.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_internet "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -43,6 +43,6 @@ data sakuracloud_internet "foobar" {
 * `ipv6_prefix_len` - Address prefix length of ipv6 network.
 * `ipv6_nw_address` - The ipv6 network address.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/internet.html.markdown
+++ b/website/docs/d/internet.html.markdown
@@ -35,9 +35,9 @@ data sakuracloud_internet "foobar" {
 * `server_ids` - The IDs of the server connected to the switch.
 * `nw_address` - The network address.
 * `gateway` - The network gateway address of the switch.
-* `min_ipaddress` - Minimum global ip address.
-* `max_ipaddress` - Maximum global ip address.
-* `ipaddresses` - Global ip address list.
+* `min_ipaddress` - Min global IP address.
+* `max_ipaddress` - Max global IP address.
+* `ipaddresses` - Global IP address list.
 * `enable_ipv6` - The ipv6 enabled flag.
 * `ipv6_prefix` - Address prefix of ipv6 network.
 * `ipv6_prefix_len` - Address prefix length of ipv6 network.

--- a/website/docs/d/internet.html.markdown
+++ b/website/docs/d/internet.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_internet"
+sidebar_current: "docs-sakuracloud-datasource-internet"
+description: |-
+  Get information on a SakuraCloud internet.
+---
+
+# sakuracloud\_internet
+
+Use this data source to retrieve information about a SakuraCloud internet(switch+router).
+
+## Example Usage
+
+```hcl
+data sakuracloud_internet "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `nw_mask_len` - Network mask length.
+* `band_width` - Bandwidth of outbound traffic.
+* `switch_id` - The ID of the switch.
+* `server_ids` - The IDs of the server connected to the switch.
+* `nw_address` - The network address.
+* `gateway` - The network gateway address of the switch.
+* `min_ipaddress` - Minimum global ip address.
+* `max_ipaddress` - Maximum global ip address.
+* `ipaddresses` - Global ip address list.
+* `enable_ipv6` - The ipv6 enabled flag.
+* `ipv6_prefix` - Address prefix of ipv6 network.
+* `ipv6_prefix_len` - Address prefix length of ipv6 network.
+* `ipv6_nw_address` - The ipv6 network address.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/internet.html.markdown
+++ b/website/docs/d/internet.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # sakuracloud\_internet
 
-Use this data source to retrieve information about a SakuraCloud internet(switch+router).
+Use this data source to retrieve information about a SakuraCloud internet (Switch+Router).
 
 ## Example Usage
 

--- a/website/docs/d/internet.html.markdown
+++ b/website/docs/d/internet.html.markdown
@@ -32,7 +32,7 @@ data sakuracloud_internet "foobar" {
 * `nw_mask_len` - Network mask length.
 * `band_width` - Bandwidth of outbound traffic.
 * `switch_id` - The ID of the switch.
-* `server_ids` - The IDs of the server connected to the switch.
+* `server_ids` - The ID list of the servers connected to the switch.
 * `nw_address` - The network address.
 * `gateway` - The network gateway address of the switch.
 * `min_ipaddress` - Min global IP address.

--- a/website/docs/d/internet.html.markdown
+++ b/website/docs/d/internet.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_internet"
 sidebar_current: "docs-sakuracloud-datasource-internet"
 description: |-
-  Get information on a SakuraCloud internet.
+  Get information on a SakuraCloud Internet (Switch+Router).
 ---
 
 # sakuracloud\_internet
 
-Use this data source to retrieve information about a SakuraCloud internet (Switch+Router).
+Use this data source to retrieve information about a SakuraCloud Internet (Switch+Router).
 
 ## Example Usage
 

--- a/website/docs/d/load_balancer.html.markdown
+++ b/website/docs/d/load_balancer.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_load_balancer"
+sidebar_current: "docs-sakuracloud-datasource-load-balancer"
+description: |-
+  Get information on a SakuraCloud Load Balancer.
+---
+
+# sakuracloud\_load\_balancer
+
+Use this data source to retrieve information about a SakuraCloud Load Balancer.
+
+## Example Usage
+
+```hcl
+data sakuracloud_load_balancer "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `switch_id` - The ID of the Switch connected to the Load Balancer.
+* `vrid` - VRID used when high-availability mode enabled.
+* `high_availability` - The flag of enable/disable high-availability mode.
+* `plan` - The name of the resource plan. 
+* `ipaddress1` - The primary IP address of the Load Balancer.
+* `ipaddress2` - The secondly IP address of the Load Balancer. It is used only when high-availability mode enabled.
+* `nw_mask_len` - Network mask length.
+* `default_route` - Default gateway address of the Load Balancer.	 
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/load_balancer.html.markdown
+++ b/website/docs/d/load_balancer.html.markdown
@@ -34,7 +34,7 @@ data sakuracloud_load_balancer "foobar" {
 * `high_availability` - The flag of enable/disable high-availability mode.
 * `plan` - The name of the resource plan. 
 * `ipaddress1` - The primary IP address of the Load Balancer.
-* `ipaddress2` - The secondly IP address of the Load Balancer. It is used only when high-availability mode enabled.
+* `ipaddress2` - The secondly IP address of the Load Balancer. Used when high-availability mode enabled.
 * `nw_mask_len` - Network mask length.
 * `default_route` - Default gateway address of the Load Balancer.	 
 * `description` - The description of the resource.

--- a/website/docs/d/load_balancer.html.markdown
+++ b/website/docs/d/load_balancer.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_load_balancer "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -38,6 +38,6 @@ data sakuracloud_load_balancer "foobar" {
 * `nw_mask_len` - Network mask length.
 * `default_route` - Default gateway address of the Load Balancer.	 
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/nfs.html.markdown
+++ b/website/docs/d/nfs.html.markdown
@@ -3,7 +3,7 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_nfs"
 sidebar_current: "docs-sakuracloud-datasource-nfs"
 description: |-
-  Get information on a SakuraCloud nfs.
+  Get information on a SakuraCloud NFS.
 ---
 
 # sakuracloud\_nfs

--- a/website/docs/d/nfs.html.markdown
+++ b/website/docs/d/nfs.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_nfs"
+sidebar_current: "docs-sakuracloud-datasource-nfs"
+description: |-
+  Get information on a SakuraCloud nfs.
+---
+
+# sakuracloud\_nfs
+
+Use this data source to retrieve information about a SakuraCloud NFS.
+
+## Example Usage
+
+```hcl
+data sakuracloud_nfs "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `switch_id` - The ID of the Switch connected to the NFS.
+* `plan` - The name of the resource plan.
+* `ipaddress` - The IP address of the NFS.
+* `nw_mask_len` - Network mask length.
+* `default_route` - Default gateway address of the NFS.	 
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+

--- a/website/docs/d/nfs.html.markdown
+++ b/website/docs/d/nfs.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_nfs "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -35,7 +35,7 @@ data sakuracloud_nfs "foobar" {
 * `nw_mask_len` - Network mask length.
 * `default_route` - Default gateway address of the NFS.	 
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/d/note.html.markdown
+++ b/website/docs/d/note.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_note "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
 
 ## Attributes Reference
@@ -31,5 +31,5 @@ data sakuracloud_note "foobar" {
 * `class` - The name of the note class.
 * `content` - The body of the note. 
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.

--- a/website/docs/d/note.html.markdown
+++ b/website/docs/d/note.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_note"
+sidebar_current: "docs-sakuracloud-datasource-note"
+description: |-
+  Get information on a SakuraCloud Note.
+---
+
+# sakuracloud\_note
+
+Use this data source to retrieve information about a SakuraCloud Note.
+
+## Example Usage
+
+```hcl
+data sakuracloud_note "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `class` - The name of the note class.
+* `content` - The body of the note. 
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.

--- a/website/docs/d/packet_filter.html.markdown
+++ b/website/docs/d/packet_filter.html.markdown
@@ -37,8 +37,8 @@ data sakuracloud_packet_filter "foobar" {
 Attributes for Filter Expressions:
 
 * `protocol` - The target protocol.
-* `source_nw` - The source network address(range).
-* `source_port` - The source port(range).
-* `dest_port` - The destination port(range).
+* `source_nw` - The source network address (range).
+* `source_port` - The source port (range).
+* `dest_port` - The destination port (range).
 * `allow` - The flag to allow packets. Default value is `true`. 
 * `description` - The description of the expression.

--- a/website/docs/d/packet_filter.html.markdown
+++ b/website/docs/d/packet_filter.html.markdown
@@ -20,7 +20,7 @@ data sakuracloud_packet_filter "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
+ * `name_selectors` - (Optional) The list of names to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 

--- a/website/docs/d/packet_filter.html.markdown
+++ b/website/docs/d/packet_filter.html.markdown
@@ -28,7 +28,7 @@ data sakuracloud_packet_filter "foobar" {
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `expressions` - List of filter-expression. It contains several attributes to [Filter Expressions](#filter-expressions).
+* `expressions` - List of filter-expression. It contains some attributes to [Filter Expressions](#filter-expressions).
 * `description` - The description of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/d/packet_filter.html.markdown
+++ b/website/docs/d/packet_filter.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_packet_filter"
+sidebar_current: "docs-sakuracloud-datasource-packet-filter"
+description: |-
+  Get information on a SakuraCloud Packet Filter.
+---
+
+# sakuracloud\_packet_filter
+
+Use this data source to retrieve information about a SakuraCloud Packet Filter.
+
+## Example Usage
+
+```hcl
+data sakuracloud_packet_filter "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `expressions` - List of filter-expression. It contains several attributes to [Filter Expressions](#filter-expressions).
+* `description` - The description of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+### Filter Expressions
+
+Attributes for Filter Expressions:
+
+* `protocol` - The target protocol.
+* `source_nw` - The source network address(range).
+* `source_port` - The source port(range).
+* `dest_port` - The destination port(range).
+* `allow` - The flag to allow packets. Default value is `true`. 
+* `description` - The description of the expression.

--- a/website/docs/d/private_host.html.markdown
+++ b/website/docs/d/private_host.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_private_host"
+sidebar_current: "docs-sakuracloud-datasource-private-host"
+description: |-
+  Get information on a SakuraCloud Private Host.
+---
+
+# sakuracloud\_private\_host
+
+Use this data source to retrieve information about a SakuraCloud Private Host.
+
+## Example Usage
+
+```hcl
+data sakuracloud_private_host "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `hostname` - The HostName of the resource.
+* `assigned_core` - The number of cores assigned to the Server.
+* `assigned_memory` - The size of memory allocated to the Server(unit:`GB`).
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/private_host.html.markdown
+++ b/website/docs/d/private_host.html.markdown
@@ -31,7 +31,7 @@ data sakuracloud_private_host "foobar" {
 * `name` - The name of the resource.
 * `hostname` - The HostName of the resource.
 * `assigned_core` - The number of cores assigned to the Server.
-* `assigned_memory` - The size of memory allocated to the Server(unit:`GB`).
+* `assigned_memory` - The size of memory allocated to the Server (unit:`GB`).
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/private_host.html.markdown
+++ b/website/docs/d/private_host.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_private_host "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -33,5 +33,5 @@ data sakuracloud_private_host "foobar" {
 * `assigned_core` - The number of cores assigned to the Server.
 * `assigned_memory` - The size of memory allocated to the Server(unit:`GB`).
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/server.html.markdown
+++ b/website/docs/d/server.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_server "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -31,13 +31,13 @@ data sakuracloud_server "foobar" {
 * `name` - The name of the resource.
 * `core` - The number of cores.
 * `memory` - The size of memory(unit:`GB`).
-* `disks` - The ID list of the Disk connected to Server.
+* `disks` - The ID list of the Disks connected to Server.
 * `interface_driver` - The name of network interface driver.
 * `nic` - The primary NIC's connection destination.
 * `cdrom_id` - The ID of the CD-ROM inserted to Server.
 * `private_host_id` - The ID of the Private Host to which the Server belongs.
 * `private_host_name` - The name of the Private Host to which the Server belongs.
-* `additional_nics` - The ID list of the Switch connected to NICs(excluding primary NIC) of Server.
+* `additional_nics` - The ID list of the Switches connected to NICs(excluding primary NIC) of Server.
 * `packet_filter_ids` - The ID list of the Packet Filter connected to Server.
 * `macaddresses` - The MAC address list of NICs connected to Server.
 * `ipaddress` - The IP address of primary NIC.
@@ -46,7 +46,7 @@ data sakuracloud_server "foobar" {
 * `nw_address` - The network address of the Server.
 * `nw_mask_len` - Network mask length of the Server.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/d/server.html.markdown
+++ b/website/docs/d/server.html.markdown
@@ -37,7 +37,7 @@ data sakuracloud_server "foobar" {
 * `cdrom_id` - The ID of the CD-ROM inserted to Server.
 * `private_host_id` - The ID of the Private Host to which the Server belongs.
 * `private_host_name` - The name of the Private Host to which the Server belongs.
-* `additional_nics` - The ID list of the Switch connected to additional NICs of Server.
+* `additional_nics` - The ID list of the Switch connected to NICs(excluding primary NIC) of Server.
 * `packet_filter_ids` - The ID list of the Packet Filter connected to Server.
 * `macaddresses` - The MAC address list of NICs connected to Server.
 * `ipaddress` - The IP address of primary NIC.

--- a/website/docs/d/server.html.markdown
+++ b/website/docs/d/server.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_server"
+sidebar_current: "docs-sakuracloud-datasource-server"
+description: |-
+  Get information on a SakuraCloud server.
+---
+
+# sakuracloud\_server
+
+Use this data source to retrieve information about a SakuraCloud server.
+
+## Example Usage
+
+```hcl
+data sakuracloud_server "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `core` - The number of cores.
+* `memory` - The size of memory(unit:`GB`).
+* `disks` - The ID list of the Disk connected to Server.
+* `interface_driver` - The name of network interface driver.
+* `nic` - The primary NIC's connection destination.
+* `cdrom_id` - The ID of the CD-ROM inserted to Server.
+* `private_host_id` - The ID of the Private Host to which the Server belongs.
+* `private_host_name` - The name of the Private Host to which the Server belongs.
+* `additional_nics` - The ID list of the Switch connected to additional NICs of Server.
+* `packet_filter_ids` - The ID list of the Packet Filter connected to Server.
+* `macaddresses` - The MAC address list of NICs connected to Server.
+* `ipaddress` - The IP address of primary NIC.
+* `dns_servers` - List of default DNS servers for the zone to which the Server belongs.
+* `gateway` - Default gateway address of the Server.	 
+* `nw_address` - The network address of the Server.
+* `nw_mask_len` - Network mask length of the Server.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+

--- a/website/docs/d/server.html.markdown
+++ b/website/docs/d/server.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_server"
 sidebar_current: "docs-sakuracloud-datasource-server"
 description: |-
-  Get information on a SakuraCloud server.
+  Get information on a SakuraCloud Server.
 ---
 
 # sakuracloud\_server
 
-Use this data source to retrieve information about a SakuraCloud server.
+Use this data source to retrieve information about a SakuraCloud Server.
 
 ## Example Usage
 

--- a/website/docs/d/server.html.markdown
+++ b/website/docs/d/server.html.markdown
@@ -30,14 +30,14 @@ data sakuracloud_server "foobar" {
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
 * `core` - The number of cores.
-* `memory` - The size of memory(unit:`GB`).
+* `memory` - The size of memory (unit:`GB`).
 * `disks` - The ID list of the Disks connected to Server.
 * `interface_driver` - The name of network interface driver.
 * `nic` - The primary NIC's connection destination.
 * `cdrom_id` - The ID of the CD-ROM inserted to Server.
 * `private_host_id` - The ID of the Private Host to which the Server belongs.
 * `private_host_name` - The name of the Private Host to which the Server belongs.
-* `additional_nics` - The ID list of the Switches connected to NICs(excluding primary NIC) of Server.
+* `additional_nics` - The ID list of the Switches connected to NICs (excluding primary NIC) of Server.
 * `packet_filter_ids` - The ID list of the Packet Filter connected to Server.
 * `macaddresses` - The MAC address list of NICs connected to Server.
 * `ipaddress` - The IP address of primary NIC.

--- a/website/docs/d/simple_monitor.html.markdown
+++ b/website/docs/d/simple_monitor.html.markdown
@@ -43,7 +43,7 @@ data sakuracloud_simple_monitor "foobar" {
 Attributes for Health Check:
 
 * `protocol` - Protocol used in health check.
-* `delay_loop` - Health check access interval(unit:`second`). 
+* `delay_loop` - Health check access interval (unit:`second`). 
 * `host_header` - The value of `Host` header used in http/https health check access.
 * `path` - The request path used in http/https health check access.
 * `status` - HTTP status code expected by health check access.

--- a/website/docs/d/simple_monitor.html.markdown
+++ b/website/docs/d/simple_monitor.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_simple_monitor"
+sidebar_current: "docs-sakuracloud-datasource-simple-monitor"
+description: |-
+  Get information on a SakuraCloud Simple Monitor.
+---
+
+# sakuracloud\_simple\_monitor
+
+Use this data source to retrieve information about a SakuraCloud Simple Monitor.
+
+## Example Usage
+
+```hcl
+data sakuracloud_simple_monitor "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `target` - The HostName or IP address of monitoring target.
+* `health_check` - Health check rules. It contains several attributes to [Health Check](#health-check).
+* `notify_email_enabled` - The flag of enable/disable notification by E-mail.
+* `notify_email_html` - The flag of enable/disable HTML format for E-mail.
+* `notify_slack_enabled` - The flag of enable/disable notification by slack.
+* `notify_slack_webhook` - The webhook URL of destination of slack notification.
+* `enabled` - The flag of enable/disable monitoring.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+
+### Health Check
+
+Attributes for Health Check:
+
+* `protocol` - Protocol used in health check.
+* `delay_loop` - Health check access interval(unit:`second`). 
+* `host_header` - The value of `Host` header used in http/https health check access.
+* `path` - The request path used in http/https health check access.
+* `status` - HTTP status code expected by health check access.
+* `sni` - The flag of enable/disable SNI.
+* `port` - Port number used in health check access.
+* `qname` - The QName value used in dns health check access.
+* `excepcted_data` - The expect value used in dns/snmp health check.
+* `community` - The community name used in snmp health check.
+* `snmp_version` - SNMP cersion used in snmp health check.
+* `oid` - The OID used in snmp health check.
+* `remaining_days` - The number of remaining days used in ssh-certificate check.

--- a/website/docs/d/simple_monitor.html.markdown
+++ b/website/docs/d/simple_monitor.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_simple_monitor "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
 
 ## Attributes Reference
@@ -35,7 +35,7 @@ data sakuracloud_simple_monitor "foobar" {
 * `notify_slack_webhook` - The webhook URL of destination of slack notification.
 * `enabled` - The flag of enable/disable monitoring.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 
 ### Health Check

--- a/website/docs/d/simple_monitor.html.markdown
+++ b/website/docs/d/simple_monitor.html.markdown
@@ -28,7 +28,7 @@ data sakuracloud_simple_monitor "foobar" {
 
 * `id` - The ID of the resource.
 * `target` - The HostName or IP address of monitoring target.
-* `health_check` - Health check rules. It contains several attributes to [Health Check](#health-check).
+* `health_check` - Health check rules. It contains some attributes to [Health Check](#health-check).
 * `notify_email_enabled` - The flag of enable/disable notification by E-mail.
 * `notify_email_html` - The flag of enable/disable HTML format for E-mail.
 * `notify_slack_enabled` - The flag of enable/disable notification by slack.

--- a/website/docs/d/ssh_key.html.markdown
+++ b/website/docs/d/ssh_key.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_ssh_key"
+sidebar_current: "docs-sakuracloud-datasource-ssh-key"
+description: |-
+  Get information on a SakuraCloud SSH Key.
+---
+
+# sakuracloud\_ssh_key
+
+Use this data source to retrieve information about a SakuraCloud SSH Key.
+
+## Example Usage
+
+```hcl
+data sakuracloud_ssh_key "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `filter` - (Optional) The map of filter key and value.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `description` - The description of the resource.
+* `public_key` - The body of the public key. 
+* `finger_print` - The fingerprint of the public key.

--- a/website/docs/d/ssh_key.html.markdown
+++ b/website/docs/d/ssh_key.html.markdown
@@ -20,7 +20,7 @@ data sakuracloud_ssh_key "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
+ * `name_selectors` - (Optional) The list of names to filtering.
  * `filter` - (Optional) The map of filter key and value.
 
 ## Attributes Reference

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -31,7 +31,7 @@ data sakuracloud_subnet "foobar" {
 * `next_hop` - Next hop address.
 * `switch_id` - The ID of the switch connected to the Subnet.
 * `nw_address` -  The network address.
-* `min_ipaddress` - Minimum global ip address.
-* `max_ipaddress` - Maximum global ip address.
-* `ipaddresses` - Global ip address list.
+* `min_ipaddress` - Min global IP address.
+* `max_ipaddress` - Max global IP address.
+* `ipaddresses` - Global IP address list.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_subnet"
+sidebar_current: "docs-sakuracloud-datasource-subnet"
+description: |-
+  Get information on a SakuraCloud Subnet.
+---
+
+# sakuracloud\_subnet
+
+Use this data source to retrieve information about a SakuraCloud Subnet.
+
+## Example Usage
+
+```hcl
+data sakuracloud_subnet "foobar" {
+  internet_id = "${sakuracloud_internet.foobar.id}"
+  index       = 0
+}
+```
+
+## Argument Reference
+
+ * `internet_id` - (Required) The filter value list of name.
+ * `index` - (Required) The filter value list of tags.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `nw_mask_len` - Network mask length of the Subnet.
+* `next_hop` - Next hop address.
+* `switch_id` - The ID of the switch connected to the Subnet.
+* `nw_address` -  The network address.
+* `min_ipaddress` - Minimum global ip address.
+* `max_ipaddress` - Maximum global ip address.
+* `ipaddresses` - Global ip address list.
+* `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -21,8 +21,8 @@ data sakuracloud_subnet "foobar" {
 
 ## Argument Reference
 
- * `internet_id` - (Required) The filter value list of name.
- * `index` - (Required) The filter value list of tags.
+ * `internet_id` - (Required) The ID of the Internet resource.
+ * `index` - (Required) The index of the target subnet.
 
 ## Attributes Reference
 

--- a/website/docs/d/switch.html.markdown
+++ b/website/docs/d/switch.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_switch"
 sidebar_current: "docs-sakuracloud-datasource-switch"
 description: |-
-  Get information on a SakuraCloud switch.
+  Get information on a SakuraCloud Switch.
 ---
 
 # sakuracloud\_switch
 
-Use this data source to retrieve information about a SakuraCloud switch.
+Use this data source to retrieve information about a SakuraCloud Switch.
 
 ## Example Usage
 

--- a/website/docs/d/switch.html.markdown
+++ b/website/docs/d/switch.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_switch"
+sidebar_current: "docs-sakuracloud-datasource-switch"
+description: |-
+  Get information on a SakuraCloud switch.
+---
+
+# sakuracloud\_switch
+
+Use this data source to retrieve information about a SakuraCloud switch.
+
+## Example Usage
+
+```hcl
+data sakuracloud_switch "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `bridge_id` - The ID of the bridge connected to the switch.
+* `name` - The name of the resource.
+* `server_ids` - The IDs of the server connected to the switch.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/switch.html.markdown
+++ b/website/docs/d/switch.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_switch "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -32,6 +32,6 @@ data sakuracloud_switch "foobar" {
 * `name` - The name of the resource.
 * `server_ids` - The IDs of the server connected to the switch.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/d/switch.html.markdown
+++ b/website/docs/d/switch.html.markdown
@@ -30,7 +30,7 @@ data sakuracloud_switch "foobar" {
 * `id` - The ID of the resource.
 * `bridge_id` - The ID of the bridge connected to the switch.
 * `name` - The name of the resource.
-* `server_ids` - The IDs of the server connected to the switch.
+* `server_ids` - The ID list of the servers connected to the switch.
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.

--- a/website/docs/d/vpc_router.html.markdown
+++ b/website/docs/d/vpc_router.html.markdown
@@ -30,7 +30,7 @@ data sakuracloud_vpc_router "foobar" {
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
 * `plan` - The name of the resource plan. 
-* `switch_id` - The ID of the Switch connected to the VPC Router(eth0).
+* `switch_id` - The ID of the Switch connected to the VPC Router (eth0).
 * `vip` - Virtual IP address of the VPC Router. Used when plan is in `premium` or `highspec`.
 * `ipaddress1` - The primary IP address of the VPC Router.
 * `ipaddress2` - The secondly IP address of the VPC Router. Used when plan is in `premium` or `highspec`.

--- a/website/docs/d/vpc_router.html.markdown
+++ b/website/docs/d/vpc_router.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router"
+sidebar_current: "docs-sakuracloud-datasource-vpc-router"
+description: |-
+  Get information on a SakuraCloud VPC Router.
+---
+
+# sakuracloud\_vpc\_router
+
+Use this data source to retrieve information about a SakuraCloud VPC Router.
+
+## Example Usage
+
+```hcl
+data sakuracloud_vpc_router "foobar" {
+  name_selectors = ["foobar"]
+}
+```
+
+## Argument Reference
+
+ * `name_selectors` - (Optional) The filter value list of name.
+ * `tag_selectors` - (Optional) The filter value list of tags.
+ * `filter` - (Optional) The map of filter key and value.
+ * `zone` - (Optional) The ID of the zone.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `plan` - The name of the resource plan. 
+* `switch_id` - The ID of the Switch connected to the VPC Router(eth0).
+* `vip` - Virtual IP address of the VPC Router. It is used only when plan is in `premium` or `highspec`.
+* `ipaddress1` - The primary IP address of the VPC Router.
+* `ipaddress2` - The secondly IP address of the VPC Router. It is used only when plan is in `premium` or `highspec`.
+* `vrid` - VRID used when plan is in `premium` or `highspec`.
+* `aliases` - The IP address aliase list. It is used only when plan is in `premium` or `highspec`.
+* `global_address` - Global IP address of the VPC Router.
+* `syslog_host` - The destination HostName/IP address to send log.	
+* `internet_connection` - The flag of enable/disable connection from the VPC Router to the Internet.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+

--- a/website/docs/d/vpc_router.html.markdown
+++ b/website/docs/d/vpc_router.html.markdown
@@ -20,8 +20,8 @@ data sakuracloud_vpc_router "foobar" {
 
 ## Argument Reference
 
- * `name_selectors` - (Optional) The filter value list of name.
- * `tag_selectors` - (Optional) The filter value list of tags.
+ * `name_selectors` - (Optional) The list of names to filtering.
+ * `tag_selectors` - (Optional) The list of tags to filtering.
  * `filter` - (Optional) The map of filter key and value.
  * `zone` - (Optional) The ID of the zone.
 
@@ -40,7 +40,7 @@ data sakuracloud_vpc_router "foobar" {
 * `syslog_host` - The destination HostName/IP address to send log.	
 * `internet_connection` - The flag of enable/disable connection from the VPC Router to the Internet.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/d/vpc_router.html.markdown
+++ b/website/docs/d/vpc_router.html.markdown
@@ -31,11 +31,11 @@ data sakuracloud_vpc_router "foobar" {
 * `name` - The name of the resource.
 * `plan` - The name of the resource plan. 
 * `switch_id` - The ID of the Switch connected to the VPC Router(eth0).
-* `vip` - Virtual IP address of the VPC Router. It is used only when plan is in `premium` or `highspec`.
+* `vip` - Virtual IP address of the VPC Router. Used when plan is in `premium` or `highspec`.
 * `ipaddress1` - The primary IP address of the VPC Router.
-* `ipaddress2` - The secondly IP address of the VPC Router. It is used only when plan is in `premium` or `highspec`.
+* `ipaddress2` - The secondly IP address of the VPC Router. Used when plan is in `premium` or `highspec`.
 * `vrid` - VRID used when plan is in `premium` or `highspec`.
-* `aliases` - The IP address aliase list. It is used only when plan is in `premium` or `highspec`.
+* `aliases` - The IP address aliase list. Used when plan is in `premium` or `highspec`.
 * `global_address` - Global IP address of the VPC Router.
 * `syslog_host` - The destination HostName/IP address to send log.	
 * `internet_connection` - The flag of enable/disable connection from the VPC Router to the Internet.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "sakuracloud"
+page_title: "Provider: SakuraCloud"
+sidebar_current: "docs-sakuracloud-index"
+description: |-
+  The SakuraCloud provider is used to interact with Sakura Cloud(IaaS).
+  The provider needs to be configured with the proper credentials before it can be used.
+---
+
+# SakuraCloud Provider
+
+The SakuraCloud provider is used to interact with Sakura Cloud(IaaS).
+The provider needs to be configured with the proper credentials before it can be used.
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+```hcl
+# Configure the SakuraCloud provider
+provider "sakuracloud" {
+  token  = "<your API token>"
+  secret = "<your API secret>"
+  zone   = "<target zone>" 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `token` - (Required) The SakuraCloud API access token. It must be provided, but it can also be sourced from the `SAKURACLOUD_ACCESS_TOKEN` environment variable.
+* `secret` - (Required) The SakuraCloud API access token secret. It must be provided, but it can also be sourced from the `SAKURACLOUD_ACCESS_TOKEN_SECRET` environment variable.
+* `zone` - (Optional) The Default target zone of API operations. It can also be sourced from the `SAKURACLOUD_ZONE` environment variable. Default value is `is1b`.
+* `accept_language` - (Optional) The value of `Accept-Language` header to be set at API call. It can also be sourced from the `SAKURACLOUD_ACCEPT_LANGUAGE` environment variable.
+* `api_root_url` - (Optional) The root URL of API call destination. It can also be sourced from the `SAKURACLOUD_API_ROOT_URL` environment variable.
+* `retry_max` - (Optional) The number of retries when an error(status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_MAX` environment variable. Default value is `10`.
+* `retry_interval` - (Optional) The retry interval(seconds) when an error(status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_INTERVAL` environment variable. Default value is `5`.
+* `timeout` - (Optional) The status change wait time in API call(minutes). It can also be sourced from the `SAKURACLOUD_TIMEOUT` environment variable. Default value is `20`.
+* `trace` - (Optional) The flag of output logs at API call. It can also be sourced from the `SAKURACLOUD_TRACE_MODE` environment variable. 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -3,13 +3,13 @@ layout: "sakuracloud"
 page_title: "Provider: SakuraCloud"
 sidebar_current: "docs-sakuracloud-index"
 description: |-
-  The SakuraCloud provider is used to interact with Sakura Cloud(IaaS).
+  The SakuraCloud provider is used to interact with Sakura Cloud (IaaS).
   The provider needs to be configured with the proper credentials before it can be used.
 ---
 
 # SakuraCloud Provider
 
-The SakuraCloud provider is used to interact with Sakura Cloud(IaaS).
+The SakuraCloud provider is used to interact with Sakura Cloud (IaaS).
 The provider needs to be configured with the proper credentials before it can be used.
 
 Use the navigation to the left to read about the available resources.
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `zone` - (Optional) The Default target zone of API operations. It can also be sourced from the `SAKURACLOUD_ZONE` environment variable. Default value is `is1b`.
 * `accept_language` - (Optional) The value of `Accept-Language` header to be set at API call. It can also be sourced from the `SAKURACLOUD_ACCEPT_LANGUAGE` environment variable.
 * `api_root_url` - (Optional) The root URL of API call destination. It can also be sourced from the `SAKURACLOUD_API_ROOT_URL` environment variable.
-* `retry_max` - (Optional) The number of retries when an error(status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_MAX` environment variable. Default value is `10`.
-* `retry_interval` - (Optional) The retry interval(seconds) when an error(status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_INTERVAL` environment variable. Default value is `5`.
-* `timeout` - (Optional) The status change wait time in API call(minutes). It can also be sourced from the `SAKURACLOUD_TIMEOUT` environment variable. Default value is `20`.
+* `retry_max` - (Optional) The number of retries when an error (status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_MAX` environment variable. Default value is `10`.
+* `retry_interval` - (Optional) The retry interval (seconds) when an error (status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_INTERVAL` environment variable. Default value is `5`.
+* `timeout` - (Optional) The status change wait time in API call (minutes). It can also be sourced from the `SAKURACLOUD_TIMEOUT` environment variable. Default value is `20`.
 * `trace` - (Optional) The flag of output logs at API call. It can also be sourced from the `SAKURACLOUD_TRACE_MODE` environment variable. 

--- a/website/docs/r/archive.html.markdown
+++ b/website/docs/r/archive.html.markdown
@@ -34,7 +34,7 @@ Valid value is one of the following: [ 20(default) / 40 / 60 / 80 / 100 / 250 / 
 * `archive_file` - (Optional) Archive file to upload(format:`raw`).
 * `hash` - (Optional) MD5 hash value of the archive file.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
@@ -46,7 +46,7 @@ The following attributes are exported:
 * `name` - The name of the resource.
 * `size` - The size of the resource(unit:`GB`)
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/archive.html.markdown
+++ b/website/docs/r/archive.html.markdown
@@ -29,9 +29,9 @@ resource sakuracloud_archive "foobar" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
-* `size` - (Optional) The size of the resource(unit:`GB`).   
-Valid value is one of the following: [ 20(default) / 40 / 60 / 80 / 100 / 250 / 500 / 750 / 1024 ]
-* `archive_file` - (Optional) Archive file to upload(format:`raw`).
+* `size` - (Optional) The size of the resource (unit:`GB`).   
+Valid value is one of the following: [ 20 (default) / 40 / 60 / 80 / 100 / 250 / 500 / 750 / 1024 ]
+* `archive_file` - (Optional) Archive file to upload (format:`raw`).
 * `hash` - (Optional) MD5 hash value of the archive file.
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
@@ -44,7 +44,7 @@ The following attributes are exported:
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `size` - The size of the resource(unit:`GB`)
+* `size` - The size of the resource (unit:`GB`).
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.

--- a/website/docs/r/archive.html.markdown
+++ b/website/docs/r/archive.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_archive"
-sidebar_current: "docs-sakuracloud-resource-archive"
+sidebar_current: "docs-sakuracloud-resource-storage-archive"
 description: |-
   Provides a SakuraCloud Archive resource. This can be used to create, update, and delete Archives.
 ---

--- a/website/docs/r/archive.html.markdown
+++ b/website/docs/r/archive.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_archive"
+sidebar_current: "docs-sakuracloud-resource-archive"
+description: |-
+  Provides a SakuraCloud Archive resource. This can be used to create, modify, and delete Archives.
+---
+
+# sakuracloud\_archive
+
+Provides a SakuraCloud Archive resource. This can be used to create, modify, and delete Archives.
+
+## Example Usage
+
+```hcl
+# Create a new Archive
+resource sakuracloud_archive "foobar" {
+  name         = "foobar"
+  size         = 20
+  archive_file = "your/archive/file.raw"
+  hash         = "${md5(file("your/archive/file.raw"))}"
+  description  = "description"
+  tags         = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `size` - (Optional) The size of the resource(unit:`GB`).   
+Valid value is one of the following: [ 20(default) / 40 / 60 / 80 / 100 / 250 / 500 / 750 / 1024 ]
+* `archive_file` - (Optional) Archive file to upload(format:`raw`).
+* `hash` - (Optional) MD5 hash value of the archive file.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `size` - The size of the resource(unit:`GB`)
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Archives can be imported using the Archive ID.
+
+```
+$ terraform import sakuracloud_archive.foobar <archive_id>
+```

--- a/website/docs/r/archive.html.markdown
+++ b/website/docs/r/archive.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_archive"
 sidebar_current: "docs-sakuracloud-resource-archive"
 description: |-
-  Provides a SakuraCloud Archive resource. This can be used to create, modify, and delete Archives.
+  Provides a SakuraCloud Archive resource. This can be used to create, update, and delete Archives.
 ---
 
 # sakuracloud\_archive
 
-Provides a SakuraCloud Archive resource. This can be used to create, modify, and delete Archives.
+Provides a SakuraCloud Archive resource. This can be used to create, update, and delete Archives.
 
 ## Example Usage
 

--- a/website/docs/r/auto_backup.html.markdown
+++ b/website/docs/r/auto_backup.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 Valid values are the following: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 * `max_backup_num` - (Optional) Max number of backups to keep.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.  
 Valid value is one of the following: ["is1b" / "tk1a"]
@@ -49,7 +49,7 @@ The following attributes are exported:
 * `weekdays` - Day of the week to get backup.  
 * `max_backup_num` - Max number of backups to keep.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/auto_backup.html.markdown
+++ b/website/docs/r/auto_backup.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_auto_backup"
-sidebar_current: "docs-sakuracloud-resource-auto-backup"
+sidebar_current: "docs-sakuracloud-resource-appliance-auto-backup"
 description: |-
   Provides a SakuraCloud Auto Backup resource. This can be used to create, update, and delete Auto Backups.
 ---

--- a/website/docs/r/auto_backup.html.markdown
+++ b/website/docs/r/auto_backup.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_auto_backup"
 sidebar_current: "docs-sakuracloud-resource-auto-backup"
 description: |-
-  Provides a SakuraCloud Auto Backup resource. This can be used to create, modify, and delete Auto Backups.
+  Provides a SakuraCloud Auto Backup resource. This can be used to create, update, and delete Auto Backups.
 ---
 
 # sakuracloud\_auto_backup
 
-Provides a SakuraCloud Auto Backup resource. This can be used to create, modify, and delete Auto Backups.
+Provides a SakuraCloud Auto Backup resource. This can be used to create, update, and delete Auto Backups.
 
 ## Example Usage
 
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `disk_id` - (Optional) The ID of the target disk. 
 * `weekdays` - (Optional) Day of the week to get backup.  
 Valid values are the following: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
-* `max_backup_num` - (Optional) Maximum number of backups to keep.
+* `max_backup_num` - (Optional) Max number of backups to keep.
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
@@ -47,7 +47,7 @@ The following attributes are exported:
 * `name` - The name of the resource.
 * `disk_id` - The ID of the target disk. 
 * `weekdays` - Day of the week to get backup.  
-* `max_backup_num` - Maximum number of backups to keep.
+* `max_backup_num` - Max number of backups to keep.
 * `description` - The description of the resource.
 * `tags` - The tag list of the resource.
 * `icon_id` - The ID of the icon of the resource.

--- a/website/docs/r/auto_backup.html.markdown
+++ b/website/docs/r/auto_backup.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_auto_backup"
+sidebar_current: "docs-sakuracloud-resource-auto-backup"
+description: |-
+  Provides a SakuraCloud Auto Backup resource. This can be used to create, modify, and delete Auto Backups.
+---
+
+# sakuracloud\_auto_backup
+
+Provides a SakuraCloud Auto Backup resource. This can be used to create, modify, and delete Auto Backups.
+
+## Example Usage
+
+```hcl
+# Create a new Auto Backup
+resource sakuracloud_auto_backup "foobar" {
+  name           = "foobar"
+  disk_id        = "${sakuracloud_disk.disk.id}"
+  weekdays       = ["fri","sun"]
+  max_backup_num = 2
+  description    = "description"
+  tags           = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `disk_id` - (Optional) The ID of the target disk. 
+* `weekdays` - (Optional) Day of the week to get backup.  
+Valid values are the following: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+* `max_backup_num` - (Optional) Maximum number of backups to keep.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.  
+Valid value is one of the following: ["is1b" / "tk1a"]
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `disk_id` - The ID of the target disk. 
+* `weekdays` - Day of the week to get backup.  
+* `max_backup_num` - Maximum number of backups to keep.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Auto Backups can be imported using the Auto Backup ID.
+
+```
+$ terraform import sakuracloud_auto_backup.foobar <auto_backup_id>
+```

--- a/website/docs/r/bridge.html.markdown
+++ b/website/docs/r/bridge.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_bridge"
-sidebar_current: "docs-sakuracloud-resource-bridge"
+sidebar_current: "docs-sakuracloud-resource-networking-bridge"
 description: |-
   Provides a SakuraCloud Bridge resource. This can be used to create, update, and delete Bridges.
 ---

--- a/website/docs/r/bridge.html.markdown
+++ b/website/docs/r/bridge.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_bridge"
+sidebar_current: "docs-sakuracloud-resource-bridge"
+description: |-
+  Provides a SakuraCloud Bridge resource. This can be used to create, modify, and delete Bridges.
+---
+
+# sakuracloud\_bridge
+
+Provides a SakuraCloud Bridge resource. This can be used to create, modify, and delete Bridges.
+
+## Example Usage
+
+```hcl
+# Create a new Bridge
+resource sakuracloud_bridge "foobar" {
+  name        = "foobar"
+  switch_ids  = ["${sakuracloud_switch.foobar.id}"]
+  description = "description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `switch_ids` - (Optional) The ID list of the Switches connected to the Bridge. 
+* `description` - (Optional) The description of the resource.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.  
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `switch_ids` - The ID list of the Switches connected to the Bridge. 
+* `description` - The description of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Bridges can be imported using the Bridge ID.
+
+```
+$ terraform import sakuracloud_bridge.foobar <bridge_id>
+```

--- a/website/docs/r/bridge.html.markdown
+++ b/website/docs/r/bridge.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_bridge"
 sidebar_current: "docs-sakuracloud-resource-bridge"
 description: |-
-  Provides a SakuraCloud Bridge resource. This can be used to create, modify, and delete Bridges.
+  Provides a SakuraCloud Bridge resource. This can be used to create, update, and delete Bridges.
 ---
 
 # sakuracloud\_bridge
 
-Provides a SakuraCloud Bridge resource. This can be used to create, modify, and delete Bridges.
+Provides a SakuraCloud Bridge resource. This can be used to create, update, and delete Bridges.
 
 ## Example Usage
 

--- a/website/docs/r/bucket_object.html.markdown
+++ b/website/docs/r/bucket_object.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_bucket_object"
-sidebar_current: "docs-sakuracloud-resource-bucket_object"
+sidebar_current: "docs-sakuracloud-resource-objectstorage-bucket-object"
 description: |-
   Provides a SakuraCloud Bucket Object resource. This can be used to create, update, and delete Bucket Objects.
 ---

--- a/website/docs/r/bucket_object.html.markdown
+++ b/website/docs/r/bucket_object.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a SakuraCloud Bucket Object resource. This can be used to create, update, and delete Bucket Objects.
 
-~> **NOTE on Bucket:**  Sakura Cloud does not support API bucket creation.
+~> **NOTE on Bucket:**  Sakura Cloud does not support bucket creation by API.
 Buckets should be created on the control panel.
 
 ## Example Usage
@@ -44,15 +44,15 @@ resource sakuracloud_bucket_object "foobar" {
 * `content_type` - Content-Type header value of the bucket object.
 * `body` - String of the value of the bucket object. Set when Content-Type is `"text/*"` or `"application/json"`.
 * `etag` - ETag of the resource.
-* `size` - Size of the resource(unit: `byte`).
+* `size` - Size of the resource (unit:`byte`).
 * `last_modified` - Update date of the resource.
-* `http_url` - URL for accessing the object via HTTP(type: `subdomain`).
-* `https_url` - URL for accessing the object via HTTPS(type: `subdomain`).
-* `http_path_url` - URL for accessing the object via HTTP(type: `path`).
-* `http_cache_url` - URL for accessing the object via HTTP(type: `cache`).
-* `https_cache_url` - URL for accessing the object via HTTPS(type: `cache`)..
+* `http_url` - URL for accessing the object via HTTP (type:`subdomain`).
+* `https_url` - URL for accessing the object via HTTPS (type:`subdomain`).
+* `http_path_url` - URL for accessing the object via HTTP (type:`path`).
+* `http_cache_url` - URL for accessing the object via HTTP (type:`cache`).
+* `https_cache_url` - URL for accessing the object via HTTPS (type:`cache`)..
 
 
-## Import(not supported)
+## Import (not supported)
 
 Import of Bucket Object is not supported.

--- a/website/docs/r/bucket_object.html.markdown
+++ b/website/docs/r/bucket_object.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_bucket_object"
+sidebar_current: "docs-sakuracloud-resource-bucket_object"
+description: |-
+  Provides a SakuraCloud Bucket Object resource. This can be used to create, modify, and delete Bucket Objects.
+---
+
+# sakuracloud\_bucket\_object
+
+Provides a SakuraCloud Bucket Object resource. This can be used to create, modify, and delete Bucket Objects.
+
+~> **NOTE on Bucket:** Currently, Sakura Cloud does not support API bucket creation.
+Buckets should be created on the control panel.
+
+## Example Usage
+
+```hcl
+# Create a new Bucket Object
+resource sakuracloud_bucket_object "foobar" {
+   bucket       = "your-bucket-name"
+   key          = "path/to/your/object"
+   source       = "path/to/your/source/file"
+   # or
+   #content     = "your-content-body"
+   content_type = "application/json"
+}
+```
+
+
+## Argument Reference
+
+* `bucket` - (Required) The name of bucket.
+* `access_key` - (Required) The access key of bucket. It must be provided, but it can also be sourced from the `SACLOUD_OJS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY_ID` environment variable.
+* `secret_key` - (Required) The secret key of bucket. It must be provided, but it can also be sourced from the `SACLOUD_OJS_SECRET_ACCESS_KEY` or `AWS_SECRET_ACCESS_KEY` environment variable.
+* `key` - (Required) The key of the bucket object.
+* `source` - (Optional) Source file path of value of the bucket object.
+* `content` - (Optional) String of the value of the bucket object. 
+* `content_type` - (Optional) Content-Type header value of the bucket object.
+
+## Attributes Reference
+
+* `id` - ID of the resource.
+* `content_type` - Content-Type header value of the bucket object.
+* `body` - String of the value of the bucket object. It is set only when Content-Type is `"text/*"` or `"application/json"`.
+* `etag` - ETag of the resource.
+* `size` - Size of the resource(unit: `byte`).
+* `last_modified` - Update date of the resource.
+* `http_url` - URL for accessing the object via HTTP(type: `subdomain`).
+* `https_url` - URL for accessing the object via HTTPS(type: `subdomain`).
+* `http_path_url` - URL for accessing the object via HTTP(type: `path`).
+* `http_cache_url` - URL for accessing the object via HTTP(type: `cache`).
+* `https_cache_url` - URL for accessing the object via HTTPS(type: `cache`)..
+
+
+## Import(not supported)
+
+Import of Bucket Object is not supported.

--- a/website/docs/r/bucket_object.html.markdown
+++ b/website/docs/r/bucket_object.html.markdown
@@ -3,14 +3,14 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_bucket_object"
 sidebar_current: "docs-sakuracloud-resource-bucket_object"
 description: |-
-  Provides a SakuraCloud Bucket Object resource. This can be used to create, modify, and delete Bucket Objects.
+  Provides a SakuraCloud Bucket Object resource. This can be used to create, update, and delete Bucket Objects.
 ---
 
 # sakuracloud\_bucket\_object
 
-Provides a SakuraCloud Bucket Object resource. This can be used to create, modify, and delete Bucket Objects.
+Provides a SakuraCloud Bucket Object resource. This can be used to create, update, and delete Bucket Objects.
 
-~> **NOTE on Bucket:** Currently, Sakura Cloud does not support API bucket creation.
+~> **NOTE on Bucket:**  Sakura Cloud does not support API bucket creation.
 Buckets should be created on the control panel.
 
 ## Example Usage
@@ -42,7 +42,7 @@ resource sakuracloud_bucket_object "foobar" {
 
 * `id` - ID of the resource.
 * `content_type` - Content-Type header value of the bucket object.
-* `body` - String of the value of the bucket object. It is set only when Content-Type is `"text/*"` or `"application/json"`.
+* `body` - String of the value of the bucket object. Set when Content-Type is `"text/*"` or `"application/json"`.
 * `etag` - ETag of the resource.
 * `size` - Size of the resource(unit: `byte`).
 * `last_modified` - Update date of the resource.

--- a/website/docs/r/cdrom.html.markdown
+++ b/website/docs/r/cdrom.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_cdrom"
 sidebar_current: "docs-sakuracloud-resource-cdrom"
 description: |-
-  Provides a SakuraCloud CDROM(ISO-Image) resource. This can be used to create, modify, and delete CDROMs.
+  Provides a SakuraCloud CDROM(ISO-Image) resource. This can be used to create, update, and delete CDROMs.
 ---
 
 # sakuracloud\_cdrom
 
-Provides a SakuraCloud CDROM(ISO-Image) resource. This can be used to create, modify, and delete CDROMs.
+Provides a SakuraCloud CDROM(ISO-Image) resource. This can be used to create, update, and delete CDROMs.
 
 ## Example Usage
 

--- a/website/docs/r/cdrom.html.markdown
+++ b/website/docs/r/cdrom.html.markdown
@@ -1,0 +1,65 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_cdrom"
+sidebar_current: "docs-sakuracloud-resource-cdrom"
+description: |-
+  Provides a SakuraCloud CDROM(ISO-Image) resource. This can be used to create, modify, and delete CDROMs.
+---
+
+# sakuracloud\_cdrom
+
+Provides a SakuraCloud CDROM(ISO-Image) resource. This can be used to create, modify, and delete CDROMs.
+
+## Example Usage
+
+```hcl
+# Create a new CDROM(ISO-Image)
+resource sakuracloud_cdrom "foobar" {
+  name           = "foobar"
+  size           = 5
+  iso_image_file = "your/cdrom/file.iso"
+  hash           = "${md5(file("your/cdrom/file.iso"))}"
+  # or
+  # content      = "your-content" 
+  # or
+  # content_file_path = "${file("your/cdrom/content.json")}" 
+  description  = "description"
+  tags         = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `size` - (Optional) The size of the resource(unit:`GB`).   
+Valid value is one of the following: [ 5(default) / 10 ]
+* `iso_image_file` - (Optional) CDROM file to upload(format:`raw`).
+* `hash` - (Optional) MD5 hash value of the CDROM file.
+* `content` - (Optional) String of the value of the CDROM. 
+* `content_file_path` - (Optional) The source file path of the CDROM. 
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `size` - The size of the resource(unit:`GB`)
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+CDROMs can be imported using the CDROM ID.
+
+```
+$ terraform import sakuracloud_cdrom.foobar <cdrom_id>
+```

--- a/website/docs/r/cdrom.html.markdown
+++ b/website/docs/r/cdrom.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_cdrom"
 sidebar_current: "docs-sakuracloud-resource-storage-cdrom"
 description: |-
-  Provides a SakuraCloud CDROM(ISO-Image) resource. This can be used to create, update, and delete CDROMs.
+  Provides a SakuraCloud CDROM (ISO-Image) resource. This can be used to create, update, and delete CDROMs.
 ---
 
 # sakuracloud\_cdrom
 
-Provides a SakuraCloud CDROM(ISO-Image) resource. This can be used to create, update, and delete CDROMs.
+Provides a SakuraCloud CDROM (ISO-Image) resource. This can be used to create, update, and delete CDROMs.
 
 ## Example Usage
 
@@ -33,9 +33,9 @@ resource sakuracloud_cdrom "foobar" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
-* `size` - (Optional) The size of the resource(unit:`GB`).   
-Valid value is one of the following: [ 5(default) / 10 ]
-* `iso_image_file` - (Optional) CDROM file to upload(format:`raw`).
+* `size` - (Optional) The size of the resource (unit:`GB`).   
+Valid value is one of the following: [ 5 (default) / 10 ]
+* `iso_image_file` - (Optional) CDROM file to upload (format:`raw`).
 * `hash` - (Optional) MD5 hash value of the CDROM file.
 * `content` - (Optional) String of the value of the CDROM. 
 * `content_file_path` - (Optional) The source file path of the CDROM. 
@@ -50,7 +50,7 @@ The following attributes are exported:
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `size` - The size of the resource(unit:`GB`)
+* `size` - The size of the resource (unit:`GB`).
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.

--- a/website/docs/r/cdrom.html.markdown
+++ b/website/docs/r/cdrom.html.markdown
@@ -40,7 +40,7 @@ Valid value is one of the following: [ 5(default) / 10 ]
 * `content` - (Optional) String of the value of the CDROM. 
 * `content_file_path` - (Optional) The source file path of the CDROM. 
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
@@ -52,7 +52,7 @@ The following attributes are exported:
 * `name` - The name of the resource.
 * `size` - The size of the resource(unit:`GB`)
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/cdrom.html.markdown
+++ b/website/docs/r/cdrom.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_cdrom"
-sidebar_current: "docs-sakuracloud-resource-cdrom"
+sidebar_current: "docs-sakuracloud-resource-storage-cdrom"
 description: |-
   Provides a SakuraCloud CDROM(ISO-Image) resource. This can be used to create, update, and delete CDROMs.
 ---

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -53,7 +53,7 @@ Valid value is one of the following: [ "10g"(default) / "30g" / "90g" / "240g" /
 * `nw_mask_len` - (Required) The network mask length of the database.
 * `default_route` - (Required) The default route IP address of the database.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the Database.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
@@ -75,7 +75,7 @@ The following attributes are exported:
 * `nw_mask_len` - The network mask length of the database.
 * `default_route` - The default route IP address of the database.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -1,0 +1,88 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_database"
+sidebar_current: "docs-sakuracloud-resource-database"
+description: |-
+  Provides a SakuraCloud Database resource. This can be used to create, modify, and delete Databases.
+---
+
+# sakuracloud\_database
+
+Provides a SakuraCloud Database resource. This can be used to create, modify, and delete Databases.
+
+## Example Usage
+
+```hcl
+# Create a new Database
+resource sakuracloud_database "foobar" {
+  name           = "foobar"
+  database_type  = "mariadb"
+  plan           = "30g"
+  user_name      = "user"
+  user_password  = "p@ssword"
+  allow_networks = ["192.168.2.0/24"]
+  port           = 33061
+  backup_time    = "00:00"
+
+  switch_id      = "${sakuracloud_switch.foobar.id}"
+  ipaddress1     = "192.168.11.101"
+  nw_mask_len    = 24
+  default_route  = "192.168.11.1"
+  
+  description    = "description"
+  tags           = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `database_type` - (Optional) The type of the Database.
+Valid value is one of the following: [ "postgresql"(default) / "mariadb"]
+* `plan` - (Optional) The plan(size) of the Database.   
+Valid value is one of the following: [ "10g"(default) / "30g" / "90g" / "240g" / "500g" / "1t" ]
+* `user_name` - (Required) The username to access database.
+* `user_password` - (Required) The password to access database.
+* `allow_networks` - (Optional) The network address list that allowed connections to the database.
+* `port` - (Optional) The number of the port on which the database is listening(default:`5432`).
+* `backup_time` - (Optional) The time to perform backup(format:`HH:mm`).
+* `switch_id` - (Required) The ID of the switch connected to the database.
+* `ipaddress1` - (Required) The IP address of the database.
+* `nw_mask_len` - (Required) The network mask length of the database.
+* `default_route` - (Required) The default route IP address of the database.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the Database.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `plan` - The name of the resource plan.
+* `user_name` - The username to access database.
+* `user_password` - The password to access database.
+* `allow_networks` - The network address list that allowed connections to the database.
+* `port` - The number of the port on which the database is listening.
+* `backup_time` - The time to perform backup.
+* `switch_id` - The ID of the switch connected to the database.
+* `ipaddress1` - The IP address of the database.
+* `nw_mask_len` - The network mask length of the database.
+* `default_route` - The default route IP address of the database.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Databases can be imported using the Database ID.
+
+```
+$ terraform import sakuracloud_database.foobar <database_id>
+```

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -40,14 +40,14 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
 * `database_type` - (Optional) The Database type.
-Valid value is one of the following: [ "postgresql"(default) / "mariadb"]
-* `plan` - (Optional) The plan(size) of the Database.   
-Valid value is one of the following: [ "10g"(default) / "30g" / "90g" / "240g" / "500g" / "1t" ]
+Valid value is one of the following: [ "postgresql" (default) / "mariadb"]
+* `plan` - (Optional) The plan (size) of the Database.   
+Valid value is one of the following: [ "10g" (default) / "30g" / "90g" / "240g" / "500g" / "1t" ]
 * `user_name` - (Required) The username to access database.
 * `user_password` - (Required) The password to access database.
 * `allow_networks` - (Optional) The network address list that allowed connections to the database.
-* `port` - (Optional) The number of the port on which the database is listening(default:`5432`).
-* `backup_time` - (Optional) The time to perform backup(format:`HH:mm`).
+* `port` - (Optional) The number of the port on which the database is listening (default:`5432`).
+* `backup_time` - (Optional) The time to perform backup (format:`HH:mm`).
 * `switch_id` - (Required) The ID of the switch connected to the database.
 * `ipaddress1` - (Required) The IP address of the database.
 * `nw_mask_len` - (Required) The network mask length of the database.
@@ -55,7 +55,7 @@ Valid value is one of the following: [ "10g"(default) / "30g" / "90g" / "240g" /
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the Database.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the Database.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_database"
 sidebar_current: "docs-sakuracloud-resource-database"
 description: |-
-  Provides a SakuraCloud Database resource. This can be used to create, modify, and delete Databases.
+  Provides a SakuraCloud Database resource. This can be used to create, update, and delete Databases.
 ---
 
 # sakuracloud\_database
 
-Provides a SakuraCloud Database resource. This can be used to create, modify, and delete Databases.
+Provides a SakuraCloud Database resource. This can be used to create, update, and delete Databases.
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource sakuracloud_database "foobar" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
-* `database_type` - (Optional) The type of the Database.
+* `database_type` - (Optional) The Database type.
 Valid value is one of the following: [ "postgresql"(default) / "mariadb"]
 * `plan` - (Optional) The plan(size) of the Database.   
 Valid value is one of the following: [ "10g"(default) / "30g" / "90g" / "240g" / "500g" / "1t" ]
@@ -55,7 +55,7 @@ Valid value is one of the following: [ "10g"(default) / "30g" / "90g" / "240g" /
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the Database.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the Database.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -39,7 +39,7 @@ resource sakuracloud_database "foobar" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
-* `database_type` - (Optional) The Database type.
+* `database_type` - (Optional) The Database type.  
 Valid value is one of the following: [ "postgresql" (default) / "mariadb"]
 * `plan` - (Optional) The plan (size) of the Database.   
 Valid value is one of the following: [ "10g" (default) / "30g" / "90g" / "240g" / "500g" / "1t" ]

--- a/website/docs/r/database.html.markdown
+++ b/website/docs/r/database.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_database"
-sidebar_current: "docs-sakuracloud-resource-database"
+sidebar_current: "docs-sakuracloud-resource-appliance-database"
 description: |-
   Provides a SakuraCloud Database resource. This can be used to create, update, and delete Databases.
 ---

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_disk"
-sidebar_current: "docs-sakuracloud-resource-disk"
+sidebar_current: "docs-sakuracloud-resource-storage-disk"
 description: |-
   Provides a SakuraCloud Disk resource. This can be used to create, update, and delete Disks.
 ---

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -1,0 +1,87 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_disk"
+sidebar_current: "docs-sakuracloud-resource-disk"
+description: |-
+  Provides a SakuraCloud Disk resource. This can be used to create, modify, and delete Disks.
+---
+
+# sakuracloud\_disk
+
+Provides a SakuraCloud Disk resource. This can be used to create, modify, and delete Disks.
+
+## Example Usage
+
+```hcl
+# Create a new Disk
+resource "sakuracloud_disk" "foobar" {
+  name              = "foobar"
+  plan              = "ssd"
+  connector         = "virtio"
+  size              = 20
+  source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
+  # or
+  # source_disk_id  = "<your-disk-id>"
+  
+  # For "Modify Disk" API
+  hostname          = "your-host-name"
+  password          = ""
+  ssh_key_ids       = ["<your-ssh-key-id>"]
+  note_ids          = ["<your-note-id"]
+  disable_pw_auth   = true
+  
+  description       = "description"
+  tags              = ["foo", "bar"]
+}
+
+# Source archive
+data "sakuracloud_archive" "ubuntu" {
+  os_type = "ubuntu"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `plan` - The plan of the resource.  
+Valid value is one of the following: [ "ssd"(default) / "hdd"]
+* `conector` - The disk connector of the resource.  
+Valid value is one of the following: [ "virtio"(default) / "ide"]
+* `size` - Size of the resource(unit:`GB`).
+* `source_archive_id` - The ID of source Archive.
+* `source_disk_id` - The ID of source Disk.
+* `hostname` - The hostname to set with "Modify Disk" API.
+* `password` - The password of OS's administrator to set with "Modify Disk" API.
+* `ssh_key_ids` - The ID list of SSH Key to set with "Modify Disk" API.
+* `note_ids` - The ID list of Note(Startup-Script) to set with "Modify Disk" API.
+* `disable_pw_auth` - The flag of disable password auth via SSH.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `plan` - The plan of the resource(`ssd`/`hdd`).
+* `conector` - The disk connector of the resource(`virtio`/`ide`).
+* `size` - Size of the resource(unit:`GB`).
+* `server_id` - The ID of the server connected to the disk.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Disks can be imported using the Disk ID.
+
+```
+$ terraform import sakuracloud_disk.foobar <disk_id>
+```

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -46,21 +46,21 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
 * `plan` - The plan of the resource.  
-Valid value is one of the following: [ "ssd"(default) / "hdd"]
+Valid value is one of the following: [ "ssd" (default) / "hdd"]
 * `conector` - The disk connector of the resource.  
-Valid value is one of the following: [ "virtio"(default) / "ide"]
-* `size` - Size of the resource(unit:`GB`).
+Valid value is one of the following: [ "virtio" (default) / "ide"]
+* `size` - Size of the resource (unit:`GB`).
 * `source_archive_id` - The ID of source Archive.
 * `source_disk_id` - The ID of source Disk.
 * `hostname` - The hostname to set with `"Modify Disk"` API.
 * `password` - The password of OS's administrator to set with `"Modify Disk"` API.
 * `ssh_key_ids` - The ID list of SSH Keys to set with `"Modify Disk"` API.
-* `note_ids` - The ID list of Notes(Startup-Scripts) to set with `"Modify Disk"` API.
+* `note_ids` - The ID list of Notes (Startup-Scripts) to set with `"Modify Disk"` API.
 * `disable_pw_auth` - The flag of disable password auth via SSH.
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -69,9 +69,9 @@ The following attributes are exported:
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `plan` - The plan of the resource(`ssd`/`hdd`).
-* `conector` - The disk connector of the resource(`virtio`/`ide`).
-* `size` - Size of the resource(unit:`GB`).
+* `plan` - The plan of the resource (`ssd`/`hdd`).
+* `conector` - The disk connector of the resource (`virtio`/`ide`).
+* `size` - Size of the resource (unit:`GB`).
 * `server_id` - The ID of the server connected to the disk.
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_disk"
 sidebar_current: "docs-sakuracloud-resource-disk"
 description: |-
-  Provides a SakuraCloud Disk resource. This can be used to create, modify, and delete Disks.
+  Provides a SakuraCloud Disk resource. This can be used to create, update, and delete Disks.
 ---
 
 # sakuracloud\_disk
 
-Provides a SakuraCloud Disk resource. This can be used to create, modify, and delete Disks.
+Provides a SakuraCloud Disk resource. This can be used to create, update, and delete Disks.
 
 ## Example Usage
 
@@ -52,15 +52,15 @@ Valid value is one of the following: [ "virtio"(default) / "ide"]
 * `size` - Size of the resource(unit:`GB`).
 * `source_archive_id` - The ID of source Archive.
 * `source_disk_id` - The ID of source Disk.
-* `hostname` - The hostname to set with "Modify Disk" API.
-* `password` - The password of OS's administrator to set with "Modify Disk" API.
-* `ssh_key_ids` - The ID list of SSH Key to set with "Modify Disk" API.
-* `note_ids` - The ID list of Note(Startup-Script) to set with "Modify Disk" API.
+* `hostname` - The hostname to set with `"Modify Disk"` API.
+* `password` - The password of OS's administrator to set with `"Modify Disk"` API.
+* `ssh_key_ids` - The ID list of SSH Key to set with `"Modify Disk"` API.
+* `note_ids` - The ID list of Note(Startup-Script) to set with `"Modify Disk"` API.
 * `disable_pw_auth` - The flag of disable password auth via SSH.
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -54,11 +54,11 @@ Valid value is one of the following: [ "virtio"(default) / "ide"]
 * `source_disk_id` - The ID of source Disk.
 * `hostname` - The hostname to set with `"Modify Disk"` API.
 * `password` - The password of OS's administrator to set with `"Modify Disk"` API.
-* `ssh_key_ids` - The ID list of SSH Key to set with `"Modify Disk"` API.
-* `note_ids` - The ID list of Note(Startup-Script) to set with `"Modify Disk"` API.
+* `ssh_key_ids` - The ID list of SSH Keys to set with `"Modify Disk"` API.
+* `note_ids` - The ID list of Notes(Startup-Scripts) to set with `"Modify Disk"` API.
 * `disable_pw_auth` - The flag of disable password auth via SSH.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
@@ -74,7 +74,7 @@ The following attributes are exported:
 * `size` - Size of the resource(unit:`GB`).
 * `server_id` - The ID of the server connected to the disk.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/dns.html.markdown
+++ b/website/docs/r/dns.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_dns"
 sidebar_current: "docs-sakuracloud-resource-dns"
 description: |-
-  Provides a SakuraCloud DNS zones resource. This can be used to create, modify, and delete DNS zones.
+  Provides a SakuraCloud DNS zones resource. This can be used to create, update, and delete DNS zones.
 ---
 
 # sakuracloud\_dns
 
-Provides a SakuraCloud DNS zones resource. This can be used to create, modify, and delete DNS zones.
+Provides a SakuraCloud DNS zones resource. This can be used to create, update, and delete DNS zones.
 
 ## Example Usage
 

--- a/website/docs/r/dns.html.markdown
+++ b/website/docs/r/dns.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_dns"
+sidebar_current: "docs-sakuracloud-resource-dns"
+description: |-
+  Provides a SakuraCloud DNS zones resource. This can be used to create, modify, and delete DNS zones.
+---
+
+# sakuracloud\_dns
+
+Provides a SakuraCloud DNS zones resource. This can be used to create, modify, and delete DNS zones.
+
+## Example Usage
+
+```hcl
+# Create a new DNS zone
+resource "sakuracloud_dns" "foobar" {
+  zone        = "example.com"
+  description = "description"
+  tags        = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone` - (Required) The name of the zone.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `zone` - The name of the zone.
+* `dns_servers` - List of host names of DNS servers.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+
+## Import
+
+DNS can be imported using the DNS ID.
+
+```
+$ terraform import sakuracloud_dns.foobar <dns_id>
+```

--- a/website/docs/r/dns.html.markdown
+++ b/website/docs/r/dns.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_dns"
-sidebar_current: "docs-sakuracloud-resource-dns"
+sidebar_current: "docs-sakuracloud-resource-global-dns-zone"
 description: |-
   Provides a SakuraCloud DNS zones resource. This can be used to create, update, and delete DNS zones.
 ---

--- a/website/docs/r/dns.html.markdown
+++ b/website/docs/r/dns.html.markdown
@@ -27,7 +27,7 @@ The following arguments are supported:
 
 * `zone` - (Required) The name of the zone.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 
 ## Attributes Reference
@@ -38,7 +38,7 @@ The following attributes are exported:
 * `zone` - The name of the zone.
 * `dns_servers` - List of host names of DNS servers.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 
 ## Import

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_dns_record"
-sidebar_current: "docs-sakuracloud-resource-drecord"
+sidebar_current: "docs-sakuracloud-resource-global-dns-record"
 description: |-
   Provides a SakuraCloud DNS Record resource. This can be used to create and delete DNS Records.
 ---

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `dns_id` - (Required) The ID of DNS zones to which the Record belongs.
 * `name` - (Required) The hostname of target Record. If "@" is specified, it indicates own zone.
-* `type` - (Required) The type of the Record.  
+* `type` - (Required) The Record type.  
 Valid value is one of the following: [ "A" / "AAAA" / "CNAME" / "NS" / "MX" / "TXT" / "SRV" ]
 * `value` - (Required) The value of the Record. 
 * `ttl` - (Optional) The ttl value of the Record(unit:`second`). 
@@ -48,7 +48,7 @@ The following attributes are exported:
 
 * `id` - The ID of the resource.
 * `name` - The hostname of target Record. 
-* `type` - The type of the Record.
+* `type` - The Record type.
 * `value` - The value of the Record. 
 * `ttl` - The ttl value of the Record(unit:`second`). 
 * `priority` - The priority used when `type` is `MX` or `SRV`.

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_dns_record"
+sidebar_current: "docs-sakuracloud-resource-drecord"
+description: |-
+  Provides a SakuraCloud DNS Record resource. This can be used to create and delete DNS Records.
+---
+
+# sakuracloud\_dns\_record
+
+Provides a SakuraCloud DNS Record resource. This can be used to create and delete DNS Records.
+
+## Example Usage
+
+```hcl
+# Create a new DNS(zones)
+resource "sakuracloud_dns" "foobar" {
+  zone = "example.com"
+}
+
+# Create a new DNS Record(Type: A)
+resource "sakuracloud_dns_record" "foobar" {
+  dns_id = "${sakuracloud_dns.foobar.id}"
+  name   = "test1"
+  type   = "A"
+  value  = "192.168.2.1"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `dns_id` - (Required) The ID of DNS zones to which the Record belongs.
+* `name` - (Required) The hostname of target Record. If "@" is specified, it indicates own zone.
+* `type` - (Required) The type of the Record.  
+Valid value is one of the following: [ "A" / "AAAA" / "CNAME" / "NS" / "MX" / "TXT" / "SRV" ]
+* `value` - (Required) The value of the Record. 
+* `ttl` - (Optional) The ttl value of the Record(unit:`second`). 
+* `priority` - (Optional) The priority used when `type` is `MX` or `SRV`.
+* `weight` - (Optional) The weight used when `type` is `SRV`.
+* `port` - (Optional) The port number used when `type` is `SRV`. 
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The hostname of target Record. 
+* `type` - The type of the Record.
+* `value` - The value of the Record. 
+* `ttl` - The ttl value of the Record(unit:`second`). 
+* `priority` - The priority used when `type` is `MX` or `SRV`.
+* `weight` - The weight used when `type` is `SRV`.
+* `port` - The port number used when `type` is `SRV`. 
+
+## Import(not supported)
+
+Import of DNS Record is not supported.

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 * `type` - (Required) The Record type.  
 Valid value is one of the following: [ "A" / "AAAA" / "CNAME" / "NS" / "MX" / "TXT" / "SRV" ]
 * `value` - (Required) The value of the Record. 
-* `ttl` - (Optional) The ttl value of the Record(unit:`second`). 
+* `ttl` - (Optional) The ttl value of the Record (unit:`second`). 
 * `priority` - (Optional) The priority used when `type` is `MX` or `SRV`.
 * `weight` - (Optional) The weight used when `type` is `SRV`.
 * `port` - (Optional) The port number used when `type` is `SRV`. 
@@ -50,11 +50,11 @@ The following attributes are exported:
 * `name` - The hostname of target Record. 
 * `type` - The Record type.
 * `value` - The value of the Record. 
-* `ttl` - The ttl value of the Record(unit:`second`). 
+* `ttl` - The ttl value of the Record (unit:`second`). 
 * `priority` - The priority used when `type` is `MX` or `SRV`.
 * `weight` - The weight used when `type` is `SRV`.
 * `port` - The port number used when `type` is `SRV`. 
 
-## Import(not supported)
+## Import (not supported)
 
 Import of DNS Record is not supported.

--- a/website/docs/r/gslb.html.markdown
+++ b/website/docs/r/gslb.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_gslb"
 sidebar_current: "docs-sakuracloud-resource-gslb"
 description: |-
-  Provides a SakuraCloud GSLB resource. This can be used to create, modify, and delete GSLBs.
+  Provides a SakuraCloud GSLB resource. This can be used to create, update, and delete GSLBs.
 ---
 
 # sakuracloud\_gslb
 
-Provides a SakuraCloud GSLB resource. This can be used to create, modify, and delete GSLBs.
+Provides a SakuraCloud GSLB resource. This can be used to create, update, and delete GSLBs.
 
 ## Example Usage
 
@@ -36,7 +36,7 @@ resource "sakuracloud_gslb" "foobar" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
-* `health_check` - (Required) Health check rules. It contains several attributes to [Health Check](#health-check).
+* `health_check` - (Required) Health check rules. It contains some attributes to [Health Check](#health-check).
 * `weighted` - (Optional) The flag for enable/disable weighting.(default:`true`)
 * `sorry_server` - (Optional) The hostname or IP address of sorry server.
 * `description` - (Optional) The description of the resource.
@@ -62,7 +62,7 @@ The following attributes are exported:
 * `id` - The ID of the resource.
 * `name` - Name of the resource.
 * `fqdn` - FQDN to access this resource.
-* `health_check` - Health check rules. It contains several attributes to [Health Check](#health-check).
+* `health_check` - Health check rules. It contains some attributes to [Health Check](#health-check).
 * `weighted` - The flag for enable/disable weighting.
 * `sorry_server` - The hostname or IP address of sorry server.
 * `description` - The description of the resource.

--- a/website/docs/r/gslb.html.markdown
+++ b/website/docs/r/gslb.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `weighted` - (Optional) The flag for enable/disable weighting.(default:`true`)
 * `sorry_server` - (Optional) The hostname or IP address of sorry server.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 
 ### Health Check
@@ -66,7 +66,7 @@ The following attributes are exported:
 * `weighted` - The flag for enable/disable weighting.
 * `sorry_server` - The hostname or IP address of sorry server.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 
 ## Import

--- a/website/docs/r/gslb.html.markdown
+++ b/website/docs/r/gslb.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_gslb"
+sidebar_current: "docs-sakuracloud-resource-gslb"
+description: |-
+  Provides a SakuraCloud GSLB resource. This can be used to create, modify, and delete GSLBs.
+---
+
+# sakuracloud\_gslb
+
+Provides a SakuraCloud GSLB resource. This can be used to create, modify, and delete GSLBs.
+
+## Example Usage
+
+```hcl
+# Create a new GSLB
+resource "sakuracloud_gslb" "foobar" {
+  name         = "foobar"
+  
+  health_check = {
+    protocol    = "https"
+    delay_loop  = 20
+    host_header = "example.com"
+    path        = "/"
+    status      = "200"
+  }
+  sorry_server = "192.2.0.1"
+  
+  description  = "description"
+  tags         = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `health_check` - (Required) Health check rules. It contains several attributes to [Health Check](#health-check).
+* `weighted` - (Optional) The flag for enable/disable weighting.(default:`true`)
+* `sorry_server` - (Optional) The hostname or IP address of sorry server.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+
+### Health Check
+
+Attributes for Health Check:
+
+* `protocol` - (Required) Protocol used in health check.  
+Valid value is one of the following: [ "http" / "https" / "ping" / "tcp" ]
+* `delay_loop` - (Optional) Health check access interval(unit:`second`, default:`10`).
+* `host_header` - (Optional) The value of `Host` header used in http/https health check access.
+* `path` - (Optional) The request path used in http/https health check access.
+* `status` - (Optional) HTTP status code expected by health check access.
+* `port` - (Optional) Port number used in tcp health check access.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - Name of the resource.
+* `fqdn` - FQDN to access this resource.
+* `health_check` - Health check rules. It contains several attributes to [Health Check](#health-check).
+* `weighted` - The flag for enable/disable weighting.
+* `sorry_server` - The hostname or IP address of sorry server.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+
+## Import
+
+GSLBs can be imported using the GSLB ID.
+
+```
+$ terraform import sakuracloud_gslb.foobar <gslb_id>
+```

--- a/website/docs/r/gslb.html.markdown
+++ b/website/docs/r/gslb.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
 * `health_check` - (Required) Health check rules. It contains some attributes to [Health Check](#health-check).
-* `weighted` - (Optional) The flag for enable/disable weighting.(default:`true`)
+* `weighted` - (Optional) The flag for enable/disable weighting (default:`true`).
 * `sorry_server` - (Optional) The hostname or IP address of sorry server.
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
@@ -49,7 +49,7 @@ Attributes for Health Check:
 
 * `protocol` - (Required) Protocol used in health check.  
 Valid value is one of the following: [ "http" / "https" / "ping" / "tcp" ]
-* `delay_loop` - (Optional) Health check access interval(unit:`second`, default:`10`).
+* `delay_loop` - (Optional) Health check access interval (unit:`second`, default:`10`).
 * `host_header` - (Optional) The value of `Host` header used in http/https health check access.
 * `path` - (Optional) The request path used in http/https health check access.
 * `status` - (Optional) HTTP status code expected by health check access.

--- a/website/docs/r/gslb.html.markdown
+++ b/website/docs/r/gslb.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_gslb"
-sidebar_current: "docs-sakuracloud-resource-gslb"
+sidebar_current: "docs-sakuracloud-resource-global-gslb-setting"
 description: |-
   Provides a SakuraCloud GSLB resource. This can be used to create, update, and delete GSLBs.
 ---

--- a/website/docs/r/gslb_server.html.markdown
+++ b/website/docs/r/gslb_server.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_gslb_server"
-sidebar_current: "docs-sakuracloud-resource-gserver"
+sidebar_current: "docs-sakuracloud-resource-global-gslb-server"
 description: |-
   Provides a SakuraCloud GSLB Server resource. This can be used to create and delete GSLB Servers.
 ---

--- a/website/docs/r/gslb_server.html.markdown
+++ b/website/docs/r/gslb_server.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_gslb_server"
+sidebar_current: "docs-sakuracloud-resource-gserver"
+description: |-
+  Provides a SakuraCloud GSLB Server resource. This can be used to create and delete GSLB Servers.
+---
+
+# sakuracloud\_gslb
+
+Provides a SakuraCloud GSLB Server resource. This can be used to create and delete GSLB Servers.
+
+## Example Usage
+
+```hcl
+# Create a new GSLB
+resource "sakuracloud_gslb" "foobar" {
+  name         = "foobar"
+  health_check = {
+    protocol    = "https"
+    delay_loop  = 20
+    host_header = "example.com"
+    path        = "/"
+    status      = "200"
+  }
+}
+
+# Add Server To GSLB
+resource "sakuracloud_gslb_server" "foobar1" {
+  gslb_id   = "${sakuracloud_gslb.foobar.id}"
+  ipaddress = "192.2.0.1"
+  enabled   = true
+  weight    = 1
+}
+
+# Add Server To GSLB
+resource "sakuracloud_gslb_server" "foobar2" {
+  gslb_id   = "${sakuracloud_gslb.foobar.id}"
+  ipaddress = "192.2.0.2"
+  enabled   = true
+  weight    = 1
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `gslb_id` - (Required) The ID of the GSLB to which the GSLB Server belongs.
+* `ipaddress` - (Required) The IP address of the GSLB Server.
+* `enabled` - (Optional) The flag for enable/disable the GSLB Server.(default:`true`)
+* `weight` - (Optional) The weight of GSLB server used when weighting is enabled in the GSLB.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `ipaddress` - The IP address of the GSLB Server.
+* `enabled` - The flag for enable/disable the GSLB Server.
+* `weight` - The weight of GSLB server used when weighting is enabled in the GSLB.
+
+## Import(not supported)
+
+Import of GSLB Server is not supported.

--- a/website/docs/r/gslb_server.html.markdown
+++ b/website/docs/r/gslb_server.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `gslb_id` - (Required) The ID of the GSLB to which the GSLB Server belongs.
 * `ipaddress` - (Required) The IP address of the GSLB Server.
-* `enabled` - (Optional) The flag for enable/disable the GSLB Server.(default:`true`)
+* `enabled` - (Optional) The flag for enable/disable the GSLB Server (default:`true`).
 * `weight` - (Optional) The weight of GSLB server used when weighting is enabled in the GSLB.
 
 ## Attributes Reference
@@ -61,6 +61,6 @@ The following attributes are exported:
 * `enabled` - The flag for enable/disable the GSLB Server.
 * `weight` - The weight of GSLB server used when weighting is enabled in the GSLB.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of GSLB Server is not supported.

--- a/website/docs/r/icon.html.markdown
+++ b/website/docs/r/icon.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_icon"
 sidebar_current: "docs-sakuracloud-resource-icon"
 description: |-
-  Provides a SakuraCloud Icon resource. This can be used to create, modify, and delete Icons.
+  Provides a SakuraCloud Icon resource. This can be used to create, update, and delete Icons.
 ---
 
 # sakuracloud\_icon
 
-Provides a SakuraCloud Icon resource. This can be used to create, modify, and delete Icons.
+Provides a SakuraCloud Icon resource. This can be used to create, update, and delete Icons.
 
 ## Example Usage
 

--- a/website/docs/r/icon.html.markdown
+++ b/website/docs/r/icon.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the resource.
 * `source` - (Optional) The path of source content file.
 * `base64content` - (Optional) The base64 encoded body of source content.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 
 ## Attributes Reference
 
@@ -42,7 +42,7 @@ The following attributes are exported:
 * `name` - The name of the resource.
 * `body` - Base64 encoded icon data(size:`small`).
 * `url` - URL to access this resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 
 ## Import
 

--- a/website/docs/r/icon.html.markdown
+++ b/website/docs/r/icon.html.markdown
@@ -40,7 +40,7 @@ The following attributes are exported:
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `body` - Base64 encoded icon data(size:`small`).
+* `body` - Base64 encoded icon data (size:`small`).
 * `url` - URL to access this resource.
 * `tags` - The tag list of the resources.
 

--- a/website/docs/r/icon.html.markdown
+++ b/website/docs/r/icon.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_icon"
-sidebar_current: "docs-sakuracloud-resource-icon"
+sidebar_current: "docs-sakuracloud-resource-misc-icon"
 description: |-
   Provides a SakuraCloud Icon resource. This can be used to create, update, and delete Icons.
 ---

--- a/website/docs/r/icon.html.markdown
+++ b/website/docs/r/icon.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_icon"
+sidebar_current: "docs-sakuracloud-resource-icon"
+description: |-
+  Provides a SakuraCloud Icon resource. This can be used to create, modify, and delete Icons.
+---
+
+# sakuracloud\_icon
+
+Provides a SakuraCloud Icon resource. This can be used to create, modify, and delete Icons.
+
+## Example Usage
+
+```hcl
+# Create a new Icon
+resource "sakuracloud_icon" "foobar" {
+  name          = "foobar"
+  
+  source        = "path/to/your/file"
+  # or
+  #base64content = "<base64-encoded-content-body>"
+  
+  tags          = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `source` - (Optional) The path of source content file.
+* `base64content` - (Optional) The base64 encoded body of source content.
+* `tags` - (Optional) The tag list of the resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `body` - Base64 encoded icon data(size:`small`).
+* `url` - URL to access this resource.
+* `tags` - The tag list of the resource.
+
+## Import
+
+Icons can be imported using the Icon ID.
+
+```
+$ terraform import sakuracloud_icon.foobar <icon_id>
+```

--- a/website/docs/r/internet.html.markdown
+++ b/website/docs/r/internet.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_internet"
-sidebar_current: "docs-sakuracloud-resource-internet"
+sidebar_current: "docs-sakuracloud-resource-networking-internet"
 description: |-
   Provides a SakuraCloud Internet resource. This can be used to create, update, and delete Internet.
 ---

--- a/website/docs/r/internet.html.markdown
+++ b/website/docs/r/internet.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_internet"
 sidebar_current: "docs-sakuracloud-resource-internet"
 description: |-
-  Provides a SakuraCloud Internet resource. This can be used to create, modify, and delete Internet.
+  Provides a SakuraCloud Internet resource. This can be used to create, update, and delete Internet.
 ---
 
 # sakuracloud\_internet
 
-Provides a SakuraCloud Internet resource. This can be used to create, modify, and delete Internet.
+Provides a SakuraCloud Internet resource. This can be used to create, update, and delete Internet.
 
 ## Example Usage
 
@@ -37,7 +37,7 @@ Valid value is one of the following: [ 100(default) / 250 / 500 / 1000 / 1500 / 
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -52,9 +52,9 @@ The following attributes are exported:
 * `server_ids` - The IDs of the server connected to the switch.
 * `nw_address` - The network address.
 * `gateway` - The network gateway address of the switch.
-* `min_ipaddress` - Minimum global ip address.
-* `max_ipaddress` - Maximum global ip address.
-* `ipaddresses` - Global ip address list.
+* `min_ipaddress` - Min global IP address.
+* `max_ipaddress` - Max global IP address.
+* `ipaddresses` - Global IP address list.
 * `enable_ipv6` - The ipv6 enabled flag.
 * `ipv6_prefix` - Address prefix of ipv6 network.
 * `ipv6_prefix_len` - Address prefix length of ipv6 network.

--- a/website/docs/r/internet.html.markdown
+++ b/website/docs/r/internet.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the resource.
 * `nw_mask_len` - (Optional) Network mask length.  
 Valid value is one of the following: [ 28 (default) / 27 / 26 ]
-* `band_width` - (Optional) Bandwidth of outbound traffic.(unit:`Mbps`)  
+* `band_width` - (Optional) Bandwidth of outbound traffic (unit:`Mbps`).  
 Valid value is one of the following: [ 100 (default) / 250 / 500 / 1000 / 1500 / 2000 / 2500 / 3000 ]
 * `enable_ipv6` - (Optional) The ipv6 enabled flag.
 * `description` - (Optional) The description of the resource.

--- a/website/docs/r/internet.html.markdown
+++ b/website/docs/r/internet.html.markdown
@@ -1,0 +1,73 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_internet"
+sidebar_current: "docs-sakuracloud-resource-internet"
+description: |-
+  Provides a SakuraCloud Internet resource. This can be used to create, modify, and delete Internet.
+---
+
+# sakuracloud\_internet
+
+Provides a SakuraCloud Internet resource. This can be used to create, modify, and delete Internet.
+
+## Example Usage
+
+```hcl
+# Create a new Internet
+resource "sakuracloud_internet" "foobar" {
+  name         = "foobar"
+  nw_mask_ken  = 28
+  band_width   = 100 
+  enable_ipv6  = true
+  description  = "description"
+  tags         = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `nw_mask_len` - (Optional) Network mask length.  
+Valid value is one of the following: [ 28(default) / 27 / 26 ]
+* `band_width` - (Optional) Bandwidth of outbound traffic.(unit:`Mbps`)  
+Valid value is one of the following: [ 100(default) / 250 / 500 / 1000 / 1500 / 2000 / 2500 / 3000 ]
+* `enable_ipv6` - (Optional) The ipv6 enabled flag.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `nw_mask_len` - Network mask length.
+* `band_width` - Bandwidth of outbound traffic.
+* `switch_id` - The ID of the switch.
+* `server_ids` - The IDs of the server connected to the switch.
+* `nw_address` - The network address.
+* `gateway` - The network gateway address of the switch.
+* `min_ipaddress` - Minimum global ip address.
+* `max_ipaddress` - Maximum global ip address.
+* `ipaddresses` - Global ip address list.
+* `enable_ipv6` - The ipv6 enabled flag.
+* `ipv6_prefix` - Address prefix of ipv6 network.
+* `ipv6_prefix_len` - Address prefix length of ipv6 network.
+* `ipv6_nw_address` - The ipv6 network address.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Internet can be imported using Internet ID.
+
+```
+$ terraform import sakuracloud_internet.foobar <internet_id>
+```

--- a/website/docs/r/internet.html.markdown
+++ b/website/docs/r/internet.html.markdown
@@ -30,14 +30,14 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
 * `nw_mask_len` - (Optional) Network mask length.  
-Valid value is one of the following: [ 28(default) / 27 / 26 ]
+Valid value is one of the following: [ 28 (default) / 27 / 26 ]
 * `band_width` - (Optional) Bandwidth of outbound traffic.(unit:`Mbps`)  
-Valid value is one of the following: [ 100(default) / 250 / 500 / 1000 / 1500 / 2000 / 2500 / 3000 ]
+Valid value is one of the following: [ 100 (default) / 250 / 500 / 1000 / 1500 / 2000 / 2500 / 3000 ]
 * `enable_ipv6` - (Optional) The ipv6 enabled flag.
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference

--- a/website/docs/r/internet.html.markdown
+++ b/website/docs/r/internet.html.markdown
@@ -49,7 +49,7 @@ The following attributes are exported:
 * `nw_mask_len` - Network mask length.
 * `band_width` - Bandwidth of outbound traffic.
 * `switch_id` - The ID of the switch.
-* `server_ids` - The IDs of the server connected to the switch.
+* `server_ids` - The ID list of the servers connected to the switch.
 * `nw_address` - The network address.
 * `gateway` - The network gateway address of the switch.
 * `min_ipaddress` - Min global IP address.

--- a/website/docs/r/internet.html.markdown
+++ b/website/docs/r/internet.html.markdown
@@ -35,7 +35,7 @@ Valid value is one of the following: [ 28(default) / 27 / 26 ]
 Valid value is one of the following: [ 100(default) / 250 / 500 / 1000 / 1500 / 2000 / 2500 / 3000 ]
 * `enable_ipv6` - (Optional) The ipv6 enabled flag.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
@@ -60,7 +60,7 @@ The following attributes are exported:
 * `ipv6_prefix_len` - Address prefix length of ipv6 network.
 * `ipv6_nw_address` - The ipv6 network address.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/ipv4_ptr.html.markdown
+++ b/website/docs/r/ipv4_ptr.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_ipv4_ptr"
-sidebar_current: "docs-sakuracloud-resource-ipv4-ptr"
+sidebar_current: "docs-sakuracloud-resource-networking-ipv4-ptr"
 description: |-
   Provides a SakuraCloud IPv4 PTR record resource. This can be used to create, update, and delete IPv4 PTR records.
 ---

--- a/website/docs/r/ipv4_ptr.html.markdown
+++ b/website/docs/r/ipv4_ptr.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_ipv4_ptr"
+sidebar_current: "docs-sakuracloud-resource-ipv4-ptr"
+description: |-
+  Provides a SakuraCloud IPv4 PTR record resource. This can be used to create, modify, and delete IPv4 PTR records.
+---
+
+# sakuracloud\_ipv4\_ptr
+
+Provides a SakuraCloud IPv4 PTR Record resource. This can be used to create, modify, and delete IPv4 PTR records.
+
+## Example Usage
+
+```hcl
+# Create a new IPv4 PTR Record
+resource "sakuracloud_ipv4_ptr" "foobar" {
+  ipaddress = "192.2.0.1"
+  hostname  = "www.example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ipaddress` - (Required) The target IP address.
+* `hostname` - (Required) The hostname of target.
+* `retry_max` - (Optional) Max count of API call retry.(default:`30`)
+* `retry_interval` - (Optional) Interval of API call retry.(unit:`second`, default:`10`)
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `ipaddress` - The target IP address.
+* `hostname` - The hostname of target.
+* `retry_max` - Max count of API call retry.
+* `retry_interval` - Interval of API call retry.(unit:`second`)
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+IPv4 PTR records can be imported using the IPv4 PTR Record ID.
+
+```
+$ terraform import sakuracloud_ipv4_ptr.foobar <ipv4_ptr_id>
+```

--- a/website/docs/r/ipv4_ptr.html.markdown
+++ b/website/docs/r/ipv4_ptr.html.markdown
@@ -26,8 +26,8 @@ The following arguments are supported:
 
 * `ipaddress` - (Required) The target IP address.
 * `hostname` - (Required) The hostname of target.
-* `retry_max` - (Optional) Max count of API call retry.(default:`30`)
-* `retry_interval` - (Optional) Interval of API call retry.(unit:`second`, default:`10`)
+* `retry_max` - (Optional) Max count of API call retry (default:`30`).
+* `retry_interval` - (Optional) Interval of API call retry (unit:`second`, default:`10`).
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -38,7 +38,7 @@ The following attributes are exported:
 * `ipaddress` - The target IP address.
 * `hostname` - The hostname of target.
 * `retry_max` - Max count of API call retry.
-* `retry_interval` - Interval of API call retry.(unit:`second`)
+* `retry_interval` - Interval of API call retry (unit:`second`).
 * `zone` - The ID of the zone to which the resource belongs.
 
 ## Import

--- a/website/docs/r/ipv4_ptr.html.markdown
+++ b/website/docs/r/ipv4_ptr.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_ipv4_ptr"
 sidebar_current: "docs-sakuracloud-resource-ipv4-ptr"
 description: |-
-  Provides a SakuraCloud IPv4 PTR record resource. This can be used to create, modify, and delete IPv4 PTR records.
+  Provides a SakuraCloud IPv4 PTR record resource. This can be used to create, update, and delete IPv4 PTR records.
 ---
 
 # sakuracloud\_ipv4\_ptr
 
-Provides a SakuraCloud IPv4 PTR Record resource. This can be used to create, modify, and delete IPv4 PTR records.
+Provides a SakuraCloud IPv4 PTR Record resource. This can be used to create, update, and delete IPv4 PTR records.
 
 ## Example Usage
 

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `vrid` - (Required) VRID used when high-availability mode enabled.
 * `high_availability` - (Optional) The flag of enable/disable high-availability mode.
 * `plan` - (Optional) The name of the resource plan.
-Valid value is one of the following: [ "standard"(default) / "highspec"]
+Valid value is one of the following: [ "standard" (default) / "highspec"]
 * `ipaddress1` - (Required) The primary IP address of the Load Balancer.
 * `ipaddress2` - (Optional) The secondly IP address of the Load Balancer. Used when high-availability mode enabled.
 * `nw_mask_len` - (Required) Network mask length.
@@ -54,7 +54,7 @@ Valid value is one of the following: [ "standard"(default) / "highspec"]
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_load_balancer"
 sidebar_current: "docs-sakuracloud-resource-load-balancer"
 description: |-
-  Provides a SakuraCloud LoadBalancer resource. This can be used to create, modify, and delete LoadBalancers.
+  Provides a SakuraCloud LoadBalancer resource. This can be used to create, update, and delete LoadBalancers.
 ---
 
 # sakuracloud\_load\_balancer
 
-Provides a SakuraCloud LoadBalancer resource. This can be used to create, modify, and delete LoadBalancers.
+Provides a SakuraCloud LoadBalancer resource. This can be used to create, update, and delete LoadBalancers.
 
 ## Example Usage
 
@@ -48,13 +48,13 @@ The following arguments are supported:
 * `plan` - (Optional) The name of the resource plan.
 Valid value is one of the following: [ "standard"(default) / "highspec"]
 * `ipaddress1` - (Required) The primary IP address of the Load Balancer.
-* `ipaddress2` - (Optional) The secondly IP address of the Load Balancer. It is used only when high-availability mode enabled.
+* `ipaddress2` - (Optional) The secondly IP address of the Load Balancer. Used when high-availability mode enabled.
 * `nw_mask_len` - (Required) Network mask length.
 * `default_route` - (Optional) Default gateway address of the Load Balancer.	 
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -68,7 +68,7 @@ The following attributes are exported:
 * `high_availability` - The flag of enable/disable high-availability mode.
 * `plan` - The name of the resource plan. 
 * `ipaddress1` - The primary IP address of the Load Balancer.
-* `ipaddress2` - The secondly IP address of the Load Balancer. It is used only when high-availability mode enabled.
+* `ipaddress2` - The secondly IP address of the Load Balancer. Used when high-availability mode enabled.
 * `nw_mask_len` - Network mask length.
 * `default_route` - Default gateway address of the Load Balancer.	 
 * `description` - The description of the resource.

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_load_balancer"
-sidebar_current: "docs-sakuracloud-resource-load-balancer"
+sidebar_current: "docs-sakuracloud-resource-lb-load-balancer"
 description: |-
   Provides a SakuraCloud LoadBalancer resource. This can be used to create, update, and delete LoadBalancers.
 ---

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `switch_id` - (Required) The ID of the Switch connected to the Load Balancer.
 * `vrid` - (Required) VRID used when high-availability mode enabled.
 * `high_availability` - (Optional) The flag of enable/disable high-availability mode.
-* `plan` - (Optional) The name of the resource plan.
+* `plan` - (Optional) The name of the resource plan.  
 Valid value is one of the following: [ "standard" (default) / "highspec"]
 * `ipaddress1` - (Required) The primary IP address of the Load Balancer.
 * `ipaddress2` - (Optional) The secondly IP address of the Load Balancer. Used when high-availability mode enabled.

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_load_balancer"
+sidebar_current: "docs-sakuracloud-resource-load-balancer"
+description: |-
+  Provides a SakuraCloud LoadBalancer resource. This can be used to create, modify, and delete LoadBalancers.
+---
+
+# sakuracloud\_load\_balancer
+
+Provides a SakuraCloud LoadBalancer resource. This can be used to create, modify, and delete LoadBalancers.
+
+## Example Usage
+
+```hcl
+# Create a new LoadBalancer
+resource "sakuracloud_load_balancer" "foobar" {
+  name              = "foobar"
+  
+  switch_id         = "${sakuracloud_switch.foobar.id}"
+  vrid              = 1
+  high_availability = false
+  plan              = "standard"
+  
+  ipaddress1        = "192.168.2.1"
+  # only when high_availability = true 
+  #ipaddress2        = "192.168.2.2"
+  nw_mask_len       = 24
+  default_route     = "192.168.2.254"
+  
+  description       = "description"
+  tags              = ["foo" , "bar"]
+}
+
+resource "sakuracloud_switch" "foobar" {
+  name = "foobar"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `switch_id` - (Required) The ID of the Switch connected to the Load Balancer.
+* `vrid` - (Required) VRID used when high-availability mode enabled.
+* `high_availability` - (Optional) The flag of enable/disable high-availability mode.
+* `plan` - (Optional) The name of the resource plan.
+Valid value is one of the following: [ "standard"(default) / "highspec"]
+* `ipaddress1` - (Required) The primary IP address of the Load Balancer.
+* `ipaddress2` - (Optional) The secondly IP address of the Load Balancer. It is used only when high-availability mode enabled.
+* `nw_mask_len` - (Required) Network mask length.
+* `default_route` - (Optional) Default gateway address of the Load Balancer.	 
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `switch_id` - The ID of the Switch connected to the Load Balancer.
+* `vrid` - VRID used when high-availability mode enabled.
+* `high_availability` - The flag of enable/disable high-availability mode.
+* `plan` - The name of the resource plan. 
+* `ipaddress1` - The primary IP address of the Load Balancer.
+* `ipaddress2` - The secondly IP address of the Load Balancer. It is used only when high-availability mode enabled.
+* `nw_mask_len` - Network mask length.
+* `default_route` - Default gateway address of the Load Balancer.	 
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+LoadBalancers can be imported using the LoadBalancer ID.
+
+```
+$ terraform import sakuracloud_load_balancer.foobar <load_balancer_id>
+```

--- a/website/docs/r/load_balancer.html.markdown
+++ b/website/docs/r/load_balancer.html.markdown
@@ -52,7 +52,7 @@ Valid value is one of the following: [ "standard"(default) / "highspec"]
 * `nw_mask_len` - (Required) Network mask length.
 * `default_route` - (Optional) Default gateway address of the Load Balancer.	 
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
@@ -72,7 +72,7 @@ The following attributes are exported:
 * `nw_mask_len` - Network mask length.
 * `default_route` - Default gateway address of the Load Balancer.	 
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/load_balancer_server.html.markdown
+++ b/website/docs/r/load_balancer_server.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_load_balancer_server"
-sidebar_current: "docs-sakuracloud-resource-lbserver"
+sidebar_current: "docs-sakuracloud-resource-lb-server"
 description: |-
   Provides a SakuraCloud LoadBalancer Server resource. This can be used to create and delete LoadBalancer Servers.
 ---

--- a/website/docs/r/load_balancer_server.html.markdown
+++ b/website/docs/r/load_balancer_server.html.markdown
@@ -32,7 +32,7 @@ resource "sakuracloud_load_balancer_vip" "vip1" {
 }
 
 # Create new LoadBalancer servers
-resource "sakuracloud_load_balancer_server" "server01"{
+resource "sakuracloud_load_balancer_server" "server01" {
   load_balancer_vip_id = "${sakuracloud_load_balancer_vip.vip1.id}"
   ipaddress            = "192.168.2.151"
   check_protocol       = "https"
@@ -40,7 +40,7 @@ resource "sakuracloud_load_balancer_server" "server01"{
   check_status         = 200 
   enabled              = true
 }
-resource "sakuracloud_load_balancer_server" "server01"{
+resource "sakuracloud_load_balancer_server" "server02" {
   load_balancer_vip_id = "${sakuracloud_load_balancer_vip.vip1.id}"
   ipaddress            = "192.168.2.152"
   check_protocol       = "https"

--- a/website/docs/r/load_balancer_server.html.markdown
+++ b/website/docs/r/load_balancer_server.html.markdown
@@ -76,7 +76,7 @@ The following attributes are exported:
 * `enabled` - The flag of enable/disable the Server.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of Load Balancer Server is not supported.
 

--- a/website/docs/r/load_balancer_server.html.markdown
+++ b/website/docs/r/load_balancer_server.html.markdown
@@ -1,0 +1,82 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_load_balancer_server"
+sidebar_current: "docs-sakuracloud-resource-lbserver"
+description: |-
+  Provides a SakuraCloud LoadBalancer Server resource. This can be used to create and delete LoadBalancer Servers.
+---
+
+# sakuracloud\_load\_balancer\_server
+
+Provides a SakuraCloud LoadBalancer Server resource. This can be used to create and delete LoadBalancer Servers.
+
+## Example Usage
+
+```hcl
+# Create a new LoadBalancer
+resource "sakuracloud_load_balancer" "foobar" {
+    name          = "foobar"
+    switch_id     = "${sakuracloud_switch.sw.id}"
+    vrid          = 1
+    ipaddress1    = "192.168.2.1"
+    nw_mask_len   = 24
+}
+
+# Create a new LoadBalancer VIP
+resource "sakuracloud_load_balancer_vip" "vip1" {
+    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
+    vip              = "192.168.2.101"
+    port             = 80
+    delay_loop       = 50
+    sorry_server     = "192.168.2.201"
+}
+
+# Create new LoadBalancer servers
+resource "sakuracloud_load_balancer_server" "server01"{
+  load_balancer_vip_id = "${sakuracloud_load_balancer_vip.vip1.id}"
+  ipaddress            = "192.168.2.151"
+  check_protocol       = "https"
+  check_path           = "/healthz"
+  check_status         = 200 
+  enabled              = true
+}
+resource "sakuracloud_load_balancer_server" "server01"{
+  load_balancer_vip_id = "${sakuracloud_load_balancer_vip.vip1.id}"
+  ipaddress            = "192.168.2.152"
+  check_protocol       = "https"
+  check_path           = "/healthz"
+  check_status         = 200 
+  enabled              = true
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `load_vip_id` - (Required) The ID of the Load Balancer VIP to which the Server belongs.
+* `ipaddress` - (Required) The IP address of the Server.
+* `check_protocol` - (Required) Protocol used in health check.  
+Valid value is one of the following: [ "http" / "https" / "ping" / "tcp" ]
+* `check_path` - (Optional) The request path used in http/https health check access.
+* `check_status` - (Optional) HTTP status code expected by health check access.
+* `enabled` - (Optional) The flag of enable/disable the Server.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `ipaddress` - The IP address of the Server.
+* `check_protocol` - Protocol used in health check.
+* `check_path` - The request path used in http/https health check access.
+* `check_status` - HTTP status code expected by health check access.
+* `enabled` - The flag of enable/disable the Server.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of Load Balancer Server is not supported.
+

--- a/website/docs/r/load_balancer_vip.html.markdown
+++ b/website/docs/r/load_balancer_vip.html.markdown
@@ -56,7 +56,7 @@ The following attributes are exported:
 * `zone` - The ID of the zone to which the resource belongs.
 
 
-## Import(not supported)
+## Import (not supported)
 
 Import of Load Balancer VIP is not supported.
 

--- a/website/docs/r/load_balancer_vip.html.markdown
+++ b/website/docs/r/load_balancer_vip.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_load_balancer_vip"
 sidebar_current: "docs-sakuracloud-resource-lbvip"
 description: |-
-  Provides a SakuraCloud LoadBalancer VIP resource. This can be used to create, modify, and delete LoadBalancer VIPs.
+  Provides a SakuraCloud LoadBalancer VIP resource. This can be used to create, update, and delete LoadBalancer VIPs.
 ---
 
 # sakuracloud\_load\_balancer\_vip
 
-Provides a SakuraCloud LoadBalancer VIP resource. This can be used to create, modify, and delete LoadBalancer VIPs.
+Provides a SakuraCloud LoadBalancer VIP resource. This can be used to create, update, and delete LoadBalancer VIPs.
 
 ## Example Usage
 

--- a/website/docs/r/load_balancer_vip.html.markdown
+++ b/website/docs/r/load_balancer_vip.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_load_balancer_vip"
+sidebar_current: "docs-sakuracloud-resource-lbvip"
+description: |-
+  Provides a SakuraCloud LoadBalancer VIP resource. This can be used to create, modify, and delete LoadBalancer VIPs.
+---
+
+# sakuracloud\_load\_balancer\_vip
+
+Provides a SakuraCloud LoadBalancer VIP resource. This can be used to create, modify, and delete LoadBalancer VIPs.
+
+## Example Usage
+
+```hcl
+# Create a new LoadBalancer
+resource "sakuracloud_load_balancer" "foobar" {
+    name          = "foobar"
+    switch_id     = "${sakuracloud_switch.sw.id}"
+    vrid          = 1
+    ipaddress1    = "192.168.2.1"
+    nw_mask_len   = 24
+}
+
+# Create a new LoadBalancer VIP
+resource "sakuracloud_load_balancer_vip" "vip1" {
+    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
+    vip              = "192.168.2.101"
+    port             = 80
+    delay_loop       = 50
+    sorry_server     = "192.168.2.201"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `load_balancer_id` - (Required) The ID of the Load Balancer to which the VIP belongs.
+* `vip` - (Required) The virtual IP address.
+* `port` - (Required) The port number on which Load Balancer listens.
+* `delay_loop` - (Optional) The interval seconds for health check access.
+* `sorry_server` - (Optional) The hostname or IP address of sorry server.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `vip` - The virtual IP address.
+* `port` - The port number on which Load Balancer listens.
+* `delay_loop` - The interval seconds for Health check access.
+* `sorry_server` - The hostname or IP address of sorry server.
+* `servers` - The internal ID list of servers under VIP.
+* `zone` - The ID of the zone to which the resource belongs.
+
+
+## Import(not supported)
+
+Import of Load Balancer VIP is not supported.
+

--- a/website/docs/r/load_balancer_vip.html.markdown
+++ b/website/docs/r/load_balancer_vip.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_load_balancer_vip"
-sidebar_current: "docs-sakuracloud-resource-lbvip"
+sidebar_current: "docs-sakuracloud-resource-lb-vip"
 description: |-
   Provides a SakuraCloud LoadBalancer VIP resource. This can be used to create, update, and delete LoadBalancer VIPs.
 ---

--- a/website/docs/r/mobile_gateway.html.markdown
+++ b/website/docs/r/mobile_gateway.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `dns_server1` - (Optional) The primary DNS server IP address.
 * `dns_server2` - (Optional) The secondly DNS server IP address.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
@@ -60,9 +60,9 @@ The following attributes are exported:
 * `internet_connection` - The flag of enable/disable connecting from MobileGateway to the Internet.
 * `dns_server1` - The primary DNS server IP address.
 * `dns_server2` - The secondly DNS server IP address.
-* `sim_ids` - The ID list of the SIM connected to the Mobile Gateway.
+* `sim_ids` - The ID list of the SIMs connected to the Mobile Gateway.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon.
 * `graceful_shutdown_timeout` - The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/r/mobile_gateway.html.markdown
+++ b/website/docs/r/mobile_gateway.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -64,7 +64,6 @@ The following attributes are exported:
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon.
-* `graceful_shutdown_timeout` - The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 
 ## Import

--- a/website/docs/r/mobile_gateway.html.markdown
+++ b/website/docs/r/mobile_gateway.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_mobile_gateway"
 sidebar_current: "docs-sakuracloud-resource-mobile-gateway"
 description: |-
-  Provides a SakuraCloud Mobile Gateway resource. This can be used to create, modify, and delete Mobile Gateways.
+  Provides a SakuraCloud Mobile Gateway resource. This can be used to create, update, and delete Mobile Gateways.
 ---
 
 # sakuracloud\_mobile\_gateway
 
-Provides a SakuraCloud Mobile Gateway resource. This can be used to create, modify, and delete Mobile Gateways.
+Provides a SakuraCloud Mobile Gateway resource. This can be used to create, update, and delete Mobile Gateways.
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -64,7 +64,7 @@ The following attributes are exported:
 * `description` - The description of the resource.
 * `tags` - The tag list of the resource.
 * `icon_id` - The ID of the icon.
-* `graceful_shutdown_timeout` - The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 
 ## Import

--- a/website/docs/r/mobile_gateway.html.markdown
+++ b/website/docs/r/mobile_gateway.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_mobile_gateway"
-sidebar_current: "docs-sakuracloud-resource-mobile-gateway"
+sidebar_current: "docs-sakuracloud-resource-secure-mobile-mobile-gateway"
 description: |-
   Provides a SakuraCloud Mobile Gateway resource. This can be used to create, update, and delete Mobile Gateways.
 ---

--- a/website/docs/r/mobile_gateway.html.markdown
+++ b/website/docs/r/mobile_gateway.html.markdown
@@ -1,0 +1,76 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_mobile_gateway"
+sidebar_current: "docs-sakuracloud-resource-mobile-gateway"
+description: |-
+  Provides a SakuraCloud Mobile Gateway resource. This can be used to create, modify, and delete Mobile Gateways.
+---
+
+# sakuracloud\_mobile\_gateway
+
+Provides a SakuraCloud Mobile Gateway resource. This can be used to create, modify, and delete Mobile Gateways.
+
+## Example Usage
+
+```hcl
+# Create a new Mobile Gateway
+resource sakuracloud_mobile_gateway "foobar" {
+  name                = "foobar"
+
+  switch_id           = "${sakuracloud_switch.sw.id}"
+  private_ipaddress   = "192.168.11.101"
+  private_nw_mask_len = 24
+  internet_connection = true
+  dns_server1         = "8.8.8.8"
+  dns_server2         = "8.8.4.4" 
+  
+  description         = "description"
+  tags                = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `switch_id` - (Optional) The ID of the switch connected to the Mobile Gateway.
+* `private_ipaddress` - (Optional) The IP address on private NIC of the Mobile Gateway.
+* `private_nw_mask_len` - (Optional) The network mask length on private NIC of the Mobile Gateway.
+* `internet_connection` - (Optional) The flag of enable/disable connecting from MobileGateway to the Internet.
+* `dns_server1` - (Optional) The primary DNS server IP address.
+* `dns_server2` - (Optional) The secondly DNS server IP address.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `switch_id` - The ID of the switch connected to the Mobile Gateway.
+* `public_ipaddress` - The IP address on public NIC of the Mobile Gateway.
+* `public_nw_mask_len` - The network mask length on public NIC of the Mobile Gateway.
+* `private_ipaddress` - The IP address on private NIC of the Mobile Gateway.
+* `private_nw_mask_len` - The network mask length on private NIC of the Mobile Gateway.
+* `internet_connection` - The flag of enable/disable connecting from MobileGateway to the Internet.
+* `dns_server1` - The primary DNS server IP address.
+* `dns_server2` - The secondly DNS server IP address.
+* `sim_ids` - The ID list of the SIM connected to the Mobile Gateway.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon.
+* `graceful_shutdown_timeout` - The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Mobile Gateways can be imported using the Mobile Gateway ID.
+
+```
+$ terraform import sakuracloud_mobile_gateway.foobar <mobile_gateway_id>
+```

--- a/website/docs/r/mobile_gateway_sim_route.html.markdown
+++ b/website/docs/r/mobile_gateway_sim_route.html.markdown
@@ -42,7 +42,7 @@ resource sakuracloud_mobile_gateway_sim_route "route1" {
 The following arguments are supported:
 
 * `mobile_gateway_id` - (Required) The ID of the Mobile Gateway to set SIM Route.
-* `prefix` - (Required) The routing prefix.(format:`CIDR`)
+* `prefix` - (Required) The routing prefix (format:`CIDR`).
 * `sim_id` - (Required) The ID of the routing destination SIM.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
@@ -53,6 +53,6 @@ The following attributes are exported:
 * `id` - The ID of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of Mobile Gateway SIM Route is not supported.

--- a/website/docs/r/mobile_gateway_sim_route.html.markdown
+++ b/website/docs/r/mobile_gateway_sim_route.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_mobile_gateway"
+sidebar_current: "docs-sakuracloud-resource-mgwsimroute"
+description: |-
+  Provides a SakuraCloud Mobile Gateway SIM Route resource. This can be used to create and delete Mobile Gateway SIM Routes.
+---
+
+# sakuracloud\_mobile\_gateway\_sim\_route
+
+Provides a SakuraCloud Mobile Gateway SIM Route resource. This can be used to create, modify, and delete Mobile Gateway SIM Routes.
+
+## Example Usage
+
+```hcl
+# Create a new Mobile Gateway
+resource sakuracloud_mobile_gateway "foobar" {
+  name                = "foobar"
+
+  switch_id           = "${sakuracloud_switch.sw.id}"
+  private_ipaddress   = "192.168.2.101"
+  private_nw_mask_len = 24
+  internet_connection = true
+  dns_server1         = "8.8.8.8"
+  dns_server2         = "8.8.4.4" 
+  
+  description         = "description"
+  tags                = ["foo", "bar"]
+}
+
+# Create a new SIM Route
+resource sakuracloud_mobile_gateway_sim_route "route1" {
+  mobile_gateway_id = "${sakuracloud_mobile_gateqway.foobar.id}"
+  prefix            = "10.16.0.0/24"
+  sim_id            = "${sakuracloud_sim.foobar.id}"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `mobile_gateway_id` - (Required) The ID of the Mobile Gateway to set SIM Route.
+* `prefix` - (Required) The routing prefix.(format:`CIDR`)
+* `sim_id` - (Required) The ID of the routing destination SIM.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of Mobile Gateway SIM Route is not supported.

--- a/website/docs/r/mobile_gateway_sim_route.html.markdown
+++ b/website/docs/r/mobile_gateway_sim_route.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_mobile_gateway"
-sidebar_current: "docs-sakuracloud-resource-mgwsimroute"
+sidebar_current: "docs-sakuracloud-resource-secure-mobile-mgwsimroute"
 description: |-
   Provides a SakuraCloud Mobile Gateway SIM Route resource. This can be used to create and delete Mobile Gateway SIM Routes.
 ---

--- a/website/docs/r/mobile_gateway_sim_route.html.markdown
+++ b/website/docs/r/mobile_gateway_sim_route.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # sakuracloud\_mobile\_gateway\_sim\_route
 
-Provides a SakuraCloud Mobile Gateway SIM Route resource. This can be used to create, modify, and delete Mobile Gateway SIM Routes.
+Provides a SakuraCloud Mobile Gateway SIM Route resource. This can be used to create, update, and delete Mobile Gateway SIM Routes.
 
 ## Example Usage
 

--- a/website/docs/r/mobile_gateway_static_route.html.markdown
+++ b/website/docs/r/mobile_gateway_static_route.html.markdown
@@ -42,7 +42,7 @@ resource sakuracloud_mobile_gateway_static_route "r1" {
 The following arguments are supported:
 
 * `mobile_gateway_id` - (Required) The ID of the Mobile Gateway to set Static Route.
-* `prefix` - (Required) The routing prefix.(format:`CIDR`)
+* `prefix` - (Required) The routing prefix (format:`CIDR`).
 * `next_hop` - (Required) The IP address of the next hop.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
@@ -53,6 +53,6 @@ The following attributes are exported:
 * `id` - The ID of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of Mobile Gateway Static Route is not supported.

--- a/website/docs/r/mobile_gateway_static_route.html.markdown
+++ b/website/docs/r/mobile_gateway_static_route.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # sakuracloud\_mobile\_gateway\_static\_route
 
-Provides a SakuraCloud Mobile Gateway Static Route resource. This can be used to create, modify, and delete Mobile Gateway Static Routes.
+Provides a SakuraCloud Mobile Gateway Static Route resource. This can be used to create, update, and delete Mobile Gateway Static Routes.
 
 ## Example Usage
 

--- a/website/docs/r/mobile_gateway_static_route.html.markdown
+++ b/website/docs/r/mobile_gateway_static_route.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_mobile_gateway"
-sidebar_current: "docs-sakuracloud-resource-mgwstaticroute"
+sidebar_current: "docs-sakuracloud-resource-secure-mobile-mgwstaticroute"
 description: |-
   Provides a SakuraCloud Mobile Gateway Static Route resource. This can be used to create and delete Mobile Gateway Static Routes.
 ---

--- a/website/docs/r/mobile_gateway_static_route.html.markdown
+++ b/website/docs/r/mobile_gateway_static_route.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_mobile_gateway"
+sidebar_current: "docs-sakuracloud-resource-mgwstaticroute"
+description: |-
+  Provides a SakuraCloud Mobile Gateway Static Route resource. This can be used to create and delete Mobile Gateway Static Routes.
+---
+
+# sakuracloud\_mobile\_gateway\_static\_route
+
+Provides a SakuraCloud Mobile Gateway Static Route resource. This can be used to create, modify, and delete Mobile Gateway Static Routes.
+
+## Example Usage
+
+```hcl
+# Create a new Mobile Gateway
+resource sakuracloud_mobile_gateway "foobar" {
+  name                = "foobar"
+
+  switch_id           = "${sakuracloud_switch.sw.id}"
+  private_ipaddress   = "192.168.2.101"
+  private_nw_mask_len = 24
+  internet_connection = true
+  dns_server1         = "8.8.8.8"
+  dns_server2         = "8.8.4.4" 
+  
+  description         = "description"
+  tags                = ["foo", "bar"]
+}
+
+# Create a new Static Route
+resource sakuracloud_mobile_gateway_static_route "r1" {
+	mobile_gateway_id = "${sakuracloud_mobile_gateway.foobar.id}"
+    prefix            = "10.16.0.0/16"
+    next_hop          = "192.168.2.1"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `mobile_gateway_id` - (Required) The ID of the Mobile Gateway to set Static Route.
+* `prefix` - (Required) The routing prefix.(format:`CIDR`)
+* `next_hop` - (Required) The IP address of the next hop.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of Mobile Gateway Static Route is not supported.

--- a/website/docs/r/nfs.html.markdown
+++ b/website/docs/r/nfs.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_nfs"
+sidebar_current: "docs-sakuracloud-resource-nfs"
+description: |-
+  Provides a SakuraCloud NFS Appliance resource. This can be used to create, modify, and delete NFS Appliances.
+---
+
+# sakuracloud\_nfs
+
+Provides a SakuraCloud NFS Appliance resource. This can be used to create, modify, and delete NFS Appliances.
+
+## Example Usage
+
+```hcl
+# Create a new NFS Appliance
+resource sakuracloud_nfs "foobar" {
+  name           = "foobar"
+  plan           = 100
+
+  switch_id      = "${sakuracloud_switch.foobar.id}"
+  ipaddress1     = "192.168.11.101"
+  nw_mask_len    = 24
+  default_route  = "192.168.11.1"
+  
+  description    = "description"
+  tags           = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `plan` - (Optional) The plan(size) of the NFS Appliance.(unit:`GB`)   
+Valid value is one of the following: [ 100(default) / 500 / 1024 / 2048 / 4096 ]
+* `switch_id` - (Required) The ID of the switch connected to the NFS Appliance.
+* `ipaddress` - (Required) The IP address of the NFS Appliance.
+* `nw_mask_len` - (Required) The network mask length of the NFS Appliance.
+* `default_route` - (Required) The default route IP address of the NFS Appliance.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the NFS Appliance.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `plan` - The plan(size) of the NFS Appliance.(unit:`GB`)   
+* `switch_id` - The ID of the switch connected to the NFS Appliance.
+* `ipaddress` - The IP address of the NFS Appliance.
+* `nw_mask_len` - The network mask length of the NFS Appliance.
+* `default_route` - The default route IP address of the NFS Appliance.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+NFS Appliances can be imported using the NFS Appliance ID.
+
+```
+$ terraform import sakuracloud_nfs.foobar <nfs_id>
+```

--- a/website/docs/r/nfs.html.markdown
+++ b/website/docs/r/nfs.html.markdown
@@ -40,7 +40,7 @@ Valid value is one of the following: [ 100(default) / 500 / 1024 / 2048 / 4096 ]
 * `nw_mask_len` - (Required) The network mask length of the NFS Appliance.
 * `default_route` - (Required) The default route IP address of the NFS Appliance.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the NFS Appliance.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
@@ -57,7 +57,7 @@ The following attributes are exported:
 * `nw_mask_len` - The network mask length of the NFS Appliance.
 * `default_route` - The default route IP address of the NFS Appliance.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/nfs.html.markdown
+++ b/website/docs/r/nfs.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_nfs"
 sidebar_current: "docs-sakuracloud-resource-nfs"
 description: |-
-  Provides a SakuraCloud NFS Appliance resource. This can be used to create, modify, and delete NFS Appliances.
+  Provides a SakuraCloud NFS Appliance resource. This can be used to create, update, and delete NFS Appliances.
 ---
 
 # sakuracloud\_nfs
 
-Provides a SakuraCloud NFS Appliance resource. This can be used to create, modify, and delete NFS Appliances.
+Provides a SakuraCloud NFS Appliance resource. This can be used to create, update, and delete NFS Appliances.
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ Valid value is one of the following: [ 100(default) / 500 / 1024 / 2048 / 4096 ]
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the NFS Appliance.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the NFS Appliance.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference

--- a/website/docs/r/nfs.html.markdown
+++ b/website/docs/r/nfs.html.markdown
@@ -33,7 +33,7 @@ resource sakuracloud_nfs "foobar" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
-* `plan` - (Optional) The plan(size) of the NFS Appliance (unit:`GB`).  
+* `plan` - (Optional) The plan (size) of the NFS Appliance (unit:`GB`).  
 Valid value is one of the following: [ 100 (default) / 500 / 1024 / 2048 / 4096 ]
 * `switch_id` - (Required) The ID of the switch connected to the NFS Appliance.
 * `ipaddress` - (Required) The IP address of the NFS Appliance.
@@ -51,7 +51,7 @@ The following attributes are exported:
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `plan` - The plan(size) of the NFS Appliance (unit:`GB`).
+* `plan` - The plan (size) of the NFS Appliance (unit:`GB`).
 * `switch_id` - The ID of the switch connected to the NFS Appliance.
 * `ipaddress` - The IP address of the NFS Appliance.
 * `nw_mask_len` - The network mask length of the NFS Appliance.

--- a/website/docs/r/nfs.html.markdown
+++ b/website/docs/r/nfs.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_nfs"
-sidebar_current: "docs-sakuracloud-resource-nfs"
+sidebar_current: "docs-sakuracloud-resource-appliance-nfs"
 description: |-
   Provides a SakuraCloud NFS Appliance resource. This can be used to create, update, and delete NFS Appliances.
 ---

--- a/website/docs/r/nfs.html.markdown
+++ b/website/docs/r/nfs.html.markdown
@@ -33,8 +33,8 @@ resource sakuracloud_nfs "foobar" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
-* `plan` - (Optional) The plan(size) of the NFS Appliance.(unit:`GB`)   
-Valid value is one of the following: [ 100(default) / 500 / 1024 / 2048 / 4096 ]
+* `plan` - (Optional) The plan(size) of the NFS Appliance (unit:`GB`).  
+Valid value is one of the following: [ 100 (default) / 500 / 1024 / 2048 / 4096 ]
 * `switch_id` - (Required) The ID of the switch connected to the NFS Appliance.
 * `ipaddress` - (Required) The IP address of the NFS Appliance.
 * `nw_mask_len` - (Required) The network mask length of the NFS Appliance.
@@ -42,7 +42,7 @@ Valid value is one of the following: [ 100(default) / 500 / 1024 / 2048 / 4096 ]
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the NFS Appliance.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the NFS Appliance.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -51,7 +51,7 @@ The following attributes are exported:
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `plan` - The plan(size) of the NFS Appliance.(unit:`GB`)   
+* `plan` - The plan(size) of the NFS Appliance (unit:`GB`).
 * `switch_id` - The ID of the switch connected to the NFS Appliance.
 * `ipaddress` - The IP address of the NFS Appliance.
 * `nw_mask_len` - The network mask length of the NFS Appliance.

--- a/website/docs/r/note.html.markdown
+++ b/website/docs/r/note.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 Valid value is one of the following: [ "shell"(default) / "yaml_cloud_config" ]
 * `content` - (Required) The content body of the Note.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 
 ## Attributes Reference
@@ -54,7 +54,7 @@ The following attributes are exported:
 * `class` - The name of the note class.
 * `content` - The body of the note. 
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 
 ## Import

--- a/website/docs/r/note.html.markdown
+++ b/website/docs/r/note.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_note"
 sidebar_current: "docs-sakuracloud-resource-misc-note"
 description: |-
-  Provides a SakuraCloud Note(Startup-Script) resource. This can be used to create, update, and delete Notes.
+  Provides a SakuraCloud Note (Startup-Script) resource. This can be used to create, update, and delete Notes.
 ---
 
 # sakuracloud\_note
 
-Provides a SakuraCloud Note(Startup-Script) resource. This can be used to create, update, and delete Notes.
+Provides a SakuraCloud Note (Startup-Script) resource. This can be used to create, update, and delete Notes.
 
 ## Example Usage
 

--- a/website/docs/r/note.html.markdown
+++ b/website/docs/r/note.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_note"
+sidebar_current: "docs-sakuracloud-resource-note"
+description: |-
+  Provides a SakuraCloud Note(Startup-Script) resource. This can be used to create, modify, and delete Notes.
+---
+
+# sakuracloud\_note
+
+Provides a SakuraCloud Note(Startup-Script) resource. This can be used to create, modify, and delete Notes.
+
+## Example Usage
+
+```hcl
+# Create a new Note
+resource "sakuracloud_note" "foobar" {
+  name        = "foobar"
+  
+  class       = "shell" 
+  content     = <<EOS
+#!/bin/sh
+
+: your-script-here
+EOS
+  
+  # for RancherOS(cloud_config)
+  # class   = "yaml_cloud_config"
+  # content = "${file("path/to/your/content")}"
+  
+  description = "description"
+  tags        = ["foo", "bar"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `class` - (Required) The content body of the Note.  
+Valid value is one of the following: [ "shell"(default) / "yaml_cloud_config" ]
+* `content` - (Required) The content body of the Note.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `class` - The name of the note class.
+* `content` - The body of the note. 
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+
+## Import
+
+Notes can be imported using the Note ID.
+
+```
+$ terraform import sakuracloud_note.foobar <note_id>
+```

--- a/website/docs/r/note.html.markdown
+++ b/website/docs/r/note.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
 * `class` - (Required) The content body of the Note.  
-Valid value is one of the following: [ "shell"(default) / "yaml_cloud_config" ]
+Valid value is one of the following: [ "shell" (default) / "yaml_cloud_config" ]
 * `content` - (Required) The content body of the Note.
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.

--- a/website/docs/r/note.html.markdown
+++ b/website/docs/r/note.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_note"
-sidebar_current: "docs-sakuracloud-resource-note"
+sidebar_current: "docs-sakuracloud-resource-misc-note"
 description: |-
   Provides a SakuraCloud Note(Startup-Script) resource. This can be used to create, update, and delete Notes.
 ---

--- a/website/docs/r/note.html.markdown
+++ b/website/docs/r/note.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_note"
 sidebar_current: "docs-sakuracloud-resource-note"
 description: |-
-  Provides a SakuraCloud Note(Startup-Script) resource. This can be used to create, modify, and delete Notes.
+  Provides a SakuraCloud Note(Startup-Script) resource. This can be used to create, update, and delete Notes.
 ---
 
 # sakuracloud\_note
 
-Provides a SakuraCloud Note(Startup-Script) resource. This can be used to create, modify, and delete Notes.
+Provides a SakuraCloud Note(Startup-Script) resource. This can be used to create, update, and delete Notes.
 
 ## Example Usage
 

--- a/website/docs/r/packet_filter.html.markdown
+++ b/website/docs/r/packet_filter.html.markdown
@@ -1,0 +1,84 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_packet_filter"
+sidebar_current: "docs-sakuracloud-resource-packet-filter"
+description: |-
+  Provides a SakuraCloud Packet Filter resource. This can be used to create, modify, and delete Packet Filters.
+---
+
+# sakuracloud\_packet\_filter
+
+Provides a SakuraCloud Packet Filter resource. This can be used to create, modify, and delete Packet Filters.
+
+## Example Usage
+
+```hcl
+# Create a new Packet Filter
+resource "sakuracloud_packet_filter" "foobar" {
+    name        = "foobar"
+    description = "description"
+    
+    expressions = {
+    	protocol    = "tcp"
+    	source_nw   = "0.0.0.0/0"
+    	source_port = "0-65535"
+    	dest_port   = "80"
+    }
+    
+    expressions = {
+    	protocol    = "ip"
+    	source_nw   = "0.0.0.0/0"
+    	allow       = false
+    	description = "deny all"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `description` - (Optional) The description of the resource.
+* `expressions` - (Required) Health check rules. It contains several attributes to [Expressions](#expressions).
+
+### Expressions
+
+Attributes for Expressions:
+
+* `protocol` - (Required) Protocol used in health check.  
+Valid value is one of the following: [ "tcp" / "udp" / "icmp" / "fragment" / "ip" ]
+* `source_nw` - (Optional) Target source network IP address or CIDR or range.  
+Valid format is one of the following:   
+  * IP address: `"xxx.xxx.xxx.xxx"`
+  * CIDR: `"xxx.xxx.xxx.xxx/nn"`
+  * Range: `"xxx.xxx.xxx.xxx/yyy.yyy.yyy.yyy"`
+* `source_port` - (Optional) Target source port.
+Valid format is one of the following:
+  * Number: `"0"` - `"65535"`
+  * Range: `"xx-yy"`
+  * Range(hex): `"0xPPPP/0xMMMM"`
+* `dest_port` - (Optional) Target destination port.
+Valid format is one of the following:
+  * Number: `"0"` - `"65535"`
+  * Range: `"xx-yy"`
+  * Range(hex): `"0xPPPP/0xMMMM"`
+* `allow` - (Optional) The flag for allow/deny packets.(default:`true`)
+* `description` - (Optional) The description of the expression.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `description` - The description of the resource.
+* `expressions` - Health check rules. It contains several attributes to [Expressions](#expressions).
+
+## Import
+
+Packet Filters can be imported using the Packet Filter ID.
+
+```
+$ terraform import sakuracloud_packet_filter.foobar <packet_filter_id>
+```

--- a/website/docs/r/packet_filter.html.markdown
+++ b/website/docs/r/packet_filter.html.markdown
@@ -63,7 +63,7 @@ Valid format is one of the following:
   * Number: `"0"` - `"65535"`
   * Range: `"xx-yy"`
   * Range(hex): `"0xPPPP/0xMMMM"`
-* `allow` - (Optional) The flag for allow/deny packets.(default:`true`)
+* `allow` - (Optional) The flag for allow/deny packets (default:`true`).
 * `description` - (Optional) The description of the expression.
 
 ## Attributes Reference

--- a/website/docs/r/packet_filter.html.markdown
+++ b/website/docs/r/packet_filter.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_packet_filter"
 sidebar_current: "docs-sakuracloud-resource-packet-filter"
 description: |-
-  Provides a SakuraCloud Packet Filter resource. This can be used to create, modify, and delete Packet Filters.
+  Provides a SakuraCloud Packet Filter resource. This can be used to create, update, and delete Packet Filters.
 ---
 
 # sakuracloud\_packet\_filter
 
-Provides a SakuraCloud Packet Filter resource. This can be used to create, modify, and delete Packet Filters.
+Provides a SakuraCloud Packet Filter resource. This can be used to create, update, and delete Packet Filters.
 
 ## Example Usage
 
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
 * `description` - (Optional) The description of the resource.
-* `expressions` - (Required) Health check rules. It contains several attributes to [Expressions](#expressions).
+* `expressions` - (Required) Health check rules. It contains some attributes to [Expressions](#expressions).
 
 ### Expressions
 
@@ -73,7 +73,7 @@ The following attributes are exported:
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
 * `description` - The description of the resource.
-* `expressions` - Health check rules. It contains several attributes to [Expressions](#expressions).
+* `expressions` - Health check rules. It contains some attributes to [Expressions](#expressions).
 
 ## Import
 

--- a/website/docs/r/packet_filter.html.markdown
+++ b/website/docs/r/packet_filter.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_packet_filter"
-sidebar_current: "docs-sakuracloud-resource-packet-filter"
+sidebar_current: "docs-sakuracloud-resource-networking-packet-filter"
 description: |-
   Provides a SakuraCloud Packet Filter resource. This can be used to create, update, and delete Packet Filters.
 ---

--- a/website/docs/r/packet_filter.html.markdown
+++ b/website/docs/r/packet_filter.html.markdown
@@ -57,12 +57,12 @@ Valid format is one of the following:
 Valid format is one of the following:
   * Number: `"0"` - `"65535"`
   * Range: `"xx-yy"`
-  * Range(hex): `"0xPPPP/0xMMMM"`
+  * Range (hex): `"0xPPPP/0xMMMM"`
 * `dest_port` - (Optional) Target destination port.
 Valid format is one of the following:
   * Number: `"0"` - `"65535"`
   * Range: `"xx-yy"`
-  * Range(hex): `"0xPPPP/0xMMMM"`
+  * Range (hex): `"0xPPPP/0xMMMM"`
 * `allow` - (Optional) The flag for allow/deny packets (default:`true`).
 * `description` - (Optional) The description of the expression.
 

--- a/website/docs/r/packet_filter_rule.html.markdown
+++ b/website/docs/r/packet_filter_rule.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_packet_filter_rule"
 sidebar_current: "docs-sakuracloud-resource-pfrule"
 description: |-
-  Provides a SakuraCloud Packet Filter Rule resource. This can be used to create, modify, and delete Packet Filter Rules.
+  Provides a SakuraCloud Packet Filter Rule resource. This can be used to create, update, and delete Packet Filter Rules.
 ---
 
 # sakuracloud\_packet\_filter\_rule
 
-Provides a SakuraCloud Packet Filter Rule resource. This can be used to create, modify, and delete Packet Filter Rules.
+Provides a SakuraCloud Packet Filter Rule resource. This can be used to create, update, and delete Packet Filter Rules.
 
 ## Example Usage
 

--- a/website/docs/r/packet_filter_rule.html.markdown
+++ b/website/docs/r/packet_filter_rule.html.markdown
@@ -62,9 +62,9 @@ Valid format is one of the following:
   * Number: `"0"` - `"65535"`
   * Range: `"xx-yy"`
   * Range(hex): `"0xPPPP/0xMMMM"`
-* `allow` - (Optional) The flag for allow/deny packets.(default:`true`)
+* `allow` - (Optional) The flag for allow/deny packets (default:`true`).
 * `description` - (Optional) The description of the expression.
-* `order` - (Optional) The order of the expression.(default:`1000`)
+* `order` - (Optional) The order of the expression (default:`1000`).
 
 ## Attributes Reference
 
@@ -75,11 +75,11 @@ The following attributes are exported:
 * `source_nw` - Target source network IP address or CIDR or range.  
 * `source_port` - Target source port.
 * `dest_port` - Target destination port.
-* `allow` - The flag for allow/deny packets.(default:`true`)
+* `allow` - The flag for allow/deny packets (default:`true`).
 * `description` - The description of the expression.
-* `order` - The order of the expression.(default:`1000`)
+* `order` - The order of the expression (default:`1000`).
 
 
-## Import(not supported)
+## Import (not supported)
 
 Import of Packet Filter Rule is not supported.

--- a/website/docs/r/packet_filter_rule.html.markdown
+++ b/website/docs/r/packet_filter_rule.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_packet_filter_rule"
-sidebar_current: "docs-sakuracloud-resource-pfrule"
+sidebar_current: "docs-sakuracloud-resource-networking-pfrule"
 description: |-
   Provides a SakuraCloud Packet Filter Rule resource. This can be used to create, update, and delete Packet Filter Rules.
 ---

--- a/website/docs/r/packet_filter_rule.html.markdown
+++ b/website/docs/r/packet_filter_rule.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_packet_filter_rule"
+sidebar_current: "docs-sakuracloud-resource-pfrule"
+description: |-
+  Provides a SakuraCloud Packet Filter Rule resource. This can be used to create, modify, and delete Packet Filter Rules.
+---
+
+# sakuracloud\_packet\_filter\_rule
+
+Provides a SakuraCloud Packet Filter Rule resource. This can be used to create, modify, and delete Packet Filter Rules.
+
+## Example Usage
+
+```hcl
+# Create a new Packet Filter
+resource "sakuracloud_packet_filter" "foobar" {
+    name        = "foobar"
+}
+
+# Create a new packet filter rule
+resource sakuracloud_packet_filter_rule "rule0" {
+    packet_filter_id = "${sakuracloud_packet_filter.foobar.id}"
+
+ 	protocol    = "tcp"
+	source_nw   = "0.0.0.0/0"
+	source_port = "0-65535"
+	dest_port   = "80"
+	order       = 0
+}
+
+resource sakuracloud_packet_filter_rule "rule1" {
+    packet_filter_id = "${sakuracloud_packet_filter.foobar.id}"
+
+	protocol    = "ip"
+	source_nw   = "0.0.0.0/0"
+	allow       = false
+	description = "deny all"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `packet_filter_id` - (Required) The ID of the Packet Filter to which the resource belongs.
+* `protocol` - (Required) Protocol used in health check.  
+Valid value is one of the following: [ "tcp" / "udp" / "icmp" / "fragment" / "ip" ]
+* `source_nw` - (Optional) Target source network IP address or CIDR or range.  
+Valid format is one of the following:   
+  * IP address: `"xxx.xxx.xxx.xxx"`
+  * CIDR: `"xxx.xxx.xxx.xxx/nn"`
+  * Range: `"xxx.xxx.xxx.xxx/yyy.yyy.yyy.yyy"`
+* `source_port` - (Optional) Target source port.
+Valid format is one of the following:
+  * Number: `"0"` - `"65535"`
+  * Range: `"xx-yy"`
+  * Range(hex): `"0xPPPP/0xMMMM"`
+* `dest_port` - (Optional) Target destination port.
+Valid format is one of the following:
+  * Number: `"0"` - `"65535"`
+  * Range: `"xx-yy"`
+  * Range(hex): `"0xPPPP/0xMMMM"`
+* `allow` - (Optional) The flag for allow/deny packets.(default:`true`)
+* `description` - (Optional) The description of the expression.
+* `order` - (Optional) The order of the expression.(default:`1000`)
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `protocol` - Protocol used in health check.  
+* `source_nw` - Target source network IP address or CIDR or range.  
+* `source_port` - Target source port.
+* `dest_port` - Target destination port.
+* `allow` - The flag for allow/deny packets.(default:`true`)
+* `description` - The description of the expression.
+* `order` - The order of the expression.(default:`1000`)
+
+
+## Import(not supported)
+
+Import of Packet Filter Rule is not supported.

--- a/website/docs/r/packet_filter_rule.html.markdown
+++ b/website/docs/r/packet_filter_rule.html.markdown
@@ -56,12 +56,12 @@ Valid format is one of the following:
 Valid format is one of the following:
   * Number: `"0"` - `"65535"`
   * Range: `"xx-yy"`
-  * Range(hex): `"0xPPPP/0xMMMM"`
+  * Range (hex): `"0xPPPP/0xMMMM"`
 * `dest_port` - (Optional) Target destination port.
 Valid format is one of the following:
   * Number: `"0"` - `"65535"`
   * Range: `"xx-yy"`
-  * Range(hex): `"0xPPPP/0xMMMM"`
+  * Range (hex): `"0xPPPP/0xMMMM"`
 * `allow` - (Optional) The flag for allow/deny packets (default:`true`).
 * `description` - (Optional) The description of the expression.
 * `order` - (Optional) The order of the expression (default:`1000`).

--- a/website/docs/r/private_host.html.markdown
+++ b/website/docs/r/private_host.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.  
 Valid value is one of the following: ["is1b" / "tk1a"]
 
@@ -48,7 +48,7 @@ The following attributes are exported:
 * `name` - The name of the resource.
 * `hostname` - The HostName of the resource.
 * `assigned_core` - The number of cores assigned to the Server.
-* `assigned_memory` - The size of memory allocated to the Server(unit:`GB`).
+* `assigned_memory` - The size of memory allocated to the Server (unit:`GB`).
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.
 * `zone` - The ID of the zone to which the resource belongs.

--- a/website/docs/r/private_host.html.markdown
+++ b/website/docs/r/private_host.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.  
@@ -50,7 +50,7 @@ The following attributes are exported:
 * `assigned_core` - The number of cores assigned to the Server.
 * `assigned_memory` - The size of memory allocated to the Server(unit:`GB`).
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `zone` - The ID of the zone to which the resource belongs.
 
 ## Import

--- a/website/docs/r/private_host.html.markdown
+++ b/website/docs/r/private_host.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_private_host"
+sidebar_current: "docs-sakuracloud-resource-private-host"
+description: |-
+  Provides a SakuraCloud Private Host resource. This can be used to create, modify, and delete Private Hosts.
+---
+
+# sakuracloud\_private\_host
+
+Provides a SakuraCloud Private Host resource. This can be used to create, modify, and delete Private Hosts.
+
+## Example Usage
+
+```hcl
+# Create a new Private Host
+resource sakuracloud_private_host "foobar" {
+  name        = "foobar"
+  description = "description"
+  tags        = ["foo", "bar"]
+}
+
+# Add server on Private Host
+resource "sakuracloud_server" "foobar" {
+  name            = "example"
+  private_host_id = "${sakuracloud_private_host.foobar.id}"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.  
+Valid value is one of the following: ["is1b" / "tk1a"]
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `hostname` - The HostName of the resource.
+* `assigned_core` - The number of cores assigned to the Server.
+* `assigned_memory` - The size of memory allocated to the Server(unit:`GB`).
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Private Hosts can be imported using the Private Host ID.
+
+```
+$ terraform import sakuracloud_private_host.foobar <private_host_id>
+```

--- a/website/docs/r/private_host.html.markdown
+++ b/website/docs/r/private_host.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_private_host"
 sidebar_current: "docs-sakuracloud-resource-private-host"
 description: |-
-  Provides a SakuraCloud Private Host resource. This can be used to create, modify, and delete Private Hosts.
+  Provides a SakuraCloud Private Host resource. This can be used to create, update, and delete Private Hosts.
 ---
 
 # sakuracloud\_private\_host
 
-Provides a SakuraCloud Private Host resource. This can be used to create, modify, and delete Private Hosts.
+Provides a SakuraCloud Private Host resource. This can be used to create, update, and delete Private Hosts.
 
 ## Example Usage
 
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.  
 Valid value is one of the following: ["is1b" / "tk1a"]
 

--- a/website/docs/r/private_host.html.markdown
+++ b/website/docs/r/private_host.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_private_host"
-sidebar_current: "docs-sakuracloud-resource-private-host"
+sidebar_current: "docs-sakuracloud-resource-computing-private-host"
 description: |-
   Provides a SakuraCloud Private Host resource. This can be used to create, update, and delete Private Hosts.
 ---

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_server"
-sidebar_current: "docs-sakuracloud-resource-server"
+sidebar_current: "docs-sakuracloud-resource-computing-server"
 description: |-
   Provides a SakuraCloud Server resource. This can be used to create, update, and delete Servers.
 ---

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_server"
 sidebar_current: "docs-sakuracloud-resource-server"
 description: |-
-  Provides a SakuraCloud Server resource. This can be used to create, modify, and delete Servers.
+  Provides a SakuraCloud Server resource. This can be used to create, update, and delete Servers.
 ---
 
 # sakuracloud\_server
 
-Provides a SakuraCloud Server resource. This can be used to create, modify, and delete Servers.
+Provides a SakuraCloud Server resource. This can be used to create, update, and delete Servers.
 
 ## Example Usage
 
@@ -86,7 +86,7 @@ Valid value is one of the following: [ "virtio"(default) / "e1000"]
 Valid value is one of the following: [ "shared"(default) / <Switch ID> / ""(disconnected) ]
 * `cdrom_id` - (Optional) The ID of the CD-ROM inserted to Server.
 * `private_host_id` - (Optional) The ID of the Private Host to which the Server belongs.
-* `additional_nics` - (Optional) The ID list of the Switch connected to additional NICs of Server.  
+* `additional_nics` - (Optional) The ID list of the Switch connected to NICs(excluding primary NIC) of Server.  
 Valid values are one of the following: [ <Switch ID> / ""(disconnected) ]
 * `packet_filter_ids` - (Optional) The ID list of the Packet Filter connected to Server.
 * `ipaddress` - (Optional) The IP address of primary NIC.
@@ -95,7 +95,7 @@ Valid values are one of the following: [ <Switch ID> / ""(disconnected) ]
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the Server.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the Server.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -112,7 +112,7 @@ The following attributes are exported:
 * `cdrom_id` - The ID of the CD-ROM inserted to Server.
 * `private_host_id` - The ID of the Private Host to which the Server belongs.
 * `private_host_name` - The name of the Private Host to which the Server belongs.
-* `additional_nics` - The ID list of the Switch connected to additional NICs of Server.
+* `additional_nics` - The ID list of the Switch connected to NICs(excluding primary NIC) of Server.
 * `packet_filter_ids` - The ID list of the Packet Filter connected to Server.
 * `macaddresses` - The MAC address list of NICs connected to Server.
 * `ipaddress` - The IP address of primary NIC.

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -79,21 +79,21 @@ The following arguments are supported:
 * `name` - (Required) The name of the resource.
 * `core` - (Optional) The number of cores(default:`1`).
 * `memory` - (Optional) The size of memory(unit:`GB`, default:`1`).
-* `disks` - (Optional) The ID list of the Disk connected to Server.
+* `disks` - (Optional) The ID list of the Disks connected to Server.
 * `interface_driver` - (Optional) The name of network interface driver.  
 Valid value is one of the following: [ "virtio"(default) / "e1000"]
 * `nic` - (Optional) The primary NIC's connection destination.  
 Valid value is one of the following: [ "shared"(default) / <Switch ID> / ""(disconnected) ]
 * `cdrom_id` - (Optional) The ID of the CD-ROM inserted to Server.
 * `private_host_id` - (Optional) The ID of the Private Host to which the Server belongs.
-* `additional_nics` - (Optional) The ID list of the Switch connected to NICs(excluding primary NIC) of Server.  
+* `additional_nics` - (Optional) The ID list of the Switches connected to NICs(excluding primary NIC) of Server.  
 Valid values are one of the following: [ <Switch ID> / ""(disconnected) ]
-* `packet_filter_ids` - (Optional) The ID list of the Packet Filter connected to Server.
+* `packet_filter_ids` - (Optional) The ID list of the Packet Filters connected to Server.
 * `ipaddress` - (Optional) The IP address of primary NIC.
 * `gateway` - (Optional) Default gateway address of the Server.	 
 * `nw_mask_len` - (Optional) Network mask length of the Server.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the Server.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
@@ -106,14 +106,14 @@ The following attributes are exported:
 * `name` - The name of the resource.
 * `core` - The number of cores.
 * `memory` - The size of memory(unit:`GB`).
-* `disks` - The ID list of the Disk connected to Server.
+* `disks` - The ID list of the Disks connected to Server.
 * `interface_driver` - The name of network interface driver.
 * `nic` - The primary NIC's connection destination.
 * `cdrom_id` - The ID of the CD-ROM inserted to Server.
 * `private_host_id` - The ID of the Private Host to which the Server belongs.
 * `private_host_name` - The name of the Private Host to which the Server belongs.
-* `additional_nics` - The ID list of the Switch connected to NICs(excluding primary NIC) of Server.
-* `packet_filter_ids` - The ID list of the Packet Filter connected to Server.
+* `additional_nics` - The ID list of the Switches connected to NICs(excluding primary NIC) of Server.
+* `packet_filter_ids` - The ID list of the Packet Filters connected to Server.
 * `macaddresses` - The MAC address list of NICs connected to Server.
 * `ipaddress` - The IP address of primary NIC.
 * `dns_servers` - List of default DNS servers for the zone to which the Server belongs.
@@ -121,7 +121,7 @@ The following attributes are exported:
 * `nw_address` - The network address of the Server.
 * `nw_mask_len` - Network mask length of the Server.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -77,17 +77,17 @@ data sakuracloud_archive "ubuntu" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
-* `core` - (Optional) The number of cores(default:`1`).
-* `memory` - (Optional) The size of memory(unit:`GB`, default:`1`).
+* `core` - (Optional) The number of cores (default:`1`).
+* `memory` - (Optional) The size of memory (unit:`GB`, default:`1`).
 * `disks` - (Optional) The ID list of the Disks connected to Server.
 * `interface_driver` - (Optional) The name of network interface driver.  
-Valid value is one of the following: [ "virtio"(default) / "e1000"]
+Valid value is one of the following: [ "virtio" (default) / "e1000"]
 * `nic` - (Optional) The primary NIC's connection destination.  
-Valid value is one of the following: [ "shared"(default) / <Switch ID> / ""(disconnected) ]
+Valid value is one of the following: [ "shared" (default) / <Switch ID> / "" (disconnected) ]
 * `cdrom_id` - (Optional) The ID of the CD-ROM inserted to Server.
 * `private_host_id` - (Optional) The ID of the Private Host to which the Server belongs.
-* `additional_nics` - (Optional) The ID list of the Switches connected to NICs(excluding primary NIC) of Server.  
-Valid values are one of the following: [ <Switch ID> / ""(disconnected) ]
+* `additional_nics` - (Optional) The ID list of the Switches connected to NICs (excluding primary NIC) of Server.  
+Valid values are one of the following: [ <Switch ID> / "" (disconnected) ]
 * `packet_filter_ids` - (Optional) The ID list of the Packet Filters connected to Server.
 * `ipaddress` - (Optional) The IP address of primary NIC.
 * `gateway` - (Optional) Default gateway address of the Server.	 
@@ -95,7 +95,7 @@ Valid values are one of the following: [ <Switch ID> / ""(disconnected) ]
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the Server.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the Server.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -105,14 +105,14 @@ The following attributes are exported:
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
 * `core` - The number of cores.
-* `memory` - The size of memory(unit:`GB`).
+* `memory` - The size of memory (unit:`GB`).
 * `disks` - The ID list of the Disks connected to Server.
 * `interface_driver` - The name of network interface driver.
 * `nic` - The primary NIC's connection destination.
 * `cdrom_id` - The ID of the CD-ROM inserted to Server.
 * `private_host_id` - The ID of the Private Host to which the Server belongs.
 * `private_host_name` - The name of the Private Host to which the Server belongs.
-* `additional_nics` - The ID list of the Switches connected to NICs(excluding primary NIC) of Server.
+* `additional_nics` - The ID list of the Switches connected to NICs (excluding primary NIC) of Server.
 * `packet_filter_ids` - The ID list of the Packet Filters connected to Server.
 * `macaddresses` - The MAC address list of NICs connected to Server.
 * `ipaddress` - The IP address of primary NIC.

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -1,0 +1,134 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_server"
+sidebar_current: "docs-sakuracloud-resource-server"
+description: |-
+  Provides a SakuraCloud Server resource. This can be used to create, modify, and delete Servers.
+---
+
+# sakuracloud\_server
+
+Provides a SakuraCloud Server resource. This can be used to create, modify, and delete Servers.
+
+## Example Usage
+
+```hcl
+# Create a new Server
+resource sakuracloud_server "foobar" {
+  name                = "foobar"
+  # core              = 1
+  # memory            = 1
+  disks               = ["${sakuracloud_disk.foobar.id}"]
+  # interface_driver  = "virtio"
+  # nic               = "shared"
+  
+  # cdrom_id          = "${sakuracloud_cdrom.foobar.id}"
+  # private_host_id   = "${sakuracloud_private_host.foobar.id}"
+  
+  # additional_nics   = [
+  #  "${sakuracloud_switch.foobar.id}",  # connect to switch
+  #  "", # disconnected
+  # ] 
+  
+  # packet_filter_ids = [
+  #  "${sakuracloud_packet_filter.foobar.id}", # for primary NIC
+  #  "${sakuracloud_packet_filter.foobar.id}", # for secondly NIC
+  #]
+ 
+  # only when nic != shared
+  # ipaddress       = "192.2.0.1"
+  # nw_mask_len     = 24
+  # gateway         = "192.2.0.254" 
+  
+  description       = "description"
+  tags              = ["foo", "bar"]
+}
+
+# Create a new Disk
+resource sakuracloud_disk "foobar" {
+  name              = "foobar"
+  plan              = "ssd"
+  connector         = "virtio"
+  size              = 20
+  source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
+  # or
+  # source_disk_id  = "<your-disk-id>"
+  
+  # For "Modify Disk" API
+  hostname          = "your-host-name"
+  password          = ""
+  ssh_key_ids       = ["<your-ssh-key-id>"]
+  note_ids          = ["<your-note-id"]
+  disable_pw_auth   = true
+  
+  description       = "description"
+  tags              = ["foo", "bar"]
+}
+
+# Source archive
+data sakuracloud_archive "ubuntu" {
+  os_type = "ubuntu"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `core` - (Optional) The number of cores(default:`1`).
+* `memory` - (Optional) The size of memory(unit:`GB`, default:`1`).
+* `disks` - (Optional) The ID list of the Disk connected to Server.
+* `interface_driver` - (Optional) The name of network interface driver.  
+Valid value is one of the following: [ "virtio"(default) / "e1000"]
+* `nic` - (Optional) The primary NIC's connection destination.  
+Valid value is one of the following: [ "shared"(default) / <Switch ID> / ""(disconnected) ]
+* `cdrom_id` - (Optional) The ID of the CD-ROM inserted to Server.
+* `private_host_id` - (Optional) The ID of the Private Host to which the Server belongs.
+* `additional_nics` - (Optional) The ID list of the Switch connected to additional NICs of Server.  
+Valid values are one of the following: [ <Switch ID> / ""(disconnected) ]
+* `packet_filter_ids` - (Optional) The ID list of the Packet Filter connected to Server.
+* `ipaddress` - (Optional) The IP address of primary NIC.
+* `gateway` - (Optional) Default gateway address of the Server.	 
+* `nw_mask_len` - (Optional) Network mask length of the Server.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the Server.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `core` - The number of cores.
+* `memory` - The size of memory(unit:`GB`).
+* `disks` - The ID list of the Disk connected to Server.
+* `interface_driver` - The name of network interface driver.
+* `nic` - The primary NIC's connection destination.
+* `cdrom_id` - The ID of the CD-ROM inserted to Server.
+* `private_host_id` - The ID of the Private Host to which the Server belongs.
+* `private_host_name` - The name of the Private Host to which the Server belongs.
+* `additional_nics` - The ID list of the Switch connected to additional NICs of Server.
+* `packet_filter_ids` - The ID list of the Packet Filter connected to Server.
+* `macaddresses` - The MAC address list of NICs connected to Server.
+* `ipaddress` - The IP address of primary NIC.
+* `dns_servers` - List of default DNS servers for the zone to which the Server belongs.
+* `gateway` - Default gateway address of the Server.	 
+* `nw_address` - The network address of the Server.
+* `nw_mask_len` - Network mask length of the Server.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Servers can be imported using the Server ID.
+
+```
+$ terraform import sakuracloud_server.foobar <server_id>
+```

--- a/website/docs/r/server_connector.html.markdown
+++ b/website/docs/r/server_connector.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_server_connector"
+sidebar_current: "docs-sakuracloud-resource-sconnector"
+description: |-
+  Provides a SakuraCloud Server Connection resource. This can be used to create, modify, and delete Servers.
+---
+
+# sakuracloud\_server
+
+Provides a SakuraCloud Server Connection resource. This can be used to create, modify, and delete Servers.
+
+## Example Usage
+
+```hcl
+# Connect Disk or CDROM or PacketFilter to Server
+resource sakuracloud_server "foobar" {
+  server_id           = "${sakuracloud_server.foobar.id}"
+  
+  # disks             = ["${sakuracloud_disk.foobar.id}"]
+  
+  # cdrom_id          = "${sakuracloud_cdrom.foobar.id}"
+  
+  # packet_filter_ids = [
+  #  "${sakuracloud_packet_filter.foobar.id}", # for primary NIC
+  #  "${sakuracloud_packet_filter.foobar.id}", # for secondly NIC
+  #]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `server_id` - (Required) The name of the resource.
+* `disks` - (Optional) The ID list of the Disk connected to Server.
+* `cdrom_id` - (Optional) The ID of the CD-ROM inserted to Server.
+* `packet_filter_ids` - (Optional) The ID list of the Packet Filter connected to Server.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the Server.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `disks` - The ID list of the Disk connected to Server.
+* `cdrom_id` - The ID of the CD-ROM inserted to Server.
+* `packet_filter_ids` - The ID list of the Packet Filter connected to Server.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Server Connections can be imported using the Server ID.
+
+```
+$ terraform import sakuracloud_server_connector.foobar <server_id>
+```

--- a/website/docs/r/server_connector.html.markdown
+++ b/website/docs/r/server_connector.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `disks` - (Optional) The ID list of the Disks connected to Server.
 * `cdrom_id` - (Optional) The ID of the CD-ROM inserted to Server.
 * `packet_filter_ids` - (Optional) The ID list of the Packet Filters connected to Server.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the Server.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the Server.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference

--- a/website/docs/r/server_connector.html.markdown
+++ b/website/docs/r/server_connector.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_server_connector"
-sidebar_current: "docs-sakuracloud-resource-sconnector"
+sidebar_current: "docs-sakuracloud-resource-computing-sconnector"
 description: |-
   Provides a SakuraCloud Server Connection resource. This can be used to create, update, and delete Servers.
 ---

--- a/website/docs/r/server_connector.html.markdown
+++ b/website/docs/r/server_connector.html.markdown
@@ -33,9 +33,9 @@ resource sakuracloud_server "foobar" {
 The following arguments are supported:
 
 * `server_id` - (Required) The name of the resource.
-* `disks` - (Optional) The ID list of the Disk connected to Server.
+* `disks` - (Optional) The ID list of the Disks connected to Server.
 * `cdrom_id` - (Optional) The ID of the CD-ROM inserted to Server.
-* `packet_filter_ids` - (Optional) The ID list of the Packet Filter connected to Server.
+* `packet_filter_ids` - (Optional) The ID list of the Packet Filters connected to Server.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the Server.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
@@ -44,9 +44,9 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the resource.
-* `disks` - The ID list of the Disk connected to Server.
+* `disks` - The ID list of the Disks connected to Server.
 * `cdrom_id` - The ID of the CD-ROM inserted to Server.
-* `packet_filter_ids` - The ID list of the Packet Filter connected to Server.
+* `packet_filter_ids` - The ID list of the Packet Filters connected to Server.
 * `zone` - The ID of the zone to which the resource belongs.
 
 ## Import

--- a/website/docs/r/server_connector.html.markdown
+++ b/website/docs/r/server_connector.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_server_connector"
 sidebar_current: "docs-sakuracloud-resource-sconnector"
 description: |-
-  Provides a SakuraCloud Server Connection resource. This can be used to create, modify, and delete Servers.
+  Provides a SakuraCloud Server Connection resource. This can be used to create, update, and delete Servers.
 ---
 
 # sakuracloud\_server
 
-Provides a SakuraCloud Server Connection resource. This can be used to create, modify, and delete Servers.
+Provides a SakuraCloud Server Connection resource. This can be used to create, update, and delete Servers.
 
 ## Example Usage
 
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `disks` - (Optional) The ID list of the Disk connected to Server.
 * `cdrom_id` - (Optional) The ID of the CD-ROM inserted to Server.
 * `packet_filter_ids` - (Optional) The ID list of the Packet Filter connected to Server.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the Server.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the Server.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference

--- a/website/docs/r/sim.html.markdown
+++ b/website/docs/r/sim.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_sim"
+sidebar_current: "docs-sakuracloud-resource-sim"
+description: |-
+  Provides a SakuraCloud SIM resource. This can be used to create, modify, and delete SIMs.
+---
+
+# sakuracloud\_sim
+
+Provides a SakuraCloud SIM resource. This can be used to create, modify, and delete SIMs.
+
+## Example Usage
+
+```hcl
+# Create a new SIM
+resource sakuracloud_sim "foobar" {
+    name     = "foobar"
+    iccid    = "<your-iccid>"
+    passcode = "<your-passcode>"
+    # imei     = "<imei>"
+    # enabled  = true
+
+    # connect to the Mobile Gateway 
+    mobile_gateway_id = "${sakuracloud_mobile_gateway.foobar.id}"
+    ipaddress         = "192.168.2.1"
+    
+    description = "description"
+    tags        = ["foo", "bar"]
+}
+
+# Create a new Mobile Gateway
+resource sakuracloud_mobile_gateway "foobar" {
+    name = "foobar"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `iccid` - (Required) The ICCID of the SIM.  
+* `passcode` - (Required) The Passcode of the SIM.  
+* `imei` - (Optional) The IMEI of the device that allows communication.
+* `enabled` - (Optional) The flag of enable/disable the Server.
+* `mobile_gateway_id` - (Optional) The ID of the Mobile Gateway to which the SIM belongs.
+* `ipaddress` - (Optional) The IP address of the SIM. Only when connected with mobile gateway.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `iccid` - The ICCID of the SIM. 
+* `ipaddress` - The IP address of the SIM. Only when connected with mobile gateway.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon.
+
+## Import
+
+SIMs can be imported using the SIM ID.
+
+```
+$ terraform import sakuracloud_sim.foobar <sim_id>
+```

--- a/website/docs/r/sim.html.markdown
+++ b/website/docs/r/sim.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_sim"
 sidebar_current: "docs-sakuracloud-resource-sim"
 description: |-
-  Provides a SakuraCloud SIM resource. This can be used to create, modify, and delete SIMs.
+  Provides a SakuraCloud SIM resource. This can be used to create, update, and delete SIMs.
 ---
 
 # sakuracloud\_sim
 
-Provides a SakuraCloud SIM resource. This can be used to create, modify, and delete SIMs.
+Provides a SakuraCloud SIM resource. This can be used to create, update, and delete SIMs.
 
 ## Example Usage
 
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `imei` - (Optional) The IMEI of the device that allows communication.
 * `enabled` - (Optional) The flag of enable/disable the Server.
 * `mobile_gateway_id` - (Optional) The ID of the Mobile Gateway to which the SIM belongs.
-* `ipaddress` - (Optional) The IP address of the SIM. Only when connected with mobile gateway.
+* `ipaddress` - (Optional) The IP address of the SIM. Used when connect to mobile gateway.
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
@@ -57,7 +57,7 @@ The following attributes are exported:
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
 * `iccid` - The ICCID of the SIM. 
-* `ipaddress` - The IP address of the SIM. Only when connected with mobile gateway.
+* `ipaddress` - The IP address of the SIM. Used when connected with mobile gateway.
 * `description` - The description of the resource.
 * `tags` - The tag list of the resource.
 * `icon_id` - The ID of the icon.

--- a/website/docs/r/sim.html.markdown
+++ b/website/docs/r/sim.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `mobile_gateway_id` - (Optional) The ID of the Mobile Gateway to which the SIM belongs.
 * `ipaddress` - (Optional) The IP address of the SIM. Used when connect to mobile gateway.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 
 ## Attributes Reference
@@ -59,7 +59,7 @@ The following attributes are exported:
 * `iccid` - The ICCID of the SIM. 
 * `ipaddress` - The IP address of the SIM. Used when connected with mobile gateway.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon.
 
 ## Import

--- a/website/docs/r/sim.html.markdown
+++ b/website/docs/r/sim.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_sim"
-sidebar_current: "docs-sakuracloud-resource-sim"
+sidebar_current: "docs-sakuracloud-resource-secure-mobile-sim"
 description: |-
   Provides a SakuraCloud SIM resource. This can be used to create, update, and delete SIMs.
 ---

--- a/website/docs/r/simple_monitor.html.markdown
+++ b/website/docs/r/simple_monitor.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_simple_monitor"
 sidebar_current: "docs-sakuracloud-resource-smonitor"
 description: |-
-  Provides a SakuraCloud Simple Monitor resource. This can be used to create, modify, and delete Simple Monitors.
+  Provides a SakuraCloud Simple Monitor resource. This can be used to create, update, and delete Simple Monitors.
 ---
 
 # sakuracloud\_simple\_monitor
 
-Provides a SakuraCloud Simple Monitor resource. This can be used to create, modify, and delete Simple Monitors.
+Provides a SakuraCloud Simple Monitor resource. This can be used to create, update, and delete Simple Monitors.
 
 ## Example Usage
 
@@ -50,7 +50,7 @@ resource sakuracloud_simple_monitor "cert" {
 The following arguments are supported:
 
 * `target` - (Required) The HostName or IP address of monitoring target.
-* `health_check` - (Required) Health check rules. It contains several attributes to [Health Check](#health-check).
+* `health_check` - (Required) Health check rules. It contains some attributes to [Health Check](#health-check).
 * `notify_email_enabled` - (Optional) The flag of enable/disable notification by E-mail.
 * `notify_email_html` - (Optional) The flag of enable/disable HTML format for E-mail.
 * `notify_slack_enabled` - (Optional) The flag of enable/disable notification by slack.
@@ -83,7 +83,7 @@ Valid value is one of the following: [ "http" / "https" / "ping" / "tcp" / "dns"
 
 * `id` - The ID of the resource.
 * `target` - The HostName or IP address of monitoring target.
-* `health_check` - Health check rules. It contains several attributes to [Health Check](#health-check).
+* `health_check` - Health check rules. It contains some attributes to [Health Check](#health-check).
 * `notify_email_enabled` - The flag of enable/disable notification by E-mail.
 * `notify_email_html` - The flag of enable/disable HTML format for E-mail.
 * `notify_slack_enabled` - The flag of enable/disable notification by slack.

--- a/website/docs/r/simple_monitor.html.markdown
+++ b/website/docs/r/simple_monitor.html.markdown
@@ -66,7 +66,7 @@ Attributes for Health Check:
 
 * `protocol` - (Required) Protocol used in health check.  
 Valid value is one of the following: [ "http" / "https" / "ping" / "tcp" / "dns" / "ssh" / "smtp" / "pop3" / "snmp" / "sslcertificate" ]
-* `delay_loop` - (Optional) Health check access interval(unit:`second`). 
+* `delay_loop` - (Optional) Health check access interval (unit:`second`). 
 * `host_header` - (Optional) The value of `Host` header used in http/https health check access.
 * `path` - (Optional) The request path used in http/https health check access.
 * `status` - (Optional) HTTP status code expected by health check access.

--- a/website/docs/r/simple_monitor.html.markdown
+++ b/website/docs/r/simple_monitor.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `notify_slack_webhook` - (Optional) The webhook URL of destination of slack notification.
 * `enabled` - (Optional) The flag of enable/disable monitoring.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon of the resource.
 
 ### Health Check
@@ -90,7 +90,7 @@ Valid value is one of the following: [ "http" / "https" / "ping" / "tcp" / "dns"
 * `notify_slack_webhook` - The webhook URL of destination of slack notification.
 * `enabled` - The flag of enable/disable monitoring.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 
 ## Import

--- a/website/docs/r/simple_monitor.html.markdown
+++ b/website/docs/r/simple_monitor.html.markdown
@@ -1,0 +1,102 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_simple_monitor"
+sidebar_current: "docs-sakuracloud-resource-smonitor"
+description: |-
+  Provides a SakuraCloud Simple Monitor resource. This can be used to create, modify, and delete Simple Monitors.
+---
+
+# sakuracloud\_simple\_monitor
+
+Provides a SakuraCloud Simple Monitor resource. This can be used to create, modify, and delete Simple Monitors.
+
+## Example Usage
+
+```hcl
+# Create a new Simple Monitor(protocol: https)
+resource sakuracloud_simple_monitor "foobar" {
+  target       = "www.example.com"
+  health_check = {
+    protocol    = "https"
+    delay_loop  = 60
+    path        = "/"
+    status      = "200"
+    host_header = "hostname.example.com"
+    sni         = true
+  }
+    
+  notify_email_enabled = true
+  notify_email_html    = true
+  notify_slack_enabled = true
+  notify_slack_webhook = "https://hooks.slack.com/services/XXX/XXX/XXXXXX"
+  
+  description = "description"
+  tags        = ["foo", "bar"]
+}
+
+# Create a new Simple Monitor(protocol: sslcertificate)
+resource sakuracloud_simple_monitor "cert" {
+  target = "www.example.com"
+  health_check = {
+    protocol       = "sslcertificate"
+    remaining_days = 30
+  }
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `target` - (Required) The HostName or IP address of monitoring target.
+* `health_check` - (Required) Health check rules. It contains several attributes to [Health Check](#health-check).
+* `notify_email_enabled` - (Optional) The flag of enable/disable notification by E-mail.
+* `notify_email_html` - (Optional) The flag of enable/disable HTML format for E-mail.
+* `notify_slack_enabled` - (Optional) The flag of enable/disable notification by slack.
+* `notify_slack_webhook` - (Optional) The webhook URL of destination of slack notification.
+* `enabled` - (Optional) The flag of enable/disable monitoring.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon of the resource.
+
+### Health Check
+
+Attributes for Health Check:
+
+* `protocol` - (Required) Protocol used in health check.  
+Valid value is one of the following: [ "http" / "https" / "ping" / "tcp" / "dns" / "ssh" / "smtp" / "pop3" / "snmp" / "sslcertificate" ]
+* `delay_loop` - (Optional) Health check access interval(unit:`second`). 
+* `host_header` - (Optional) The value of `Host` header used in http/https health check access.
+* `path` - (Optional) The request path used in http/https health check access.
+* `status` - (Optional) HTTP status code expected by health check access.
+* `sni` - (Optional) The flag of enable/disable SNI.
+* `port` - (Optional) Port number used in health check access.
+* `qname` - (Optional) The QName value used in dns health check access.
+* `excepcted_data` - (Optional) The expect value used in dns/snmp health check.
+* `community` - (Optional) The community name used in snmp health check.
+* `snmp_version` - (Optional) SNMP cersion used in snmp health check.
+* `oid` - (Optional) The OID used in snmp health check.
+* `remaining_days` - (Optional) The number of remaining days used in ssh-certificate check.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `target` - The HostName or IP address of monitoring target.
+* `health_check` - Health check rules. It contains several attributes to [Health Check](#health-check).
+* `notify_email_enabled` - The flag of enable/disable notification by E-mail.
+* `notify_email_html` - The flag of enable/disable HTML format for E-mail.
+* `notify_slack_enabled` - The flag of enable/disable notification by slack.
+* `notify_slack_webhook` - The webhook URL of destination of slack notification.
+* `enabled` - The flag of enable/disable monitoring.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+
+## Import
+
+Simple Monitors can be imported using the Simple Monitor ID.
+
+```
+$ terraform import sakuracloud_simple_monitor.foobar <simple_monitor_id>
+```

--- a/website/docs/r/simple_monitor.html.markdown
+++ b/website/docs/r/simple_monitor.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_simple_monitor"
-sidebar_current: "docs-sakuracloud-resource-smonitor"
+sidebar_current: "docs-sakuracloud-resource-global-simple-monitor"
 description: |-
   Provides a SakuraCloud Simple Monitor resource. This can be used to create, update, and delete Simple Monitors.
 ---

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_ssh_key"
 sidebar_current: "docs-sakuracloud-resource-ssh-key"
 description: |-
-  Provides a SakuraCloud SSH Key resource. This can be used to create, modify, and delete SSH Keys.
+  Provides a SakuraCloud SSH Key resource. This can be used to create, update, and delete SSH Keys.
 ---
 
 # sakuracloud\_ssh_key
 
-Provides a SakuraCloud SSH Key resource. This can be used to create, modify, and delete SSH Keys.
+Provides a SakuraCloud SSH Key resource. This can be used to create, update, and delete SSH Keys.
 
 ## Example Usage
 

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_ssh_key"
-sidebar_current: "docs-sakuracloud-resource-ssh-key"
+sidebar_current: "docs-sakuracloud-resource-misc-ssh-key"
 description: |-
   Provides a SakuraCloud SSH Key resource. This can be used to create, update, and delete SSH Keys.
 ---

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_ssh_key"
+sidebar_current: "docs-sakuracloud-resource-ssh-key"
+description: |-
+  Provides a SakuraCloud SSH Key resource. This can be used to create, modify, and delete SSH Keys.
+---
+
+# sakuracloud\_ssh_key
+
+Provides a SakuraCloud SSH Key resource. This can be used to create, modify, and delete SSH Keys.
+
+## Example Usage
+
+```hcl
+# Create a new SSH Key(from file)
+resource "sakuracloud_ssh_key" "foobar" {
+  name       = "foobar"
+  public_key = "${file("~/.ssh/id_rsa")}"
+}
+
+# Create a new SSH Key(from tls_private_key resource)
+resource "tls_private_key" "foobar" {
+  algorithm = "RSA"
+}
+
+resource sakuracloud_ssh_key "foobar2" {
+  name       = "foobar2"
+  public_key = "${tls_private_key.foobar.public_key_openssh}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `public_key` - (Required) The body of the public key. 
+* `description` - (Optional) The description of the resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `description` - The description of the resource.
+* `public_key` - The body of the public key. 
+* `finger_print` - The fingerprint of the public key.
+
+## Import
+
+SSH Keys can be imported using the SSH Key ID.
+
+```
+$ terraform import sakuracloud_ssh_key.foobar <ssh_key_id>
+```

--- a/website/docs/r/ssh_key_gen.html.markdown
+++ b/website/docs/r/ssh_key_gen.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_ssh_key_gen"
+sidebar_current: "docs-sakuracloud-resource-skeygen"
+description: |-
+  Provides a SakuraCloud SSH Key Gen resource. This can be used to create and delete SSH Keys.
+---
+
+# sakuracloud\_ssh_key
+
+Provides a SakuraCloud SSH Key resource. This can be used to create and delete SSH Keys.
+The private and public keys is generated on the Sakura Cloud platform.
+
+## Example Usage
+
+```hcl
+# Create a new SSH Key
+resource sakuracloud_ssh_key_gen "foobar" {
+  name        = "foobar"
+  pass_phrase = "<your-pass-phrase>"
+  description = "description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `pass_phrase` - (Optional) The path phrase of keys. 
+* `description` - (Optional) The description of the resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `description` - The description of the resource.
+* `private_key` - The body of the generated private key. 
+* `public_key` - The body of the generated public key. 
+* `finger_print` - The fingerprint of the generated public key.
+
+## Import(not supported)
+
+Import of SSH Key Gen is not supported.

--- a/website/docs/r/ssh_key_gen.html.markdown
+++ b/website/docs/r/ssh_key_gen.html.markdown
@@ -41,6 +41,6 @@ The following attributes are exported:
 * `public_key` - The body of the generated public key. 
 * `finger_print` - The fingerprint of the generated public key.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of SSH Key Gen is not supported.

--- a/website/docs/r/ssh_key_gen.html.markdown
+++ b/website/docs/r/ssh_key_gen.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_ssh_key_gen"
-sidebar_current: "docs-sakuracloud-resource-skeygen"
+sidebar_current: "docs-sakuracloud-resource-misc-skeygen"
 description: |-
   Provides a SakuraCloud SSH Key Gen resource. This can be used to create and delete SSH Keys.
 ---

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_subnet"
+sidebar_current: "docs-sakuracloud-resource-subnet"
+description: |-
+  Provides a SakuraCloud Subnet resource. This can be used to create, modify, and delete Subnets.
+---
+
+# sakuracloud\_subnet
+
+Provides a SakuraCloud Subnet resource. This can be used to create, modify, and delete Subnets.
+
+## Example Usage
+
+```hcl
+# Create a new Subnet
+resource sakuracloud_subnet "foobar" {
+  name        = "foobar"
+  description = "description"
+  tags        = ["foo", "bar"]
+ 
+  # If you want to connect to the bridge, please uncomment here.
+  #bridge_id = "${sakuracloud_bridge.br.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `internet_id` - (Required) The ID of the Internet resource.
+* `nw_mask_len` - (Optional) Network mask length.  
+Valid value is one of the following: [ 28(default) / 27 / 26 ]
+* `next_hop` - (Optional) The next hop IP address.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `nw_mask_len` - Network mask length of the Subnet.
+* `next_hop` - The next hop IP address.
+* `subnet_id` - The ID of the subnet connected to the Subnet.
+* `nw_address` -  The network address.
+* `min_ipaddress` - Minimum global ip address.
+* `max_ipaddress` - Maximum global ip address.
+* `ipaddresses` - Global ip address list.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Subnets can be imported using the Subnet ID.
+
+```
+$ terraform import sakuracloud_subnet.foobar <subnet_id>
+```

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 * `internet_id` - (Required) The ID of the Internet resource.
 * `nw_mask_len` - (Optional) Network mask length.  
-Valid value is one of the following: [ 28(default) / 27 / 26 ]
+Valid value is one of the following: [ 28 (default) / 27 / 26 ]
 * `next_hop` - (Optional) The next hop IP address.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_subnet"
-sidebar_current: "docs-sakuracloud-resource-subnet"
+sidebar_current: "docs-sakuracloud-resource-networking-subnet"
 description: |-
   Provides a SakuraCloud Subnet resource. This can be used to create, update, and delete Subnets.
 ---

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_subnet"
 sidebar_current: "docs-sakuracloud-resource-subnet"
 description: |-
-  Provides a SakuraCloud Subnet resource. This can be used to create, modify, and delete Subnets.
+  Provides a SakuraCloud Subnet resource. This can be used to create, update, and delete Subnets.
 ---
 
 # sakuracloud\_subnet
 
-Provides a SakuraCloud Subnet resource. This can be used to create, modify, and delete Subnets.
+Provides a SakuraCloud Subnet resource. This can be used to create, update, and delete Subnets.
 
 ## Example Usage
 
@@ -42,9 +42,9 @@ The following attributes are exported:
 * `next_hop` - The next hop IP address.
 * `subnet_id` - The ID of the subnet connected to the Subnet.
 * `nw_address` -  The network address.
-* `min_ipaddress` - Minimum global ip address.
-* `max_ipaddress` - Maximum global ip address.
-* `ipaddresses` - Global ip address list.
+* `min_ipaddress` - Min global IP address.
+* `max_ipaddress` - Max global IP address.
+* `ipaddresses` - Global IP address list.
 * `zone` - The ID of the zone to which the resource belongs.
 
 ## Import

--- a/website/docs/r/switch.html.markdown
+++ b/website/docs/r/switch.html.markdown
@@ -42,7 +42,7 @@ The following attributes are exported:
 
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
-* `server_ids` - The IDs of the server connected to the switch.
+* `server_ids` - The ID list of the servers connected to the switch.
 * `bridge_id` - The ID of the bridge connected to the switch.
 * `icon_id` - The ID of the icon.
 * `description` - The description of the resource.

--- a/website/docs/r/switch.html.markdown
+++ b/website/docs/r/switch.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_switch"
-sidebar_current: "docs-sakuracloud-resource-switch"
+sidebar_current: "docs-sakuracloud-resource-networking-switch"
 description: |-
   Provides a SakuraCloud Switch resource. This can be used to create, update, and delete Switches.
 ---

--- a/website/docs/r/switch.html.markdown
+++ b/website/docs/r/switch.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_switch"
 sidebar_current: "docs-sakuracloud-resource-switch"
 description: |-
-  Provides a SakuraCloud Switch resource. This can be used to create, modify, and delete Switches.
+  Provides a SakuraCloud Switch resource. This can be used to create, update, and delete Switches.
 ---
 
 # sakuracloud\_switch
 
-Provides a SakuraCloud Switch resource. This can be used to create, modify, and delete Switches.
+Provides a SakuraCloud Switch resource. This can be used to create, update, and delete Switches.
 
 ## Example Usage
 
@@ -33,7 +33,7 @@ The following arguments are supported:
 * `tags` - (Optional) The tag list of the resource.
 * `bridge_id` - (Optional) The ID of the Bridge to connect to the Switch.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference

--- a/website/docs/r/switch.html.markdown
+++ b/website/docs/r/switch.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `bridge_id` - (Optional) The ID of the Bridge to connect to the Switch.
 * `icon_id` - (Optional) The ID of the icon.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
@@ -46,7 +46,7 @@ The following attributes are exported:
 * `bridge_id` - The ID of the bridge connected to the switch.
 * `icon_id` - The ID of the icon.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `zone` - The ID of the zone to which the resource belongs.
 
 ## Import

--- a/website/docs/r/switch.html.markdown
+++ b/website/docs/r/switch.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_switch"
+sidebar_current: "docs-sakuracloud-resource-switch"
+description: |-
+  Provides a SakuraCloud Switch resource. This can be used to create, modify, and delete Switches.
+---
+
+# sakuracloud\_switch
+
+Provides a SakuraCloud Switch resource. This can be used to create, modify, and delete Switches.
+
+## Example Usage
+
+```hcl
+# Create a new Switch
+resource sakuracloud_switch "foobar" {
+  name        = "foobar"
+  description = "description"
+  tags        = ["foo", "bar"]
+ 
+  # If you want to connect to the bridge, please uncomment here.
+  #bridge_id = "${sakuracloud_bridge.br.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `bridge_id` - (Optional) The ID of the Bridge to connect to the Switch.
+* `icon_id` - (Optional) The ID of the icon.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the server connected to the resource.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `server_ids` - The IDs of the server connected to the switch.
+* `bridge_id` - The ID of the bridge connected to the switch.
+* `icon_id` - The ID of the icon.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+Switches can be imported using the Switch ID.
+
+```
+$ terraform import sakuracloud_switch.foobar <switch_id>
+```

--- a/website/docs/r/switch.html.markdown
+++ b/website/docs/r/switch.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
 * `tags` - (Optional) The tag list of the resources.
 * `bridge_id` - (Optional) The ID of the Bridge to connect to the Switch.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the server connected to the resource.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the server connected to the resource.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference

--- a/website/docs/r/vpc_router.html.markdown
+++ b/website/docs/r/vpc_router.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router"
 sidebar_current: "docs-sakuracloud-resource-vpc-router"
 description: |-
-  Provides a SakuraCloud VPC Router resource. This can be used to create, modify, and delete VPC Routers.
+  Provides a SakuraCloud VPC Router resource. This can be used to create, update, and delete VPC Routers.
 ---
 
 # sakuracloud\_vpc\_router
 
-Provides a SakuraCloud VPC Router resource. This can be used to create, modify, and delete VPC Routers.
+Provides a SakuraCloud VPC Router resource. This can be used to create, update, and delete VPC Routers.
 
 ## Example Usage
 
@@ -45,16 +45,16 @@ The following arguments are supported:
 * `name` - (Required) The name of the resource.
 * `plan` - (Optional) The plan of the VPC Router.   
 Valid value is one of the following: [ "standard"(default) / "premium" / "highspec" ]
-* `switch_id` - (Required) The ID of the switch connected to the VPC Router. It is used only when plan is `premium` or `highspec`.
+* `switch_id` - (Required) The ID of the switch connected to the VPC Router. Used when plan is `premium` or `highspec`.
 * `vrid` - (Required) VRID used when plan is `premium` or `highspec`.
 * `ipaddress1` - (Required) The primary IP address of the VPC Router.
-* `ipaddress2` - (Optional) The secondly IP address of the VPC Router. It is used only when plan is `premium` or `highspec`.
-* `vip` - (Optional) The Virtual IP address of the VPC Router. It is used only when plan is `premium` or `highspec`.
-* `aliases` - (Optional) The IP address aliase list. It is used only when plan is `premium` or `highspec`.
+* `ipaddress2` - (Optional) The secondly IP address of the VPC Router. Used when plan is `premium` or `highspec`.
+* `vip` - (Optional) The Virtual IP address of the VPC Router. Used when plan is `premium` or `highspec`.
+* `aliases` - (Optional) The IP address aliase list. Used when plan is `premium` or `highspec`.
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resource.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the VPC Router.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the VPC Router.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -65,11 +65,11 @@ The following attributes are exported:
 * `name` - The name of the resource.
 * `plan` - The name of the resource plan. 
 * `switch_id` - The ID of the Switch connected to the VPC Router(eth0).
-* `vip` - Virtual IP address of the VPC Router. It is used only when plan is in `premium` or `highspec`.
+* `vip` - Virtual IP address of the VPC Router. Used when plan is in `premium` or `highspec`.
 * `ipaddress1` - The primary IP address of the VPC Router.
-* `ipaddress2` - The secondly IP address of the VPC Router. It is used only when plan is in `premium` or `highspec`.
+* `ipaddress2` - The secondly IP address of the VPC Router. Used when plan is in `premium` or `highspec`.
 * `vrid` - VRID used when plan is in `premium` or `highspec`.
-* `aliases` - The IP address aliase list. It is used only when plan is in `premium` or `highspec`.
+* `aliases` - The IP address aliase list. Used when plan is in `premium` or `highspec`.
 * `global_address` - Global IP address of the VPC Router.
 * `syslog_host` - The destination HostName/IP address to send log.	
 * `internet_connection` - The flag of enable/disable connection from the VPC Router to the Internet.

--- a/website/docs/r/vpc_router.html.markdown
+++ b/website/docs/r/vpc_router.html.markdown
@@ -52,7 +52,7 @@ Valid value is one of the following: [ "standard"(default) / "premium" / "highsp
 * `vip` - (Optional) The Virtual IP address of the VPC Router. Used when plan is `premium` or `highspec`.
 * `aliases` - (Optional) The IP address aliase list. Used when plan is `premium` or `highspec`.
 * `description` - (Optional) The description of the resource.
-* `tags` - (Optional) The tag list of the resource.
+* `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the VPC Router.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
@@ -74,7 +74,7 @@ The following attributes are exported:
 * `syslog_host` - The destination HostName/IP address to send log.	
 * `internet_connection` - The flag of enable/disable connection from the VPC Router to the Internet.
 * `description` - The description of the resource.
-* `tags` - The tag list of the resource.
+* `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 

--- a/website/docs/r/vpc_router.html.markdown
+++ b/website/docs/r/vpc_router.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
 * `plan` - (Optional) The plan of the VPC Router.   
-Valid value is one of the following: [ "standard"(default) / "premium" / "highspec" ]
+Valid value is one of the following: [ "standard" (default) / "premium" / "highspec" ]
 * `switch_id` - (Required) The ID of the switch connected to the VPC Router. Used when plan is `premium` or `highspec`.
 * `vrid` - (Required) VRID used when plan is `premium` or `highspec`.
 * `ipaddress1` - (Required) The primary IP address of the VPC Router.
@@ -54,7 +54,7 @@ Valid value is one of the following: [ "standard"(default) / "premium" / "highsp
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
 * `icon_id` - (Optional) The ID of the icon.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the VPC Router.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the VPC Router.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -64,7 +64,7 @@ The following attributes are exported:
 * `id` - The ID of the resource.
 * `name` - The name of the resource.
 * `plan` - The name of the resource plan. 
-* `switch_id` - The ID of the Switch connected to the VPC Router(eth0).
+* `switch_id` - The ID of the Switch connected to the VPC Router (eth0).
 * `vip` - Virtual IP address of the VPC Router. Used when plan is in `premium` or `highspec`.
 * `ipaddress1` - The primary IP address of the VPC Router.
 * `ipaddress2` - The secondly IP address of the VPC Router. Used when plan is in `premium` or `highspec`.

--- a/website/docs/r/vpc_router.html.markdown
+++ b/website/docs/r/vpc_router.html.markdown
@@ -1,0 +1,87 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router"
+sidebar_current: "docs-sakuracloud-resource-vpc-router"
+description: |-
+  Provides a SakuraCloud VPC Router resource. This can be used to create, modify, and delete VPC Routers.
+---
+
+# sakuracloud\_vpc\_router
+
+Provides a SakuraCloud VPC Router resource. This can be used to create, modify, and delete VPC Routers.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+  
+  #syslog_host         = "192.168.11.1"
+  #internet_connection = true
+  
+  description    = "description"
+  tags           = ["foo", "bar"]
+}
+
+# Create a new VPC Router(premium or highspec)
+resource sakuracloud_vpc_router "foobar1" {
+  name                = "foobar"
+  plan                = "premium"
+  switch_id           = "${sakuracloud_internet.foobar.switch_id}"
+  vip                 = "${sakuracloud_internet.foobar.ipaddresses[0]}"
+  ipaddress1          = "${sakuracloud_internet.foobar.ipaddresses[1]}"
+  ipaddress2          = "${sakuracloud_internet.foobar.ipaddresses[2]}"
+  #aliases             = ["${sakuracloud_internet.foobar.ipaddresses[3]}"] 
+  vrid                = 1
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the resource.
+* `plan` - (Optional) The plan of the VPC Router.   
+Valid value is one of the following: [ "standard"(default) / "premium" / "highspec" ]
+* `switch_id` - (Required) The ID of the switch connected to the VPC Router. It is used only when plan is `premium` or `highspec`.
+* `vrid` - (Required) VRID used when plan is `premium` or `highspec`.
+* `ipaddress1` - (Required) The primary IP address of the VPC Router.
+* `ipaddress2` - (Optional) The secondly IP address of the VPC Router. It is used only when plan is `premium` or `highspec`.
+* `vip` - (Optional) The Virtual IP address of the VPC Router. It is used only when plan is `premium` or `highspec`.
+* `aliases` - (Optional) The IP address aliase list. It is used only when plan is `premium` or `highspec`.
+* `description` - (Optional) The description of the resource.
+* `tags` - (Optional) The tag list of the resource.
+* `icon_id` - (Optional) The ID of the icon.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the VPC Router.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The name of the resource.
+* `plan` - The name of the resource plan. 
+* `switch_id` - The ID of the Switch connected to the VPC Router(eth0).
+* `vip` - Virtual IP address of the VPC Router. It is used only when plan is in `premium` or `highspec`.
+* `ipaddress1` - The primary IP address of the VPC Router.
+* `ipaddress2` - The secondly IP address of the VPC Router. It is used only when plan is in `premium` or `highspec`.
+* `vrid` - VRID used when plan is in `premium` or `highspec`.
+* `aliases` - The IP address aliase list. It is used only when plan is in `premium` or `highspec`.
+* `global_address` - Global IP address of the VPC Router.
+* `syslog_host` - The destination HostName/IP address to send log.	
+* `internet_connection` - The flag of enable/disable connection from the VPC Router to the Internet.
+* `description` - The description of the resource.
+* `tags` - The tag list of the resource.
+* `icon_id` - The ID of the icon of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import
+
+VPC Routers can be imported using the VPC Router ID.
+
+```
+$ terraform import sakuracloud_vpc_router.foobar <vpc_router_id>
+```

--- a/website/docs/r/vpc_router_dhcp_server.html.markdown
+++ b/website/docs/r/vpc_router_dhcp_server.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_dhcp_server"
-sidebar_current: "docs-sakuracloud-resource-vdhcpserver"
+sidebar_current: "docs-sakuracloud-resource-vpc-dhcpserver"
 description: |-
   Provides a SakuraCloud VPC Router DHCP Server resource. This can be used to create, update, and delete VPC Router DHCP Servers.
 ---

--- a/website/docs/r/vpc_router_dhcp_server.html.markdown
+++ b/website/docs/r/vpc_router_dhcp_server.html.markdown
@@ -59,6 +59,6 @@ The following attributes are exported:
 * `dns_servers` - DNS server list to be assigned by DHCP.  
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router DHCP Server is not supported.

--- a/website/docs/r/vpc_router_dhcp_server.html.markdown
+++ b/website/docs/r/vpc_router_dhcp_server.html.markdown
@@ -1,0 +1,64 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_dhcp_server"
+sidebar_current: "docs-sakuracloud-resource-vdhcpserver"
+description: |-
+  Provides a SakuraCloud VPC Router DHCP Server resource. This can be used to create, modify, and delete VPC Router DHCP Servers.
+---
+
+# sakuracloud\_vpc\_router\_dhcp\_server
+
+Provides a SakuraCloud VPC Router DHCP Server resource. This can be used to create, modify, and delete VPC Router DHCP Servers.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+}
+
+# Add NIC to the VPC Router
+resource sakuracloud_vpc_router_interface "eth1"{
+  vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+  index         = 1
+  switch_id     = "${sakuracloud_switch.foobar.id}"
+  ipaddress     = ["192.168.2.1"]
+  nw_mask_len   = 24
+}
+
+# Create a new DHCP Server under the VPC Router
+resource "sakuracloud_vpc_router_dhcp_server" "foobar" {
+  vpc_router_id              = "${sakuracloud_vpc_router.foobar.id}"
+  vpc_router_interface_index = "${sakuracloud_vpc_router_interface.eth1.index}"
+
+  range_start = "192.168.2.101"
+  range_stop  = "192.168.2.200"
+  dns_servers = ["8.8.8.8", "8.8.4.4"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `vpc_router_interface_index` - (Required) The NIC index of VPC Router running DHCP Server.
+* `range_start` - (Required) Start IP address of address range to be assigned by DHCP.
+* `range_stop` - (Required) End IP address of address range to be assigned by DHCP.
+* `dns_servers` - (Required) DNS server list to be assigned by DHCP.  
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `range_start` - Start IP address of address range to be assigned by DHCP.
+* `range_stop` - End IP address of address range to be assigned by DHCP.
+* `dns_servers` - DNS server list to be assigned by DHCP.  
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router DHCP Server is not supported.

--- a/website/docs/r/vpc_router_dhcp_server.html.markdown
+++ b/website/docs/r/vpc_router_dhcp_server.html.markdown
@@ -19,7 +19,7 @@ resource sakuracloud_vpc_router "foobar" {
 }
 
 # Add NIC to the VPC Router
-resource sakuracloud_vpc_router_interface "eth1"{
+resource sakuracloud_vpc_router_interface "eth1" {
   vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
   index         = 1
   switch_id     = "${sakuracloud_switch.foobar.id}"

--- a/website/docs/r/vpc_router_dhcp_server.html.markdown
+++ b/website/docs/r/vpc_router_dhcp_server.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_dhcp_server"
 sidebar_current: "docs-sakuracloud-resource-vdhcpserver"
 description: |-
-  Provides a SakuraCloud VPC Router DHCP Server resource. This can be used to create, modify, and delete VPC Router DHCP Servers.
+  Provides a SakuraCloud VPC Router DHCP Server resource. This can be used to create, update, and delete VPC Router DHCP Servers.
 ---
 
 # sakuracloud\_vpc\_router\_dhcp\_server
 
-Provides a SakuraCloud VPC Router DHCP Server resource. This can be used to create, modify, and delete VPC Router DHCP Servers.
+Provides a SakuraCloud VPC Router DHCP Server resource. This can be used to create, update, and delete VPC Router DHCP Servers.
 
 ## Example Usage
 

--- a/website/docs/r/vpc_router_dhcp_static_mapping.html.markdown
+++ b/website/docs/r/vpc_router_dhcp_static_mapping.html.markdown
@@ -66,6 +66,6 @@ The following attributes are exported:
 * `ipaddress` - The MAC address to be the key of the mapping. 
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router DHCP Static Mapping is not supported.

--- a/website/docs/r/vpc_router_dhcp_static_mapping.html.markdown
+++ b/website/docs/r/vpc_router_dhcp_static_mapping.html.markdown
@@ -19,7 +19,7 @@ resource sakuracloud_vpc_router "foobar" {
 }
 
 # Add NIC to the VPC Router
-resource sakuracloud_vpc_router_interface "eth1"{
+resource sakuracloud_vpc_router_interface "eth1" {
   vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
   index         = 1
   switch_id     = "${sakuracloud_switch.foobar.id}"

--- a/website/docs/r/vpc_router_dhcp_static_mapping.html.markdown
+++ b/website/docs/r/vpc_router_dhcp_static_mapping.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_dhcp_static_mapping"
+sidebar_current: "docs-sakuracloud-resource-vdhcpmapping"
+description: |-
+  Provides a SakuraCloud VPC Router DHCP Static Mapping resource. This can be used to create and delete VPC Router DHCP Static Mappings.
+---
+
+# sakuracloud\_vpc\_router\_dhcp\_static\_mapping
+
+Provides a SakuraCloud VPC Router DHCP Static Mapping resource. This can be used to create and delete VPC Router DHCP Static Mappings.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+}
+
+# Add NIC to the VPC Router
+resource sakuracloud_vpc_router_interface "eth1"{
+  vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+  index         = 1
+  switch_id     = "${sakuracloud_switch.foobar.id}"
+  ipaddress     = ["192.168.2.1"]
+  nw_mask_len   = 24
+}
+
+# Create a new DHCP Server under the VPC Router
+resource sakuracloud_vpc_router_dhcp_server "foobar" {
+  vpc_router_id              = "${sakuracloud_vpc_router.foobar.id}"
+  vpc_router_interface_index = "${sakuracloud_vpc_router_interface.eth1.index}"
+
+  range_start = "192.168.2.101"
+  range_stop  = "192.168.2.200"
+  dns_servers = ["8.8.8.8", "8.8.4.4"]
+}
+
+# Create a new DHCP Static Mapping config
+resource sakuracloud_vpc_router_dhcp_static_mapping "dhcp_map" {
+    vpc_router_id             = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_dhcp_server_id = "${sakuracloud_vpc_router_dhcp_server.foobar.id}"
+
+    macaddress = "aa:bb:cc:aa:bb:cc"
+    ipaddress = "192.168.2.51"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `vpc_router_dhcp_server_id` - (Required) The ID of VPC Router DHCP Server.
+* `macaddress` - (Required) The IP address mapped by MAC address.
+* `ipaddress` - (Required) The MAC address to be the key of the mapping. 
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `macaddress` - The IP address mapped by MAC address.
+* `ipaddress` - The MAC address to be the key of the mapping. 
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router DHCP Static Mapping is not supported.

--- a/website/docs/r/vpc_router_dhcp_static_mapping.html.markdown
+++ b/website/docs/r/vpc_router_dhcp_static_mapping.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_dhcp_static_mapping"
-sidebar_current: "docs-sakuracloud-resource-vdhcpmapping"
+sidebar_current: "docs-sakuracloud-resource-vpc-dhcpmapping"
 description: |-
   Provides a SakuraCloud VPC Router DHCP Static Mapping resource. This can be used to create and delete VPC Router DHCP Static Mappings.
 ---

--- a/website/docs/r/vpc_router_firewall.html.markdown
+++ b/website/docs/r/vpc_router_firewall.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `vpc_router_id` - (Required) The ID of the Internet resource.
 * `vpc_router_interface_index` - (Required) The NIC index of VPC Router.
-* `direction` - (Required) Direction of filtering packets.
+* `direction` - (Required) Direction of filtering packets.  
 Valid value is one of the following: [ "send" / "receive" ]
 * `expressions` - (Required) Filtering rules. It contains some attributes to [Expressions](#expressions).
 * `zone` - (Optional) The ID of the zone to which the resource belongs.

--- a/website/docs/r/vpc_router_firewall.html.markdown
+++ b/website/docs/r/vpc_router_firewall.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_firewall"
-sidebar_current: "docs-sakuracloud-resource-vfirewall"
+sidebar_current: "docs-sakuracloud-resource-vpc-firewall"
 description: |-
   Provides a SakuraCloud VPC Router Firewall resource. This can be used to create and delete VPC Router Firewalls.
 ---

--- a/website/docs/r/vpc_router_firewall.html.markdown
+++ b/website/docs/r/vpc_router_firewall.html.markdown
@@ -19,7 +19,7 @@ resource sakuracloud_vpc_router "foobar" {
 }
 
 # Add NIC to the VPC Router
-resource sakuracloud_vpc_router_interface "eth1"{
+resource sakuracloud_vpc_router_interface "eth1" {
   vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
   index         = 1
   switch_id     = "${sakuracloud_switch.foobar.id}"

--- a/website/docs/r/vpc_router_firewall.html.markdown
+++ b/website/docs/r/vpc_router_firewall.html.markdown
@@ -84,7 +84,7 @@ Valid format is one of the following:
 Valid format is one of the following:
   * Number: `"0"` - `"65535"`
   * Range: `"xx-yy"`
-  * Range(hex): `"0xPPPP/0xMMMM"`
+  * Range (hex): `"0xPPPP/0xMMMM"`
 * `dest_nw` - (Required) Target destination network IP address or CIDR or range.  
   Valid format is one of the following:   
     * IP address: `"xxx.xxx.xxx.xxx"`
@@ -94,7 +94,7 @@ Valid format is one of the following:
 Valid format is one of the following:
   * Number: `"0"` - `"65535"`
   * Range: `"xx-yy"`
-  * Range(hex): `"0xPPPP/0xMMMM"`
+  * Range (hex): `"0xPPPP/0xMMMM"`
 * `allow` - (Required) The flag for allow/deny packets.
 * `logging` - (Required) The flag for enable/disable logging.
 * `description` - (Optional) The description of the expression.

--- a/website/docs/r/vpc_router_firewall.html.markdown
+++ b/website/docs/r/vpc_router_firewall.html.markdown
@@ -1,0 +1,113 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_firewall"
+sidebar_current: "docs-sakuracloud-resource-vfirewall"
+description: |-
+  Provides a SakuraCloud VPC Router Firewall resource. This can be used to create and delete VPC Router Firewalls.
+---
+
+# sakuracloud\_vpc\_router\_firewall
+
+Provides a SakuraCloud VPC Router Firewall resource. This can be used to create and delete VPC Router Firewalls.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+}
+
+# Add NIC to the VPC Router
+resource sakuracloud_vpc_router_interface "eth1"{
+  vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+  index         = 1
+  switch_id     = "${sakuracloud_switch.foobar.id}"
+  ipaddress     = ["192.168.2.1"]
+  nw_mask_len   = 24
+}
+
+# Create a new Firewall config
+resource "sakuracloud_vpc_router_firewall" "send_fw" {
+  vpc_router_id              = "${sakuracloud_vpc_router.foobar.id}"
+  vpc_router_interface_index = 1
+  
+  direction   = "send"
+  expressions = {
+    protocol    = "tcp"
+    source_nw   = ""
+    source_port = "80"
+    dest_nw     = ""
+    dest_port   = ""
+    allow       = true
+    logging     = true
+    description = "allow http"
+  }
+
+  expressions = {
+    protocol    = "ip"
+    source_nw   = ""
+    source_port = ""
+    dest_nw     = ""
+    dest_port   = ""
+    allow       = false
+    logging     = false
+    description = "deny all"
+  }
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `vpc_router_interface_index` - (Required) The NIC index of VPC Router.
+* `direction` - (Required) Direction of filtering packets.
+Valid value is one of the following: [ "send" / "receive" ]
+* `expressions` - (Required) Filtering rules. It contains several attributes to [Expressions](#expressions).
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+### Expressions
+
+Attributes for Expressions:
+
+* `protocol` - (Required) Protocol used in health check.  
+Valid value is one of the following: [ "tcp" / "udp" / "icmp" / "ip" ]
+* `source_nw` - (Required) Target source network IP address or CIDR or range.  
+Valid format is one of the following:   
+  * IP address: `"xxx.xxx.xxx.xxx"`
+  * CIDR: `"xxx.xxx.xxx.xxx/nn"`
+  * Range: `"xxx.xxx.xxx.xxx/yyy.yyy.yyy.yyy"`
+* `source_port` - (Required) Target source port.
+Valid format is one of the following:
+  * Number: `"0"` - `"65535"`
+  * Range: `"xx-yy"`
+  * Range(hex): `"0xPPPP/0xMMMM"`
+* `dest_nw` - (Required) Target destination network IP address or CIDR or range.  
+  Valid format is one of the following:   
+    * IP address: `"xxx.xxx.xxx.xxx"`
+    * CIDR: `"xxx.xxx.xxx.xxx/nn"`
+    * Range: `"xxx.xxx.xxx.xxx/yyy.yyy.yyy.yyy"`
+* `dest_port` - (Required) Target destination port.
+Valid format is one of the following:
+  * Number: `"0"` - `"65535"`
+  * Range: `"xx-yy"`
+  * Range(hex): `"0xPPPP/0xMMMM"`
+* `allow` - (Required) The flag for allow/deny packets.
+* `logging` - (Required) The flag for enable/disable logging.
+* `description` - (Optional) The description of the expression.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `direction` - Direction of filtering packets.
+* `expressions` - Filtering rules. It contains several attributes to [Expressions](#expressions).
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router Firewall is not supported.

--- a/website/docs/r/vpc_router_firewall.html.markdown
+++ b/website/docs/r/vpc_router_firewall.html.markdown
@@ -108,6 +108,6 @@ The following attributes are exported:
 * `expressions` - Filtering rules. It contains some attributes to [Expressions](#expressions).
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router Firewall is not supported.

--- a/website/docs/r/vpc_router_firewall.html.markdown
+++ b/website/docs/r/vpc_router_firewall.html.markdown
@@ -66,7 +66,7 @@ The following arguments are supported:
 * `vpc_router_interface_index` - (Required) The NIC index of VPC Router.
 * `direction` - (Required) Direction of filtering packets.
 Valid value is one of the following: [ "send" / "receive" ]
-* `expressions` - (Required) Filtering rules. It contains several attributes to [Expressions](#expressions).
+* `expressions` - (Required) Filtering rules. It contains some attributes to [Expressions](#expressions).
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ### Expressions
@@ -105,7 +105,7 @@ The following attributes are exported:
 
 * `id` - The ID of the resource.
 * `direction` - Direction of filtering packets.
-* `expressions` - Filtering rules. It contains several attributes to [Expressions](#expressions).
+* `expressions` - Filtering rules. It contains some attributes to [Expressions](#expressions).
 * `zone` - The ID of the zone to which the resource belongs.
 
 ## Import(not supported)

--- a/website/docs/r/vpc_router_interface.html.markdown
+++ b/website/docs/r/vpc_router_interface.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_interface"
+sidebar_current: "docs-sakuracloud-resource-vinterface"
+description: |-
+  Provides a SakuraCloud VPC Router Interface resource. This can be used to create and delete VPC Router Interfaces.
+---
+
+# sakuracloud\_vpc\_router\_interface
+
+Provides a SakuraCloud VPC Router Interface resource. This can be used to create and delete VPC Router Interfaces.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+}
+
+# Add NIC to the VPC Router
+resource sakuracloud_vpc_router_interface "eth1"{
+  vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+  index         = 1
+  switch_id     = "${sakuracloud_switch.foobar.id}"
+  ipaddress     = ["192.168.2.1"]
+  nw_mask_len   = 24
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `index` - (Required) The NIC index of VPC Router Interface.
+* `switch_id` - (Required) The ID of the switch connected to the VPC Router.
+* `ipaddresses` - (Required) The IP address list of the VPC Router Interface.
+* `vip` - (Optional) The Virtual IP address of the VPC Router Interface. It is used only when VPC Router's plan is `premium` or `highspec`.
+* `nw_mask_len` - (Optional) Network mask length of the VPC Router Interface.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the VPC Router.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `vpc_router_id` - The ID of the Internet resource.
+* `index` - The NIC index of VPC Router Interface.
+* `switch_id` - The ID of the switch connected to the VPC Router.
+* `ipaddresses` - The IP address list of the VPC Router Interface.
+* `vip` - The Virtual IP address of the VPC Router Interface. It is used only when VPC Router's plan is `premium` or `highspec`.
+* `nw_mask_len` - Network mask length of the VPC Router Interface.
+* `graceful_shutdown_timeout` - The wait time(seconds) to gracefully shutdown the VPC Router.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router Interface is not supported.

--- a/website/docs/r/vpc_router_interface.html.markdown
+++ b/website/docs/r/vpc_router_interface.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 * `ipaddresses` - (Required) The IP address list of the VPC Router Interfaces.
 * `vip` - (Optional) The Virtual IP address of the VPC Router Interface. Used when VPC Router's plan is `premium` or `highspec`.
 * `nw_mask_len` - (Optional) Network mask length of the VPC Router Interface.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the VPC Router.
+* `graceful_shutdown_timeout` - (Optional) The wait time (seconds) to do graceful shutdown the VPC Router.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -53,9 +53,9 @@ The following attributes are exported:
 * `ipaddresses` - The IP address list of the VPC Router Interfaces.
 * `vip` - The Virtual IP address of the VPC Router Interface. Used when VPC Router's plan is `premium` or `highspec`.
 * `nw_mask_len` - Network mask length of the VPC Router Interface.
-* `graceful_shutdown_timeout` - The wait time(seconds) to do graceful shutdown the VPC Router.
+* `graceful_shutdown_timeout` - The wait time (seconds) to do graceful shutdown the VPC Router.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router Interface is not supported.

--- a/website/docs/r/vpc_router_interface.html.markdown
+++ b/website/docs/r/vpc_router_interface.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `vpc_router_id` - (Required) The ID of the Internet resource.
 * `index` - (Required) The NIC index of VPC Router Interface.
 * `switch_id` - (Required) The ID of the switch connected to the VPC Router.
-* `ipaddresses` - (Required) The IP address list of the VPC Router Interface.
+* `ipaddresses` - (Required) The IP address list of the VPC Router Interfaces.
 * `vip` - (Optional) The Virtual IP address of the VPC Router Interface. Used when VPC Router's plan is `premium` or `highspec`.
 * `nw_mask_len` - (Optional) Network mask length of the VPC Router Interface.
 * `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the VPC Router.
@@ -50,7 +50,7 @@ The following attributes are exported:
 * `vpc_router_id` - The ID of the Internet resource.
 * `index` - The NIC index of VPC Router Interface.
 * `switch_id` - The ID of the switch connected to the VPC Router.
-* `ipaddresses` - The IP address list of the VPC Router Interface.
+* `ipaddresses` - The IP address list of the VPC Router Interfaces.
 * `vip` - The Virtual IP address of the VPC Router Interface. Used when VPC Router's plan is `premium` or `highspec`.
 * `nw_mask_len` - Network mask length of the VPC Router Interface.
 * `graceful_shutdown_timeout` - The wait time(seconds) to do graceful shutdown the VPC Router.

--- a/website/docs/r/vpc_router_interface.html.markdown
+++ b/website/docs/r/vpc_router_interface.html.markdown
@@ -19,7 +19,7 @@ resource sakuracloud_vpc_router "foobar" {
 }
 
 # Add NIC to the VPC Router
-resource sakuracloud_vpc_router_interface "eth1"{
+resource sakuracloud_vpc_router_interface "eth1" {
   vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
   index         = 1
   switch_id     = "${sakuracloud_switch.foobar.id}"

--- a/website/docs/r/vpc_router_interface.html.markdown
+++ b/website/docs/r/vpc_router_interface.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_interface"
-sidebar_current: "docs-sakuracloud-resource-vinterface"
+sidebar_current: "docs-sakuracloud-resource-vpc-interface"
 description: |-
   Provides a SakuraCloud VPC Router Interface resource. This can be used to create and delete VPC Router Interfaces.
 ---

--- a/website/docs/r/vpc_router_interface.html.markdown
+++ b/website/docs/r/vpc_router_interface.html.markdown
@@ -37,9 +37,9 @@ The following arguments are supported:
 * `index` - (Required) The NIC index of VPC Router Interface.
 * `switch_id` - (Required) The ID of the switch connected to the VPC Router.
 * `ipaddresses` - (Required) The IP address list of the VPC Router Interface.
-* `vip` - (Optional) The Virtual IP address of the VPC Router Interface. It is used only when VPC Router's plan is `premium` or `highspec`.
+* `vip` - (Optional) The Virtual IP address of the VPC Router Interface. Used when VPC Router's plan is `premium` or `highspec`.
 * `nw_mask_len` - (Optional) Network mask length of the VPC Router Interface.
-* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to gracefully shutdown the VPC Router.
+* `graceful_shutdown_timeout` - (Optional) The wait time(seconds) to do graceful shutdown the VPC Router.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -51,9 +51,9 @@ The following attributes are exported:
 * `index` - The NIC index of VPC Router Interface.
 * `switch_id` - The ID of the switch connected to the VPC Router.
 * `ipaddresses` - The IP address list of the VPC Router Interface.
-* `vip` - The Virtual IP address of the VPC Router Interface. It is used only when VPC Router's plan is `premium` or `highspec`.
+* `vip` - The Virtual IP address of the VPC Router Interface. Used when VPC Router's plan is `premium` or `highspec`.
 * `nw_mask_len` - Network mask length of the VPC Router Interface.
-* `graceful_shutdown_timeout` - The wait time(seconds) to gracefully shutdown the VPC Router.
+* `graceful_shutdown_timeout` - The wait time(seconds) to do graceful shutdown the VPC Router.
 * `zone` - The ID of the zone to which the resource belongs.
 
 ## Import(not supported)

--- a/website/docs/r/vpc_router_l2tp.html.markdown
+++ b/website/docs/r/vpc_router_l2tp.html.markdown
@@ -60,6 +60,6 @@ The following attributes are exported:
 * `range_stop` - End IP address of address range to be assigned by L2TP.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router L2TP is not supported.

--- a/website/docs/r/vpc_router_l2tp.html.markdown
+++ b/website/docs/r/vpc_router_l2tp.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_l2tp"
 sidebar_current: "docs-sakuracloud-resource-vl2tp"
 description: |-
-  Provides a SakuraCloud VPC Router L2TP resource. This can be used to create, modify, and delete VPC Router L2TP.
+  Provides a SakuraCloud VPC Router L2TP resource. This can be used to create, update, and delete VPC Router L2TP.
 ---
 
 # sakuracloud\_vpc\_router\_l2tp
 
-Provides a SakuraCloud VPC Router L2TP resource. This can be used to create, modify, and delete VPC Router L2TP.
+Provides a SakuraCloud VPC Router L2TP resource. This can be used to create, update, and delete VPC Router L2TP.
 
 ## Example Usage
 

--- a/website/docs/r/vpc_router_l2tp.html.markdown
+++ b/website/docs/r/vpc_router_l2tp.html.markdown
@@ -1,0 +1,65 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_l2tp"
+sidebar_current: "docs-sakuracloud-resource-vl2tp"
+description: |-
+  Provides a SakuraCloud VPC Router L2TP resource. This can be used to create, modify, and delete VPC Router L2TP.
+---
+
+# sakuracloud\_vpc\_router\_l2tp
+
+Provides a SakuraCloud VPC Router L2TP resource. This can be used to create, modify, and delete VPC Router L2TP.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+}
+
+# Add NIC to the VPC Router
+resource sakuracloud_vpc_router_interface "eth1" {
+  vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+  index         = 1
+  switch_id     = "${sakuracloud_switch.foobar.id}"
+  ipaddress     = ["192.168.2.1"]
+  nw_mask_len   = 24
+}
+
+# Create a new L2TP config.
+resource sakuracloud_vpc_router_l2tp "l2tp" {
+    vpc_router_id           = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
+
+    pre_shared_secret = "pre-shared-secret"
+    range_start       = "192.168.2.51"
+    range_stop        = "192.168.2.100"
+
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `vpc_router_interface_id` - (Required) The ID of VPC Router Interface.
+* `pre_shared_secret` - (Required) The pre shared secret for L2TP.
+* `range_start` - (Required) Start IP address of address range to be assigned by L2TP.
+* `range_stop` - (Required) End IP address of address range to be assigned by L2TP.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `pre_shared_secret` - The pre shared secret for L2TP.
+* `range_start` - Start IP address of address range to be assigned by L2TP.
+* `range_stop` - End IP address of address range to be assigned by L2TP.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router L2TP is not supported.

--- a/website/docs/r/vpc_router_l2tp.html.markdown
+++ b/website/docs/r/vpc_router_l2tp.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_l2tp"
-sidebar_current: "docs-sakuracloud-resource-vl2tp"
+sidebar_current: "docs-sakuracloud-resource-vpc-l2tp"
 description: |-
   Provides a SakuraCloud VPC Router L2TP resource. This can be used to create, update, and delete VPC Router L2TP.
 ---

--- a/website/docs/r/vpc_router_port_forwarding.html.markdown
+++ b/website/docs/r/vpc_router_port_forwarding.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_port_forwarding"
-sidebar_current: "docs-sakuracloud-resource-vpf"
+sidebar_current: "docs-sakuracloud-resource-vpc-pf"
 description: |-
   Provides a SakuraCloud VPC Router Port Forwarding resource. This can be used to create, update, and delete VPC Router Port Forwarding.
 ---

--- a/website/docs/r/vpc_router_port_forwarding.html.markdown
+++ b/website/docs/r/vpc_router_port_forwarding.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 * `vpc_router_id` - (Required) The ID of the Internet resource.
 * `vpc_router_interface_id` - (Required) The ID of VPC Router Interface.
 * `protocol` - (Required) The target protocol of the Port Forwarding.  
-Valid value is one of the following: [ "tcp"(default) / "udp" ]
+Valid value is one of the following: [ "tcp" (default) / "udp" ]
 * `global_port` - (Required) The global port of the Port Forwarding.
 * `private_address` - (Required) The destination private IP address of the Port Forwarding.
 * `private_port` - (Required) The destination port number of the Port Forwarding.
@@ -67,6 +67,6 @@ The following attributes are exported:
 * `description` - The description of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router Port Forwarding is not supported.

--- a/website/docs/r/vpc_router_port_forwarding.html.markdown
+++ b/website/docs/r/vpc_router_port_forwarding.html.markdown
@@ -1,0 +1,72 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_port_forwarding"
+sidebar_current: "docs-sakuracloud-resource-vpf"
+description: |-
+  Provides a SakuraCloud VPC Router Port Forwarding resource. This can be used to create, modify, and delete VPC Router Port Forwarding.
+---
+
+# sakuracloud\_vpc\_router\_port_forwarding
+
+Provides a SakuraCloud VPC Router Port Forwarding resource. This can be used to create, modify, and delete VPC Router Port Forwarding.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+}
+
+# Add NIC to the VPC Router
+resource sakuracloud_vpc_router_interface "eth1" {
+  vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+  index         = 1
+  switch_id     = "${sakuracloud_switch.foobar.id}"
+  ipaddress     = ["192.168.2.1"]
+  nw_mask_len   = 24
+}
+
+# Add Port Forwarding rule to the VPC Router
+resource "sakuracloud_vpc_router_port_forwarding" "forward1" {
+    vpc_router_id           = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
+
+    protocol        = "tcp"
+    global_port     = 10022
+    private_address = "192.168.2.11"
+    private_port    = 22
+    description     = "description"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `vpc_router_interface_id` - (Required) The ID of VPC Router Interface.
+* `protocol` - (Required) The target protocol of the Port Forwarding.  
+Valid value is one of the following: [ "tcp"(default) / "udp" ]
+* `global_port` - (Required) The global port of the Port Forwarding.
+* `private_address` - (Required) The destination private IP address of the Port Forwarding.
+* `private_port` - (Required) The destination port number of the Port Forwarding.
+* `description` - (Optional) The description of the resource.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `protocol` - The target protocol of the Port Forwarding.  
+* `global_port` - The global port of the Port Forwarding.
+* `private_address` - The destination private IP address of the Port Forwarding.
+* `private_port` - The destination port number of the Port Forwarding.
+* `description` - The description of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router Port Forwarding is not supported.

--- a/website/docs/r/vpc_router_port_forwarding.html.markdown
+++ b/website/docs/r/vpc_router_port_forwarding.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_port_forwarding"
 sidebar_current: "docs-sakuracloud-resource-vpf"
 description: |-
-  Provides a SakuraCloud VPC Router Port Forwarding resource. This can be used to create, modify, and delete VPC Router Port Forwarding.
+  Provides a SakuraCloud VPC Router Port Forwarding resource. This can be used to create, update, and delete VPC Router Port Forwarding.
 ---
 
 # sakuracloud\_vpc\_router\_port_forwarding
 
-Provides a SakuraCloud VPC Router Port Forwarding resource. This can be used to create, modify, and delete VPC Router Port Forwarding.
+Provides a SakuraCloud VPC Router Port Forwarding resource. This can be used to create, update, and delete VPC Router Port Forwarding.
 
 ## Example Usage
 

--- a/website/docs/r/vpc_router_pptp.html.markdown
+++ b/website/docs/r/vpc_router_pptp.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_pptp"
-sidebar_current: "docs-sakuracloud-resource-vpptp"
+sidebar_current: "docs-sakuracloud-resource-vpc-pptp"
 description: |-
   Provides a SakuraCloud VPC Router PPTP resource. This can be used to create, update, and delete VPC Router PPTP.
 ---

--- a/website/docs/r/vpc_router_pptp.html.markdown
+++ b/website/docs/r/vpc_router_pptp.html.markdown
@@ -1,0 +1,63 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_pptp"
+sidebar_current: "docs-sakuracloud-resource-vpptp"
+description: |-
+  Provides a SakuraCloud VPC Router PPTP resource. This can be used to create, modify, and delete VPC Router PPTP.
+---
+
+# sakuracloud\_vpc\_router\_pptp
+
+Provides a SakuraCloud VPC Router PPTP resource. This can be used to create, modify, and delete VPC Router PPTP.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+}
+
+# Add NIC to the VPC Router
+resource sakuracloud_vpc_router_interface "eth1" {
+  vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+  index         = 1
+  switch_id     = "${sakuracloud_switch.foobar.id}"
+  ipaddress     = ["192.168.2.1"]
+  nw_mask_len   = 24
+}
+
+# Create a new PPTP config.
+resource sakuracloud_vpc_router_pptp "pptp" {
+    vpc_router_id           = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
+
+    range_start       = "192.168.2.51"
+    range_stop        = "192.168.2.100"
+
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `vpc_router_interface_id` - (Required) The ID of VPC Router Interface.
+* `range_start` - (Required) Start IP address of address range to be assigned by PPTP.
+* `range_stop` - (Required) End IP address of address range to be assigned by PPTP.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `pre_shared_secret` - The pre shared secret for PPTP.
+* `range_start` - Start IP address of address range to be assigned by PPTP.
+* `range_stop` - End IP address of address range to be assigned by PPTP.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router PPTP is not supported.

--- a/website/docs/r/vpc_router_pptp.html.markdown
+++ b/website/docs/r/vpc_router_pptp.html.markdown
@@ -3,12 +3,12 @@ layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_pptp"
 sidebar_current: "docs-sakuracloud-resource-vpptp"
 description: |-
-  Provides a SakuraCloud VPC Router PPTP resource. This can be used to create, modify, and delete VPC Router PPTP.
+  Provides a SakuraCloud VPC Router PPTP resource. This can be used to create, update, and delete VPC Router PPTP.
 ---
 
 # sakuracloud\_vpc\_router\_pptp
 
-Provides a SakuraCloud VPC Router PPTP resource. This can be used to create, modify, and delete VPC Router PPTP.
+Provides a SakuraCloud VPC Router PPTP resource. This can be used to create, update, and delete VPC Router PPTP.
 
 ## Example Usage
 

--- a/website/docs/r/vpc_router_pptp.html.markdown
+++ b/website/docs/r/vpc_router_pptp.html.markdown
@@ -58,6 +58,6 @@ The following attributes are exported:
 * `range_stop` - End IP address of address range to be assigned by PPTP.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router PPTP is not supported.

--- a/website/docs/r/vpc_router_site_to_site_vpn.html.markdown
+++ b/website/docs/r/vpc_router_site_to_site_vpn.html.markdown
@@ -79,6 +79,6 @@ The following attributes are exported:
 * `vpc_router_outside_ipaddress` - VPC Router outside IP address.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router Site To Site VPN is not supported.

--- a/website/docs/r/vpc_router_site_to_site_vpn.html.markdown
+++ b/website/docs/r/vpc_router_site_to_site_vpn.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_site_to_site_vpn"
-sidebar_current: "docs-sakuracloud-resource-vs2s"
+sidebar_current: "docs-sakuracloud-resource-vpc-s2s"
 description: |-
   Provides a SakuraCloud VPC Router Site To Site VPN resource. This can be used to create and delete VPC Router Site To Site VPN.
 ---

--- a/website/docs/r/vpc_router_site_to_site_vpn.html.markdown
+++ b/website/docs/r/vpc_router_site_to_site_vpn.html.markdown
@@ -1,0 +1,84 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_site_to_site_vpn"
+sidebar_current: "docs-sakuracloud-resource-vs2s"
+description: |-
+  Provides a SakuraCloud VPC Router Site To Site VPN resource. This can be used to create and delete VPC Router Site To Site VPN.
+---
+
+# sakuracloud\_vpc\_router\_site\_to\_site\_vpn
+
+Provides a SakuraCloud VPC Router Site To Site VPN resource. This can be used to create and delete VPC Router Site To Site VPN.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+}
+
+# Add NIC to the VPC Router
+resource sakuracloud_vpc_router_interface "eth1" {
+  vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+  index         = 1
+  switch_id     = "${sakuracloud_switch.foobar.id}"
+  ipaddress     = ["192.168.2.1"]
+  nw_mask_len   = 24
+}
+
+# Add Site to Site VPN config
+resource "sakuracloud_vpc_router_site_to_site_vpn" "s2s" {
+  vpc_router_id     = "${sakuracloud_vpc_router.foobar.id}"
+  peer              = "172.16.0.1"
+  remote_id         = "172.16.0.1"
+  pre_shared_secret = "<your-pre-shared-secret>"
+  routes            = ["10.0.0.0/8"]
+  local_prefix      = ["192.168.2.0/24"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `peer` - (Required) The peer IP address.
+* `remote_id` - (Required) The IPSec ID of target.
+* `pre_shared_secret` - (Required) The pre shared secret for IPSec.
+* `routes` - (Required) The routing prefix.
+* `local_prefix` - (Required) The local prefix.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `peer` - The peer IP address.
+* `remote_id` - The IPSec ID of target.
+* `pre_shared_secret` - The pre shared secret for IPSec.
+* `routes` - The routing prefix.
+* `local_prefix` - The local prefix.
+* `esp_authentication_protocol` - ESP authentication protocol.
+* `esp_dh_group` - ESP DH group.
+* `esp_encryption_protocol` - ESP encryption protocol.
+* `esp_lifetime` - ESP lifetime.
+* `esp_mode` - ESP mode.
+* `esp_perfect_forward_secrecy` - ESP perfect forward secrecy.
+* `ike_authentication_protocol` - IKE authentication protocol.
+* `ike_encryption_protocol` - IKE encryption protocol.
+* `ike_lifetime` - IKE lifetime.
+* `ike_mode` - IKE mode.
+* `ike_perfect_forward_secrecy` - IKE perfect forward secrecy.
+* `ike_pre_shared_secret` - IKE pre shared secret.
+* `peer_id` - Peer ID.
+* `peer_inside_networks` - Peer inside networks.
+* `peer_outside_ipaddress` - Peer outsite ipaddress.
+* `vpc_router_inside_networks` - VPC Router inside networks.
+* `vpc_router_outside_ipaddress` - VPC Router outside IP address.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router Site To Site VPN is not supported.

--- a/website/docs/r/vpc_router_static_nat.html.markdown
+++ b/website/docs/r/vpc_router_static_nat.html.markdown
@@ -26,7 +26,7 @@ resource sakuracloud_vpc_router "foobar" {
 }
 
 # Add NIC to the VPC Router
-resource sakuracloud_vpc_router_interface "eth1"{
+resource sakuracloud_vpc_router_interface "eth1" {
   vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
   index         = 1
   switch_id     = "${sakuracloud_switch.foobar.id}"

--- a/website/docs/r/vpc_router_static_nat.html.markdown
+++ b/website/docs/r/vpc_router_static_nat.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_static_nat"
-sidebar_current: "docs-sakuracloud-resource-vsnat"
+sidebar_current: "docs-sakuracloud-resource-vpc-staticnat"
 description: |-
   Provides a SakuraCloud VPC Router Static NAT resource. This can be used to create and delete VPC Router Static NAT.
 ---

--- a/website/docs/r/vpc_router_static_nat.html.markdown
+++ b/website/docs/r/vpc_router_static_nat.html.markdown
@@ -1,0 +1,72 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_static_nat"
+sidebar_current: "docs-sakuracloud-resource-vsnat"
+description: |-
+  Provides a SakuraCloud VPC Router Static NAT resource. This can be used to create and delete VPC Router Static NAT.
+---
+
+# sakuracloud\_vpc\_router\_static\_nat
+
+Provides a SakuraCloud VPC Router Static NAT resource. This can be used to create and delete VPC Router Static NAT.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(premium or highspec)
+resource sakuracloud_vpc_router "foobar" {
+  name                = "foobar"
+  plan                = "premium"
+  switch_id           = "${sakuracloud_internet.foobar.switch_id}"
+  vip                 = "${sakuracloud_internet.foobar.ipaddresses[0]}"
+  ipaddress1          = "${sakuracloud_internet.foobar.ipaddresses[1]}"
+  ipaddress2          = "${sakuracloud_internet.foobar.ipaddresses[2]}"
+  #aliases             = ["${sakuracloud_internet.foobar.ipaddresses[3]}"] 
+  vrid                = 1
+}
+
+# Add NIC to the VPC Router
+resource sakuracloud_vpc_router_interface "eth1"{
+  vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+  index         = 1
+  switch_id     = "${sakuracloud_switch.foobar.id}"
+  vip           = "192.2.0.1"
+  ipaddress     = ["192.2.0.2", "192.2.0.3"]
+  nw_mask_len   = 24
+}
+
+# Add Static NAT config
+resource sakuracloud_vpc_router_static_nat "snat" {
+    vpc_router_id           = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
+
+    global_address  = "${sakuracloud_internet.router1.ipaddresses[3]}"
+    private_address = "192.2.0.11"
+    description     = "description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `vpc_router_interface_id` - (Required) The ID of VPC Router Interface.
+* `global_address` - (Required) The global IP address of the Static NAT.
+* `private_address` - (Required) The private IP address of the Static NAT.
+* `description` - (Optional) The description of the resource.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `global_address` - The global IP address of the Static NAT.
+* `private_address` - The private IP address of the Static NAT.
+* `description` - The description of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router Static NAT is not supported.

--- a/website/docs/r/vpc_router_static_nat.html.markdown
+++ b/website/docs/r/vpc_router_static_nat.html.markdown
@@ -67,6 +67,6 @@ The following attributes are exported:
 * `description` - The description of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router Static NAT is not supported.

--- a/website/docs/r/vpc_router_static_route.html.markdown
+++ b/website/docs/r/vpc_router_static_route.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_static_route"
-sidebar_current: "docs-sakuracloud-resource-vsroute"
+sidebar_current: "docs-sakuracloud-resource-vpc-staticroute"
 description: |-
   Provides a SakuraCloud VPC Router Static Route resource. This can be used to create and delete VPC Router Static Route.
 ---

--- a/website/docs/r/vpc_router_static_route.html.markdown
+++ b/website/docs/r/vpc_router_static_route.html.markdown
@@ -20,7 +20,7 @@ resource sakuracloud_vpc_router "foobar" {
 }
 
 # Add NIC to the VPC Router
-resource sakuracloud_vpc_router_interface "eth1"{
+resource sakuracloud_vpc_router_interface "eth1" {
   vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
   index         = 1
   switch_id     = "${sakuracloud_switch.foobar.id}"

--- a/website/docs/r/vpc_router_static_route.html.markdown
+++ b/website/docs/r/vpc_router_static_route.html.markdown
@@ -1,0 +1,65 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_static_route"
+sidebar_current: "docs-sakuracloud-resource-vsroute"
+description: |-
+  Provides a SakuraCloud VPC Router Static Route resource. This can be used to create and delete VPC Router Static Route.
+---
+
+# sakuracloud\_vpc\_router\_static\_route
+
+Provides a SakuraCloud VPC Router Static Route resource. This can be used to create and delete VPC Router Static Route.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(premium or highspec)
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+}
+
+# Add NIC to the VPC Router
+resource sakuracloud_vpc_router_interface "eth1"{
+  vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+  index         = 1
+  switch_id     = "${sakuracloud_switch.foobar.id}"
+  ipaddress     = ["192.168.2.1"]
+  nw_mask_len   = 24
+}
+
+# Add Static Route config
+resource sakuracloud_vpc_router_static_route "route" {
+    vpc_router_id           = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
+
+    prefix      = "10.0.0.0/8"
+    next_hop    = "192.2.0.11"
+    description = "description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `vpc_router_interface_id` - (Required) The ID of VPC Router Interface.
+* `prefix` - (Required) The prefix of the Static Route.
+* `next_hop` - (Required) The next hop IP address of the Static Route.
+* `description` - (Optional) The description of the resource.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `prefix` - The prefix of the Static Route.
+* `next_hop` - The next hop IP address of the Static Route.
+* `description` - The description of the resource.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router Static Route is not supported.

--- a/website/docs/r/vpc_router_static_route.html.markdown
+++ b/website/docs/r/vpc_router_static_route.html.markdown
@@ -60,6 +60,6 @@ The following attributes are exported:
 * `description` - The description of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router Static Route is not supported.

--- a/website/docs/r/vpc_router_user.html.markdown
+++ b/website/docs/r/vpc_router_user.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_vpc_router_user"
-sidebar_current: "docs-sakuracloud-resource-vuser"
+sidebar_current: "docs-sakuracloud-resource-vpc-user"
 description: |-
   Provides a SakuraCloud VPC Router User resource. This can be used to create and delete VPC Router User.
 ---

--- a/website/docs/r/vpc_router_user.html.markdown
+++ b/website/docs/r/vpc_router_user.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_vpc_router_user"
+sidebar_current: "docs-sakuracloud-resource-vuser"
+description: |-
+  Provides a SakuraCloud VPC Router User resource. This can be used to create and delete VPC Router User.
+---
+
+# sakuracloud\_vpc\_router\_user
+
+Provides a SakuraCloud VPC Router User resource. This can be used to create and delete VPC Router User.
+
+## Example Usage
+
+```hcl
+# Create a new VPC Router(standard)
+resource sakuracloud_vpc_router "foobar" {
+  name           = "foobar"
+}
+
+# Create a new VPC Router User.
+resource "sakuracloud_vpc_router_user" "user" {
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    name          = "<user-name>"
+    password      = "<p@ssword>"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_router_id` - (Required) The ID of the Internet resource.
+* `name` - (Required) The user name.
+* `password` - (Required) The password.
+* `zone` - (Optional) The ID of the zone to which the resource belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `name` - The user name.
+* `password` - The password.
+* `zone` - The ID of the zone to which the resource belongs.
+
+## Import(not supported)
+
+Import of VPC Router User is not supported.

--- a/website/docs/r/vpc_router_user.html.markdown
+++ b/website/docs/r/vpc_router_user.html.markdown
@@ -44,6 +44,6 @@ The following attributes are exported:
 * `password` - The password.
 * `zone` - The ID of the zone to which the resource belongs.
 
-## Import(not supported)
+## Import (not supported)
 
 Import of VPC Router User is not supported.

--- a/website/sakuracloud.erb
+++ b/website/sakuracloud.erb
@@ -77,148 +77,204 @@
               <a href="/docs/providers/sakuracloud/d/vpc_router.html">sakuracloud_vpc_router</a>
             </li>
           </ul>
-       </li>
+        </li>
 
-        <li<%= sidebar_current("docs-sakuracloud-resource") %>>
-          <a href="#">Resources</a>
+        <li<%= sidebar_current("docs-sakuracloud-resource-computing") %>>
+          <a href="#">Computing Resources</a>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-sakuracloud-resource-archive") %>>
-              <a href="/docs/providers/sakuracloud/r/archive.html">sakuracloud_archive</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-auto-backup") %>>
-              <a href="/docs/providers/sakuracloud/r/auto_backup.html">sakuracloud_auto_backup</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-bridge") %>>
-              <a href="/docs/providers/sakuracloud/r/bridge.html">sakuracloud_bridge</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-bucket-object") %>>
-              <a href="/docs/providers/sakuracloud/r/bucket_object.html">sakuracloud_bucket_object</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-cdrom") %>>
-              <a href="/docs/providers/sakuracloud/r/cdrom.html">sakuracloud_cdrom</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-database") %>>
-              <a href="/docs/providers/sakuracloud/r/database.html">sakuracloud_database</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-disk") %>>
-              <a href="/docs/providers/sakuracloud/r/disk.html">sakuracloud_disk</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-dns") %>>
-              <a href="/docs/providers/sakuracloud/r/dns.html">sakuracloud_dns</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-drecord") %>>
-              <a href="/docs/providers/sakuracloud/r/dns_record.html">sakuracloud_dns_record</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-gslb") %>>
-              <a href="/docs/providers/sakuracloud/r/gslb.html">sakuracloud_gslb</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-gserver") %>>
-              <a href="/docs/providers/sakuracloud/r/gslb_server.html">sakuracloud_gslb_server</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-icon") %>>
-              <a href="/docs/providers/sakuracloud/r/icon.html">sakuracloud_icon</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-internet") %>>
-              <a href="/docs/providers/sakuracloud/r/internet.html">sakuracloud_internet</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-ipv4-ptr") %>>
-              <a href="/docs/providers/sakuracloud/r/ipv4_ptr.html">sakuracloud_ipv4_ptr</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-load-balancer") %>>
-              <a href="/docs/providers/sakuracloud/r/load_balancer.html">sakuracloud_load_balancer</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-lbserver") %>>
-              <a href="/docs/providers/sakuracloud/r/load_balancer_server.html">sakuracloud_load_balancer_server</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-lbvip") %>>
-              <a href="/docs/providers/sakuracloud/r/load_balancer_vip.html">sakuracloud_load_balancer_vip</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-mobile-gateway") %>>
-              <a href="/docs/providers/sakuracloud/r/mobile_gateway.html">sakuracloud_mobile_gateway</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-mgwsimroute") %>>
-              <a href="/docs/providers/sakuracloud/r/mobile_gateway_sim_route.html">sakuracloud_mobile_gateway_sim_route</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-mgwstaticroute") %>>
-              <a href="/docs/providers/sakuracloud/r/mobile_gateway_static_route.html">sakuracloud_mobile_gateway_static_route</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-nfs") %>>
-              <a href="/docs/providers/sakuracloud/r/nfs.html">sakuracloud_nfs</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-note") %>>
-              <a href="/docs/providers/sakuracloud/r/note.html">sakuracloud_note</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-packet-filter") %>>
-              <a href="/docs/providers/sakuracloud/r/packet_filter.html">sakuracloud_packet_filter</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-pfrule") %>>
-              <a href="/docs/providers/sakuracloud/r/packet_filter_rule.html">sakuracloud_packet_filter_rule</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-private-host") %>>
-              <a href="/docs/providers/sakuracloud/r/private_host.html">sakuracloud_private_host</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-server") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-computing-server") %>>
               <a href="/docs/providers/sakuracloud/r/server.html">sakuracloud_server</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-sconnector") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-computing-sconnector") %>>
               <a href="/docs/providers/sakuracloud/r/server_connector.html">sakuracloud_server_connector</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-sim") %>>
-              <a href="/docs/providers/sakuracloud/r/sim.html">sakuracloud_sim</a>
+            <li<%= sidebar_current("docs-sakuracloud-resource-computing-private-host") %>>
+              <a href="/docs/providers/sakuracloud/r/private_host.html">sakuracloud_private_host</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-smonitor") %>>
-              <a href="/docs/providers/sakuracloud/r/simple_monitor.html">sakuracloud_simple_monitor</a>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-resource-storage") %>>
+          <a href="#">Storage Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-sakuracloud-resource-storage-disk") %>>
+              <a href="/docs/providers/sakuracloud/r/disk.html">sakuracloud_disk</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-ssh-key") %>>
-              <a href="/docs/providers/sakuracloud/r/ssh_key.html">sakuracloud_ssh_key</a>
+            <li<%= sidebar_current("docs-sakuracloud-resource-storage-archive") %>>
+              <a href="/docs/providers/sakuracloud/r/archive.html">sakuracloud_archive</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-skeygen") %>>
-              <a href="/docs/providers/sakuracloud/r/ssh_key_gen.html">sakuracloud_ssh_key_gen</a>
+            <li<%= sidebar_current("docs-sakuracloud-resource-storage-cdrom") %>>
+              <a href="/docs/providers/sakuracloud/r/cdrom.html">sakuracloud_cdrom</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-subnet") %>>
-              <a href="/docs/providers/sakuracloud/r/subnet.html">sakuracloud_subnet</a>
-            </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-switch") %>>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-resource-networking") %>>
+          <a href="#">Networking Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-sakuracloud-resource-networking-switch") %>>
               <a href="/docs/providers/sakuracloud/r/switch.html">sakuracloud_switch</a>
             </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-networking-internet") %>>
+              <a href="/docs/providers/sakuracloud/r/internet.html">sakuracloud_internet</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-networking-subnet") %>>
+              <a href="/docs/providers/sakuracloud/r/subnet.html">sakuracloud_subnet</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-networking-ipv4-ptr") %>>
+              <a href="/docs/providers/sakuracloud/r/ipv4_ptr.html">sakuracloud_ipv4_ptr</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-networking-packet-filter") %>>
+              <a href="/docs/providers/sakuracloud/r/packet_filter.html">sakuracloud_packet_filter</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-networking-pfrule") %>>
+              <a href="/docs/providers/sakuracloud/r/packet_filter_rule.html">sakuracloud_packet_filter_rule</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-networking-bridge") %>>
+              <a href="/docs/providers/sakuracloud/r/bridge.html">sakuracloud_bridge</a>
+            </li>
+
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-resource-appliance") %>>
+          <a href="#">Appliance Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-sakuracloud-resource-appliance-auto-backup") %>>
+              <a href="/docs/providers/sakuracloud/r/auto_backup.html">sakuracloud_auto_backup</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-appliance-database") %>>
+              <a href="/docs/providers/sakuracloud/r/database.html">sakuracloud_database</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-appliance-nfs") %>>
+              <a href="/docs/providers/sakuracloud/r/nfs.html">sakuracloud_nfs</a>
+            </li>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-resource-lb") %>>
+          <a href="#">Load Balancer(Appliance) Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-sakuracloud-resource-lb-load-balancer") %>>
+              <a href="/docs/providers/sakuracloud/r/load_balancer.html">sakuracloud_load_balancer</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-lb-server") %>>
+              <a href="/docs/providers/sakuracloud/r/load_balancer_server.html">sakuracloud_load_balancer_server</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-lb-vip") %>>
+              <a href="/docs/providers/sakuracloud/r/load_balancer_vip.html">sakuracloud_load_balancer_vip</a>
+            </li>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-resource-vpc") %>>
+          <a href="#">VPC Router(Appliance) Resources</a>
+          <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-sakuracloud-resource-vpc-router") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router.html">sakuracloud_vpc_router</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vdhcpserver") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-dhcpserver") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_dhcp_server.html">sakuracloud_vpc_router_dhcp_server</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vdhcpmapping") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-dhcpmapping") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_dhcp_static_mapping.html">sakuracloud_vpc_router_dhcp_static_mapping</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vfirewall") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-firewall") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_firewall.html">sakuracloud_vpc_router_firewall</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vinterface") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-interface") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_interface.html">sakuracloud_vpc_router_interface</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vl2tp") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-l2tp") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_l2tp.html">sakuracloud_vpc_router_l2tp</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vpf") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-pf") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_port_forwarding.html">sakuracloud_vpc_router_port_forwarding</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vpptp") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-pptp") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_pptp.html">sakuracloud_vpc_router_pptp</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vs2s") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-s2s") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_site_to_site_vpn.html">sakuracloud_vpc_router_site_to_site_vpn</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vsnat") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-staticnat") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_static_nat.html">sakuracloud_vpc_router_static_nat</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vsroute") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-staticroute") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_static_route.html">sakuracloud_vpc_router_static_route</a>
             </li>
-            <li<%= sidebar_current("docs-sakuracloud-resource-vuser") %>>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-user") %>>
               <a href="/docs/providers/sakuracloud/r/vpc_router_user.html">sakuracloud_vpc_router_user</a>
             </li>
-         </ul>
+          </ul>
         </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-resource-global") %>>
+          <a href="#">Global Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-sakuracloud-resource-global-gslb-setting") %>>
+              <a href="/docs/providers/sakuracloud/r/gslb.html">sakuracloud_gslb</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-global-gslb-server") %>>
+              <a href="/docs/providers/sakuracloud/r/gslb_server.html">sakuracloud_gslb_server</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-global-dns-zone") %>>
+              <a href="/docs/providers/sakuracloud/r/dns.html">sakuracloud_dns</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-global-dns-record") %>>
+              <a href="/docs/providers/sakuracloud/r/dns_record.html">sakuracloud_dns_record</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-global-simple-monitor") %>>
+              <a href="/docs/providers/sakuracloud/r/simple_monitor.html">sakuracloud_simple_monitor</a>
+            </li>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-resource-secure-mobile") %>>
+          <a href="#">Secure Mobile Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-sakuracloud-resource-secure-mobile-sim") %>>
+              <a href="/docs/providers/sakuracloud/r/sim.html">sakuracloud_sim</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-secure-mobile-mobile-gateway") %>>
+              <a href="/docs/providers/sakuracloud/r/mobile_gateway.html">sakuracloud_mobile_gateway</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-secure-mobile-mgwsimroute") %>>
+              <a href="/docs/providers/sakuracloud/r/mobile_gateway_sim_route.html">sakuracloud_mobile_gateway_sim_route</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-secure-mobile-mgwstaticroute") %>>
+              <a href="/docs/providers/sakuracloud/r/mobile_gateway_static_route.html">sakuracloud_mobile_gateway_static_route</a>
+            </li>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-resource-misc") %>>
+          <a href="#">Misc Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-sakuracloud-resource-misc-ssh-key") %>>
+              <a href="/docs/providers/sakuracloud/r/ssh_key.html">sakuracloud_ssh_key</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-misc-skeygen") %>>
+              <a href="/docs/providers/sakuracloud/r/ssh_key_gen.html">sakuracloud_ssh_key_gen</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-misc-note") %>>
+              <a href="/docs/providers/sakuracloud/r/note.html">sakuracloud_note</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-misc-icon") %>>
+              <a href="/docs/providers/sakuracloud/r/icon.html">sakuracloud_icon</a>
+            </li>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-resource-objectstorage") %>>
+          <a href="#">Object Storage Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-sakuracloud-resource-objectstorage-bucket-object") %>>
+              <a href="/docs/providers/sakuracloud/r/bucket_object.html">sakuracloud_bucket_object</a>
+            </li>
+          </ul>
+        </li>
+
       </ul>
     </div>
   <% end %>

--- a/website/sakuracloud.erb
+++ b/website/sakuracloud.erb
@@ -1,0 +1,227 @@
+<% wrap_layout :inner do %>
+  <% content_for :sidebar do %>
+    <div class="docs-sidebar hidden-print affix-top" role="complementary">
+      <ul class="nav docs-sidenav">
+        <li<%= sidebar_current("docs-home") %>>
+          <a href="/docs/providers/index.html">All Providers</a>
+        </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-index") %>>
+          <a href="/docs/providers/sakuracloud/index.html">SakuraCloud Provider</a>
+        </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-datasource") %>>
+          <a href="#">Data Sources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-sakuracloud-datasource-archive") %>>
+              <a href="/docs/providers/sakuracloud/d/archive.html">sakuracloud_archive</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-bridge") %>>
+              <a href="/docs/providers/sakuracloud/d/bridge.html">sakuracloud_bridge</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-bucket-object") %>>
+              <a href="/docs/providers/sakuracloud/d/bucket_object.html">sakuracloud_bucket_object</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-cdrom") %>>
+              <a href="/docs/providers/sakuracloud/d/cdrom.html">sakuracloud_cdrom</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-database") %>>
+              <a href="/docs/providers/sakuracloud/d/database.html">sakuracloud_database</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-disk") %>>
+              <a href="/docs/providers/sakuracloud/d/disk.html">sakuracloud_disk</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-dns") %>>
+              <a href="/docs/providers/sakuracloud/d/dns.html">sakuracloud_dns</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-gslb") %>>
+              <a href="/docs/providers/sakuracloud/d/gslb.html">sakuracloud_gslb</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-icon") %>>
+              <a href="/docs/providers/sakuracloud/d/icon.html">sakuracloud_icon</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-internet") %>>
+              <a href="/docs/providers/sakuracloud/d/internet.html">sakuracloud_internet</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-load-balancer") %>>
+              <a href="/docs/providers/sakuracloud/d/load_balancer.html">sakuracloud_load_balancer</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-nfs") %>>
+              <a href="/docs/providers/sakuracloud/d/nfs.html">sakuracloud_nfs</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-note") %>>
+              <a href="/docs/providers/sakuracloud/d/note.html">sakuracloud_note</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-packet-filter") %>>
+              <a href="/docs/providers/sakuracloud/d/packet_filter.html">sakuracloud_packet_filter</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-private-host") %>>
+              <a href="/docs/providers/sakuracloud/d/private_host.html">sakuracloud_private_host</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-server") %>>
+              <a href="/docs/providers/sakuracloud/d/server.html">sakuracloud_server</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-simple-monitor") %>>
+              <a href="/docs/providers/sakuracloud/d/simple_monitor.html">sakuracloud_simple_monitor</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-ssh-key") %>>
+              <a href="/docs/providers/sakuracloud/d/ssh_key.html">sakuracloud_ssh_key</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-subnet") %>>
+              <a href="/docs/providers/sakuracloud/d/subnet.html">sakuracloud_subnet</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-switch") %>>
+              <a href="/docs/providers/sakuracloud/d/switch.html">sakuracloud_switch</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-datasource-vpc-router") %>>
+              <a href="/docs/providers/sakuracloud/d/vpc_router.html">sakuracloud_vpc_router</a>
+            </li>
+          </ul>
+       </li>
+
+        <li<%= sidebar_current("docs-sakuracloud-resource") %>>
+          <a href="#">Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-sakuracloud-resource-archive") %>>
+              <a href="/docs/providers/sakuracloud/r/archive.html">sakuracloud_archive</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-auto-backup") %>>
+              <a href="/docs/providers/sakuracloud/r/auto_backup.html">sakuracloud_auto_backup</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-bridge") %>>
+              <a href="/docs/providers/sakuracloud/r/bridge.html">sakuracloud_bridge</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-bucket-object") %>>
+              <a href="/docs/providers/sakuracloud/r/bucket_object.html">sakuracloud_bucket_object</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-cdrom") %>>
+              <a href="/docs/providers/sakuracloud/r/cdrom.html">sakuracloud_cdrom</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-database") %>>
+              <a href="/docs/providers/sakuracloud/r/database.html">sakuracloud_database</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-disk") %>>
+              <a href="/docs/providers/sakuracloud/r/disk.html">sakuracloud_disk</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-dns") %>>
+              <a href="/docs/providers/sakuracloud/r/dns.html">sakuracloud_dns</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-drecord") %>>
+              <a href="/docs/providers/sakuracloud/r/dns_record.html">sakuracloud_dns_record</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-gslb") %>>
+              <a href="/docs/providers/sakuracloud/r/gslb.html">sakuracloud_gslb</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-gserver") %>>
+              <a href="/docs/providers/sakuracloud/r/gslb_server.html">sakuracloud_gslb_server</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-icon") %>>
+              <a href="/docs/providers/sakuracloud/r/icon.html">sakuracloud_icon</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-internet") %>>
+              <a href="/docs/providers/sakuracloud/r/internet.html">sakuracloud_internet</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-ipv4-ptr") %>>
+              <a href="/docs/providers/sakuracloud/r/ipv4_ptr.html">sakuracloud_ipv4_ptr</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-load-balancer") %>>
+              <a href="/docs/providers/sakuracloud/r/load_balancer.html">sakuracloud_load_balancer</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-lbserver") %>>
+              <a href="/docs/providers/sakuracloud/r/load_balancer_server.html">sakuracloud_load_balancer_server</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-lbvip") %>>
+              <a href="/docs/providers/sakuracloud/r/load_balancer_vip.html">sakuracloud_load_balancer_vip</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-mobile-gateway") %>>
+              <a href="/docs/providers/sakuracloud/r/mobile_gateway.html">sakuracloud_mobile_gateway</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-mgwsimroute") %>>
+              <a href="/docs/providers/sakuracloud/r/mobile_gateway_sim_route.html">sakuracloud_mobile_gateway_sim_route</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-mgwstaticroute") %>>
+              <a href="/docs/providers/sakuracloud/r/mobile_gateway_static_route.html">sakuracloud_mobile_gateway_static_route</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-nfs") %>>
+              <a href="/docs/providers/sakuracloud/r/nfs.html">sakuracloud_nfs</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-note") %>>
+              <a href="/docs/providers/sakuracloud/r/note.html">sakuracloud_note</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-packet-filter") %>>
+              <a href="/docs/providers/sakuracloud/r/packet_filter.html">sakuracloud_packet_filter</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-pfrule") %>>
+              <a href="/docs/providers/sakuracloud/r/packet_filter_rule.html">sakuracloud_packet_filter_rule</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-private-host") %>>
+              <a href="/docs/providers/sakuracloud/r/private_host.html">sakuracloud_private_host</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-server") %>>
+              <a href="/docs/providers/sakuracloud/r/server.html">sakuracloud_server</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-sconnector") %>>
+              <a href="/docs/providers/sakuracloud/r/server_connector.html">sakuracloud_server_connector</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-sim") %>>
+              <a href="/docs/providers/sakuracloud/r/sim.html">sakuracloud_sim</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-smonitor") %>>
+              <a href="/docs/providers/sakuracloud/r/simple_monitor.html">sakuracloud_simple_monitor</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-ssh-key") %>>
+              <a href="/docs/providers/sakuracloud/r/ssh_key.html">sakuracloud_ssh_key</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-skeygen") %>>
+              <a href="/docs/providers/sakuracloud/r/ssh_key_gen.html">sakuracloud_ssh_key_gen</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-subnet") %>>
+              <a href="/docs/providers/sakuracloud/r/subnet.html">sakuracloud_subnet</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-switch") %>>
+              <a href="/docs/providers/sakuracloud/r/switch.html">sakuracloud_switch</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpc-router") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router.html">sakuracloud_vpc_router</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vdhcpserver") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_dhcp_server.html">sakuracloud_vpc_router_dhcp_server</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vdhcpmapping") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_dhcp_static_mapping.html">sakuracloud_vpc_router_dhcp_static_mapping</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vfirewall") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_firewall.html">sakuracloud_vpc_router_firewall</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vinterface") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_interface.html">sakuracloud_vpc_router_interface</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vl2tp") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_l2tp.html">sakuracloud_vpc_router_l2tp</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpf") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_port_forwarding.html">sakuracloud_vpc_router_port_forwarding</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vpptp") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_pptp.html">sakuracloud_vpc_router_pptp</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vs2s") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_site_to_site_vpn.html">sakuracloud_vpc_router_site_to_site_vpn</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vsnat") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_static_nat.html">sakuracloud_vpc_router_static_nat</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vsroute") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_static_route.html">sakuracloud_vpc_router_static_route</a>
+            </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-vuser") %>>
+              <a href="/docs/providers/sakuracloud/r/vpc_router_user.html">sakuracloud_vpc_router_user</a>
+            </li>
+         </ul>
+        </li>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= yield %>
+<% end %>


### PR DESCRIPTION
( To fix #316 )

Terraform公式ドキュメント(https://terraform.io/docs/providers) 互換の英語版ドキュメントを追加。

## プレビュー方法

[terraform-website](https://github.com/hashicorp/terraform-website)を利用する。

### 前提条件

- `docker`
- `make`
- `git`

### 手順

1. [terraform-website](https://github.com/hashicorp/terraform-website)をクローンしサブモジュールの最新ソースを取得

```bash
git clone https://github.com/hashicorp/terraform-website
cd terraform-website
make sync
```

3. sakuracloudディレクトリをクローン

```bash
git clone https://github.com/yamamoto-febc/terraform-provider-sakuracloud  ext/providers/sakuracloud
```

3. ドキュメントのブランチをチェックアウト

```bash
cd ext/providers/sakuracloud
git fetch origin tf_docs
git checkout FETCH_HEAD
cd ../../../
```

4. シンボリックリンクの作成(2箇所)

```bash
# 1) レイアウト用erbファイルのシンボリックリンク作成
cd content/source/layouts/
ln -s ../../../ext/providers/sakuracloud/website/sakuracloud.erb sakuracloud.erb
cd ../../../

# 2) ドキュメント本体用のシンボリックリンク作成
cd content/source/docs/providers/
ln -s ../../../../ext/providers/sakuracloud/website/docs sakuracloud
cd ../../../../
```

4. プレビュー

```bash
make website
```

その後`http://localhost:4567/docs/providers/sakuracloud/index.html`を開く

