### PR TITLE
シンプル監視でのBasic認証

### DIFF
--- a/build_docs/docs/configuration/resources/simple_monitor.md
+++ b/build_docs/docs/configuration/resources/simple_monitor.md
@@ -16,6 +16,10 @@ resource sakuracloud_simple_monitor "mymonitor" {
     delay_loop = 60
     path       = "/"
     status     = "200"
+    
+    # BASIC認証
+    # username   = "foo"
+    # password   = "bar"
   }
 
   notify_email_enabled = true
@@ -73,6 +77,8 @@ resource sakuracloud_simple_monitor "my_sslcert_monitor" {
 | `host_header`  | △   | HOSTヘッダ  | - | 文字列 | プロトコルが`http`または`https`の場合のみ有効 |
 | `status`       | △   | レスポンスコード | - | 文字列 | プロトコルが`http`または`https`の場合のみ有効かつ必須 |
 | `sni`          | △   | SNI | `false` | `true`<br />`false`| プロトコルが`https`の場合のみ有効 |
+| `username`     | △   | Basic認証ユーザー名 | - | 文字列 | プロトコルが`http`または`https`の場合のみ有効 |
+| `password`     | △   | Basic認証パスワード | - | 文字列 | プロトコルが`http`または`https`の場合のみ有効 |
 | `port`         | △   | ポート番号 | - | 数値 | プロトコルが`tcp`,`ssh`,`smtp`,`pop3`の場合のみ有効かつ必須 |
 | `qname`        | △   | 問合せFQDN | - | 文字列 | プロトコルが`dns`の場合のみ有効かつ必須 |
 | `expected_data`| △   | 期待値 | - | 文字列 | プロトコルが`dns`,`snmp`の場合のみ有効<br />`dns`の場合、省略すると、何らかのAレコードの応答があるかのチェックとなる<br />`snmp`の場合は必須 |

--- a/sakuracloud/data_source_sakuracloud_simple_monitor.go
+++ b/sakuracloud/data_source_sakuracloud_simple_monitor.go
@@ -76,6 +76,14 @@ func dataSourceSakuraCloudSimpleMonitor() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"username": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"password": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"port": {
 							Type:     schema.TypeInt,
 							Computed: true,

--- a/sakuracloud/resource_sakuracloud_simple_monitor.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor.go
@@ -66,6 +66,14 @@ func resourceSakuraCloudSimpleMonitor() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"username": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"password": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"port": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -168,7 +176,9 @@ func resourceSakuraCloudSimpleMonitorCreate(d *schema.ResourceData, meta interfa
 		opts.SetHealthCheckHTTP(port,
 			forceString(conf["path"]),
 			forceString(conf["status"]),
-			forceString(conf["host_header"]))
+			forceString(conf["host_header"]),
+			forceString(conf["username"]),
+			forceString(conf["password"]))
 	case "https":
 		if port == "" {
 			port = "443"
@@ -177,7 +187,9 @@ func resourceSakuraCloudSimpleMonitorCreate(d *schema.ResourceData, meta interfa
 			forceString(conf["path"]),
 			forceString(conf["status"]),
 			forceString(conf["host_header"]),
-			forceBool(conf["sni"]))
+			forceBool(conf["sni"]),
+			forceString(conf["username"]),
+			forceString(conf["password"]))
 
 	case "dns":
 		opts.SetHealthCheckDNS(forceString(conf["qname"]),
@@ -301,7 +313,10 @@ func resourceSakuraCloudSimpleMonitorUpdate(d *schema.ResourceData, meta interfa
 			simpleMonitor.SetHealthCheckHTTP(port,
 				forceString(conf["path"]),
 				forceString(conf["status"]),
-				forceString(conf["host_header"]))
+				forceString(conf["host_header"]),
+				forceString(conf["username"]),
+				forceString(conf["password"]),
+			)
 		case "https":
 			if port == "" {
 				port = "443"
@@ -310,7 +325,10 @@ func resourceSakuraCloudSimpleMonitorUpdate(d *schema.ResourceData, meta interfa
 				forceString(conf["path"]),
 				forceString(conf["status"]),
 				forceString(conf["host_header"]),
-				forceBool(conf["sni"]))
+				forceBool(conf["sni"]),
+				forceString(conf["username"]),
+				forceString(conf["password"]),
+			)
 
 		case "dns":
 			simpleMonitor.SetHealthCheckDNS(forceString(conf["qname"]),
@@ -440,6 +458,8 @@ func setSimpleMonitorResourceData(d *schema.ResourceData, client *APIClient, dat
 		if port != "" || readHealthCheck.Port != "80" {
 			healthCheck["port"] = readHealthCheck.Port
 		}
+		healthCheck["username"] = readHealthCheck.BasicAuthUsername
+		healthCheck["password"] = readHealthCheck.BasicAuthPassword
 	case "https":
 		healthCheck["path"] = readHealthCheck.Path
 		healthCheck["status"] = readHealthCheck.Status
@@ -449,6 +469,8 @@ func setSimpleMonitorResourceData(d *schema.ResourceData, client *APIClient, dat
 			healthCheck["port"] = readHealthCheck.Port
 		}
 		healthCheck["sni"] = strings.ToLower(readHealthCheck.SNI) == "true"
+		healthCheck["username"] = readHealthCheck.BasicAuthUsername
+		healthCheck["password"] = readHealthCheck.BasicAuthPassword
 	case "tcp":
 		healthCheck["port"] = port
 		healthCheck["port"] = readHealthCheck.Port

--- a/sakuracloud/resource_sakuracloud_simple_monitor_test.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor_test.go
@@ -31,6 +31,10 @@ func TestAccResourceSakuraCloudSimpleMonitor(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "health_check.0.sni", "true"),
 					resource.TestCheckResourceAttr(
+						"sakuracloud_simple_monitor.foobar", "health_check.0.username", "foo"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_simple_monitor.foobar", "health_check.0.password", "bar"),
+					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "target", "terraform.io"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "notify_email_enabled", "true"),
@@ -181,6 +185,8 @@ resource "sakuracloud_simple_monitor" "foobar" {
         status = "200"
         host_header = "libsacloud.com"
 		sni  = true
+        username = "foo"
+        password = "bar"
     }
     description = "SimpleMonitor from TerraForm for SAKURA CLOUD"
     tags = ["hoge1" , "hoge2"]

--- a/vendor/github.com/sacloud/libsacloud/sacloud/loadbalancer.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/loadbalancer.go
@@ -26,6 +26,7 @@ type LoadBalancerSetting struct {
 	Port             string                `json:",omitempty"` // ポート番号
 	DelayLoop        string                `json:",omitempty"` // 監視間隔
 	SorryServer      string                `json:",omitempty"` // ソーリーサーバー
+	Description      string                `json:",omitempty"` // 説明
 	Servers          []*LoadBalancerServer `json:",omitempty"` // 仮想IP配下の実サーバー
 }
 

--- a/vendor/github.com/sacloud/libsacloud/sacloud/simple_monitor.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/simple_monitor.go
@@ -47,18 +47,20 @@ type SimpleMonitorProvider struct {
 
 // SimpleMonitorHealthCheck ヘルスチェック
 type SimpleMonitorHealthCheck struct {
-	Protocol      string `json:",omitempty"` // プロトコル
-	Port          string `json:",omitempty"` // ポート
-	Path          string `json:",omitempty"` // HTTP/HTTPS監視の場合のリクエストパス
-	Status        string `json:",omitempty"` // HTTP/HTTPS監視の場合の期待ステータスコード
-	SNI           string `json:",omitempty"` // HTTPS監視時のSNI有効/無効
-	Host          string `json:",omitempty"` // 対象ホスト(IP or FQDN)
-	QName         string `json:",omitempty"` // DNS監視の場合の問い合わせFQDN
-	ExpectedData  string `json:",omitempty"` // 期待値
-	Community     string `json:",omitempty"` // SNMP監視の場合のコミュニティ名
-	SNMPVersion   string `json:",omitempty"` // SNMP監視 SNMPバージョン
-	OID           string `json:",omitempty"` // SNMP監視 OID
-	RemainingDays int    `json:",omitempty"` // SSL証明書 有効残日数
+	Protocol          string `json:",omitempty"` // プロトコル
+	Port              string `json:",omitempty"` // ポート
+	Path              string `json:",omitempty"` // HTTP/HTTPS監視の場合のリクエストパス
+	Status            string `json:",omitempty"` // HTTP/HTTPS監視の場合の期待ステータスコード
+	SNI               string `json:",omitempty"` // HTTPS監視時のSNI有効/無効
+	Host              string `json:",omitempty"` // 対象ホスト(IP or FQDN)
+	BasicAuthUsername string `json:",omitempty"` // HTTP/HTTPS監視の場合のBASIC認証 ユーザー名
+	BasicAuthPassword string `json:",omitempty"` // HTTP/HTTPS監視の場合のBASIC認証 パスワード
+	QName             string `json:",omitempty"` // DNS監視の場合の問い合わせFQDN
+	ExpectedData      string `json:",omitempty"` // 期待値
+	Community         string `json:",omitempty"` // SNMP監視の場合のコミュニティ名
+	SNMPVersion       string `json:",omitempty"` // SNMP監視 SNMPバージョン
+	OID               string `json:",omitempty"` // SNMP監視 OID
+	RemainingDays     int    `json:",omitempty"` // SSL証明書 有効残日数
 }
 
 // SimpleMonitorNotify シンプル監視通知
@@ -142,29 +144,33 @@ func (s *SimpleMonitor) SetHealthCheckTCP(port string) {
 }
 
 // SetHealthCheckHTTP HTTPでのヘルスチェック設定
-func (s *SimpleMonitor) SetHealthCheckHTTP(port string, path string, status string, host string) {
+func (s *SimpleMonitor) SetHealthCheckHTTP(port string, path string, status string, host string, user, pass string) {
 	s.Settings.SimpleMonitor.HealthCheck = &SimpleMonitorHealthCheck{
-		Protocol: "http",
-		Port:     port,
-		Path:     path,
-		Status:   status,
-		Host:     host,
+		Protocol:          "http",
+		Port:              port,
+		Path:              path,
+		Status:            status,
+		Host:              host,
+		BasicAuthUsername: user,
+		BasicAuthPassword: pass,
 	}
 }
 
 // SetHealthCheckHTTPS HTTPSでのヘルスチェック設定
-func (s *SimpleMonitor) SetHealthCheckHTTPS(port string, path string, status string, host string, sni bool) {
+func (s *SimpleMonitor) SetHealthCheckHTTPS(port string, path string, status string, host string, sni bool, user, pass string) {
 	strSNI := "False"
 	if sni {
 		strSNI = "True"
 	}
 	s.Settings.SimpleMonitor.HealthCheck = &SimpleMonitorHealthCheck{
-		Protocol: "https",
-		Port:     port,
-		Path:     path,
-		Status:   status,
-		Host:     host,
-		SNI:      strSNI,
+		Protocol:          "https",
+		Port:              port,
+		Path:              path,
+		Status:            status,
+		Host:              host,
+		SNI:               strSNI,
+		BasicAuthUsername: user,
+		BasicAuthPassword: pass,
 	}
 }
 

--- a/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router_status.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router_status.go
@@ -5,4 +5,22 @@ type VPCRouterStatus struct {
 	FirewallReceiveLogs []string
 	FirewallSendLogs    []string
 	VPNLogs             []string
+	DHCPServerLeases    []struct {
+		IPAddress  string
+		MACAddress string
+	}
+	L2TPIPsecServerSessions []struct {
+		User      string
+		IPAddress string
+		TimeSec   string
+	}
+	PPTPServerSessions []struct {
+		User      string
+		IPAddress string
+		TimeSec   string
+	}
+	SiteToSiteIPsecVPNPeers []struct {
+		Status string
+		Peer   string
+	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -837,38 +837,38 @@
 		{
 			"checksumSHA1": "8nDGNcD2krFRHIfRjkHx+e715eQ=",
 			"path": "github.com/sacloud/libsacloud",
-			"revision": "fe25edb44f1e9b5f601f472e4c3ef688f10c628d",
-			"revisionTime": "2018-08-07T01:26:10Z"
+			"revision": "9207724918f5a5c8eeb188e11d81d457922e550e",
+			"revisionTime": "2018-08-23T07:11:47Z"
 		},
 		{
 			"checksumSHA1": "ZUzeefxzjgdxHAxHkSAAePFHR70=",
 			"path": "github.com/sacloud/libsacloud/api",
-			"revision": "fe25edb44f1e9b5f601f472e4c3ef688f10c628d",
-			"revisionTime": "2018-08-07T01:26:10Z"
+			"revision": "9207724918f5a5c8eeb188e11d81d457922e550e",
+			"revisionTime": "2018-08-23T07:11:47Z"
 		},
 		{
-			"checksumSHA1": "4AkCd74kAf9M4LDWj85d0htbHtU=",
+			"checksumSHA1": "epFeaAW3W176crE+Lr67Hka4W5g=",
 			"path": "github.com/sacloud/libsacloud/sacloud",
-			"revision": "fe25edb44f1e9b5f601f472e4c3ef688f10c628d",
-			"revisionTime": "2018-08-07T01:26:10Z"
+			"revision": "9207724918f5a5c8eeb188e11d81d457922e550e",
+			"revisionTime": "2018-08-23T07:11:47Z"
 		},
 		{
 			"checksumSHA1": "CCHevC5s2wMPgjYZMKhbcTmB65w=",
 			"path": "github.com/sacloud/libsacloud/sacloud/ostype",
-			"revision": "fe25edb44f1e9b5f601f472e4c3ef688f10c628d",
-			"revisionTime": "2018-08-07T01:26:10Z"
+			"revision": "9207724918f5a5c8eeb188e11d81d457922e550e",
+			"revisionTime": "2018-08-23T07:11:47Z"
 		},
 		{
 			"checksumSHA1": "WTBpxpedzjJAQKMVJ/w8/G72DHU=",
 			"path": "github.com/sacloud/libsacloud/utils/server",
-			"revision": "fe25edb44f1e9b5f601f472e4c3ef688f10c628d",
-			"revisionTime": "2018-08-07T01:26:10Z"
+			"revision": "9207724918f5a5c8eeb188e11d81d457922e550e",
+			"revisionTime": "2018-08-23T07:11:47Z"
 		},
 		{
 			"checksumSHA1": "rFnP8fart3FGUJK1OLNZuNk4Tmc=",
 			"path": "github.com/sacloud/libsacloud/utils/setup",
-			"revision": "fe25edb44f1e9b5f601f472e4c3ef688f10c628d",
-			"revisionTime": "2018-08-07T01:26:10Z"
+			"revision": "9207724918f5a5c8eeb188e11d81d457922e550e",
+			"revisionTime": "2018-08-23T07:11:47Z"
 		},
 		{
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",

--- a/website/docs/d/simple_monitor.html.markdown
+++ b/website/docs/d/simple_monitor.html.markdown
@@ -48,6 +48,8 @@ Attributes for Health Check:
 * `path` - The request path used in http/https health check access.
 * `status` - HTTP status code expected by health check access.
 * `sni` - The flag of enable/disable SNI.
+* `username` - The Basic Auth Username used in http/https health check access.
+* `password` - The Basic Auth Password request path used in http/https health check access.
 * `port` - Port number used in health check access.
 * `qname` - The QName value used in dns health check access.
 * `excepcted_data` - The expect value used in dns/snmp health check.

--- a/website/docs/r/simple_monitor.html.markdown
+++ b/website/docs/r/simple_monitor.html.markdown
@@ -23,6 +23,9 @@ resource sakuracloud_simple_monitor "foobar" {
     status      = "200"
     host_header = "hostname.example.com"
     sni         = true
+    # for Basic Auth
+    # username = "foo"
+    # password = "bar"
   }
     
   notify_email_enabled = true
@@ -71,6 +74,8 @@ Valid value is one of the following: [ "http" / "https" / "ping" / "tcp" / "dns"
 * `path` - (Optional) The request path used in http/https health check access.
 * `status` - (Optional) HTTP status code expected by health check access.
 * `sni` - (Optional) The flag of enable/disable SNI.
+* `username` - (Optional) The Basic Auth Username used in http/https health check access.
+* `password` - (Optional) The Basic Auth Password request path used in http/https health check access.
 * `port` - (Optional) Port number used in health check access.
 * `qname` - (Optional) The QName value used in dns health check access.
 * `excepcted_data` - (Optional) The expect value used in dns/snmp health check.


### PR DESCRIPTION
シンプル監視にてプロトコルに`http`または`https`を指定した際、Basic認証用のユーザ名/パスワードを指定可能にする。

#### 例

```tf
resource sakuracloud_simple_monitor "foobar" {
  target       = "www.example.com"
  health_check = {
    protocol    = "https"
    path        = "/"
    status      = "200"
    # for Basic Auth
    username = "foo" # ユーザー名
    password = "bar" # パスワード
  }
    
  notify_email_enabled = true
  notify_email_html    = true
}
```