### PR TITLE
帯域変更後のルータID変更

### DIFF
--- a/sakuracloud/resource_sakuracloud_internet.go
+++ b/sakuracloud/resource_sakuracloud_internet.go
@@ -220,6 +220,9 @@ func resourceSakuraCloudInternetUpdate(d *schema.ResourceData, meta interface{})
 		if err != nil {
 			return fmt.Errorf("Error updating SakuraCloud Internet bandwidth: %s", err)
 		}
+		// internet.ID is changed when UpdateBandWidth() is called.
+		// so call SetID here.
+		d.SetId(internet.GetStrID()) // nolint
 	}
 
 	// handle ipv6 param


### PR DESCRIPTION
To fix #327 

帯域変更後にルータIDが変更されるため、`SetID()`の再呼び出しを行うようにする。