### PR TITLE
ロードバランサーVIPヘの説明欄追加

### DIFF
--- a/build_docs/docs/configuration/resources/load_balancer.md
+++ b/build_docs/docs/configuration/resources/load_balancer.md
@@ -35,6 +35,7 @@ resource sakuracloud_load_balancer_vip "vip1" {
   port             = 80
   #delay_loop       = 10
   #sorry_server     = "192.168.11.11"
+  #description      = "description"
 
   zone = "tk1v"
 }
@@ -117,6 +118,7 @@ resource sakuracloud_switch "sw" {
 | `port`             | ◯   | ポート番号      | -        | 数値                          | - |
 | `delay_loop`       | -   | チェック間隔秒数  | `10`    | `10`〜`2147483647`の整数           | - |
 | `sorry_server`     | -   | ソーリーサーバ  | -        | 文字列     | VIPに紐づく実サーバがすべてダウンした場合、<br />すべてのアクセスを指定したサーバに誘導します |
+| `description`      | -   | 説明           | -        | 文字列                         | - |
 | `zone`             | -   | ゾーン          | -        | `is1a`<br />`is1b`<br />`tk1a`<br />`tk1v` | - |
 
 

--- a/sakuracloud/resource_sakuracloud_loadbalancer_vip.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer_vip.go
@@ -46,6 +46,10 @@ func resourceSakuraCloudLoadBalancerVIP() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"zone": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/sakuracloud/resource_sakuracloud_loadbalancer_vip_test.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer_vip_test.go
@@ -31,6 +31,8 @@ func TestAccSakuraCloudLoadBalancerVIP(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_load_balancer_vip.vip1", "sorry_server", "192.168.11.11"),
 					resource.TestCheckResourceAttr(
+						"sakuracloud_load_balancer_vip.vip1", "description", "description"),
+					resource.TestCheckResourceAttr(
 						"sakuracloud_load_balancer_vip.vip2", "vip", "192.168.11.202"),
 				),
 			},
@@ -111,6 +113,7 @@ resource "sakuracloud_load_balancer_vip" "vip1" {
     port = 80
     delay_loop = 100
     sorry_server = "192.168.11.11"
+    description  = "description"
 }
 resource "sakuracloud_load_balancer_vip" "vip2" {
     load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"

--- a/website/docs/r/load_balancer_vip.html.markdown
+++ b/website/docs/r/load_balancer_vip.html.markdown
@@ -29,6 +29,7 @@ resource "sakuracloud_load_balancer_vip" "vip1" {
     port             = 80
     delay_loop       = 50
     sorry_server     = "192.168.2.201"
+    description      = "description"
 }
 ```
 
@@ -41,6 +42,7 @@ The following arguments are supported:
 * `port` - (Required) The port number on which Load Balancer listens.
 * `delay_loop` - (Optional) The interval seconds for health check access.
 * `sorry_server` - (Optional) The hostname or IP address of sorry server.
+* `description` - (Optional) The description of the VIP.
 * `zone` - (Optional) The ID of the zone to which the resource belongs.
 
 ## Attributes Reference
@@ -52,6 +54,7 @@ The following attributes are exported:
 * `port` - The port number on which Load Balancer listens.
 * `delay_loop` - The interval seconds for Health check access.
 * `sorry_server` - The hostname or IP address of sorry server.
+* `description` - The description of the VIP.
 * `servers` - The internal ID list of servers under VIP.
 * `zone` - The ID of the zone to which the resource belongs.
 


### PR DESCRIPTION
VIPに対し説明を記載可能にする。

#### 利用例

```tf
resource "sakuracloud_load_balancer_vip" "vip1" {
    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
    vip              = "192.168.2.101"
    port             = 80
    delay_loop       = 50
    sorry_server     = "192.168.2.201"
    description      = "description" # VIPの説明
}
```