### PR TITLE
ディスクのストレージ隔離用パラメータ distant_from 追加

### DIFF
--- a/build_docs/docs/configuration/resources/disk.md
+++ b/build_docs/docs/configuration/resources/disk.md
@@ -22,6 +22,8 @@ resource sakuracloud_disk "disk01" {
   #  ignore_changes = ["source_archive_id"] 
   #}
 
+  # 指定ディスクと別ストレージに格納したい場合
+  #distant_from = ["<your-disk-id>"]
 
   #ディスクの修正関連
   hostname = "your-host-name"
@@ -67,6 +69,7 @@ resource sakuracloud_note "note" {
 | `plan`            | -   | ディスクプラン        | `ssd` | `ssd`<br />`hdd` | - |
 | `connector`      | -   | ディスク接続          | `virtio` | `virtio`<br />`ide`    | - |
 | `size`            | -   | ディスクサイズ(GB単位) | 20       | 数値                    | - |
+| `distant_from`    | -   | ストレージ隔離対象ディスクID | -       | リスト(文字列)                    | ストレージを隔離したいディスクのIDのリスト |
 |`source_archive_id`| -   | コピー元アーカイブID   | -        | 文字列                | [注1](#注1) |
 |`source_disk_id`   | -   | コピー元ディスクID   | -        | 文字列                | [注1](#注1) |
 | `hostname`        | -   | ホスト名               | - | 文字列 | ディスク修正機能で設定される、ホスト名 [注2](#注2)|

--- a/sakuracloud/resource_sakuracloud_disk.go
+++ b/sakuracloud/resource_sakuracloud_disk.go
@@ -65,6 +65,12 @@ func resourceSakuraCloudDisk() *schema.Resource {
 				ForceNew: true,
 				Default:  20,
 			},
+			"distant_from": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+			},
 			"server_id": {
 				Type:     schema.TypeString,
 				Computed: true, //ReadOnly
@@ -166,6 +172,19 @@ func resourceSakuraCloudDiskCreate(d *schema.ResourceData, meta interface{}) err
 	rawTags := d.Get("tags").([]interface{})
 	if rawTags != nil {
 		opts.Tags = expandTags(client, rawTags)
+	}
+
+	if _, ok := d.GetOk("distant_from"); ok {
+		rawDistantFrom := d.Get("distant_from").([]interface{})
+		if rawDistantFrom != nil {
+			strDiskIDs := expandStringList(rawDistantFrom)
+			diskIDs := []int64{}
+			for _, id := range strDiskIDs {
+				diskIDs = append(diskIDs, int64(forceAtoI(id)))
+			}
+
+			opts.DistantFrom = diskIDs
+		}
 	}
 
 	diskBuilder := &setup.RetryableSetup{

--- a/sakuracloud/resource_sakuracloud_disk_test.go
+++ b/sakuracloud/resource_sakuracloud_disk_test.go
@@ -188,6 +188,7 @@ resource "sakuracloud_disk" "foobar" {
     plan = "ssd"
     connector = "virtio"
     size = 20
+    distant_from = ["111111111111"]
     source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
     description = "Disk from TerraForm for SAKURA CLOUD"
     tags = ["hoge1" , "hoge2"]
@@ -213,6 +214,7 @@ resource "sakuracloud_disk" "foobar" {
     plan = "ssd"
     connector = "virtio"
     size = 20
+    distant_from = ["111111111111"]
     source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
     description = "Disk from TerraForm for SAKURA CLOUD"
     tags = ["hoge1" , "hoge2"]

--- a/vendor/github.com/sacloud/libsacloud/api/disk.go
+++ b/vendor/github.com/sacloud/libsacloud/api/disk.go
@@ -56,7 +56,15 @@ func (api *DiskAPI) Create(value *sacloud.Disk) (*sacloud.Disk, error) {
 		Success string `json:",omitempty"`
 	}
 	res := &diskResponse{}
-	err := api.create(api.createRequest(value), res)
+
+	rawBody := &sacloud.Request{}
+	rawBody.Disk = value
+	if len(value.DistantFrom) > 0 {
+		rawBody.DistantFrom = value.DistantFrom
+		value.DistantFrom = []int64{}
+	}
+
+	err := api.create(rawBody, res)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +98,14 @@ func (api *DiskAPI) install(id int64, body *sacloud.Disk) (bool, error) {
 		Success string `json:",omitempty"`
 	}
 	res := &diskResponse{}
-	err := api.baseAPI.request(method, uri, api.createRequest(body), res)
+	rawBody := &sacloud.Request{}
+	rawBody.Disk = body
+	if len(body.DistantFrom) > 0 {
+		rawBody.DistantFrom = body.DistantFrom
+		body.DistantFrom = []int64{}
+	}
+
+	err := api.baseAPI.request(method, uri, rawBody, res)
 	if err != nil {
 		return false, err
 	}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
@@ -213,7 +213,7 @@ type Request struct {
 	Filter               map[string]interface{} `json:",omitempty"` // フィルタ
 	Exclude              []string               `json:",omitempty"` // 除外する項目
 	Include              []string               `json:",omitempty"` // 取得する項目
-
+	DistantFrom          []int64                `json:",omitempty"` // ストレージ隔離対象ディスク
 }
 
 // AddFilter フィルタの追加

--- a/vendor/github.com/sacloud/libsacloud/sacloud/server.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/server.go
@@ -43,10 +43,13 @@ func (s *Server) IPAddress() string {
 
 // Gateway デフォルトゲートウェイアドレス
 func (s *Server) Gateway() string {
-	if len(s.Interfaces) == 0 || s.Interfaces[0].Switch == nil || s.Interfaces[0].Switch.UserSubnet == nil {
+	if len(s.Interfaces) == 0 || s.Interfaces[0].Switch == nil {
 		return ""
 	}
-	return s.Interfaces[0].Switch.UserSubnet.DefaultRoute
+	if s.Interfaces[0].Switch.UserSubnet != nil {
+		return s.Interfaces[0].Switch.UserSubnet.DefaultRoute
+	}
+	return s.Interfaces[0].Switch.Subnet.DefaultRoute
 }
 
 // DefaultRoute デフォルトゲートウェイアドレス(Gatewayのエイリアス)
@@ -56,10 +59,13 @@ func (s *Server) DefaultRoute() string {
 
 // NetworkMaskLen サーバの1番目のNIC(eth0)のネットワークマスク長
 func (s *Server) NetworkMaskLen() int {
-	if len(s.Interfaces) == 0 || s.Interfaces[0].Switch == nil || s.Interfaces[0].Switch.UserSubnet == nil {
+	if len(s.Interfaces) == 0 || s.Interfaces[0].Switch == nil {
 		return 0
 	}
-	return s.Interfaces[0].Switch.UserSubnet.NetworkMaskLen
+	if s.Interfaces[0].Switch.UserSubnet != nil {
+		return s.Interfaces[0].Switch.UserSubnet.NetworkMaskLen
+	}
+	return s.Interfaces[0].Switch.Subnet.NetworkMaskLen
 }
 
 // NetworkAddress サーバの1番目のNIC(eth0)のネットワークアドレス

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -837,38 +837,38 @@
 		{
 			"checksumSHA1": "8nDGNcD2krFRHIfRjkHx+e715eQ=",
 			"path": "github.com/sacloud/libsacloud",
-			"revision": "1c75e3a1aa0ec8dfe435ec4fc309cfc8afb2b793",
-			"revisionTime": "2018-08-31T01:03:41Z"
+			"revision": "9d2d727a9ddcec03444dc20aafd9f1e284cfdbe4",
+			"revisionTime": "2018-09-04T07:33:19Z"
 		},
 		{
-			"checksumSHA1": "Q105JaP5A4y5JHQbrU/XyywR/XQ=",
+			"checksumSHA1": "SjwqdEPn8jtMNUBDR6J2I1rPI9s=",
 			"path": "github.com/sacloud/libsacloud/api",
-			"revision": "1c75e3a1aa0ec8dfe435ec4fc309cfc8afb2b793",
-			"revisionTime": "2018-08-31T01:03:41Z"
+			"revision": "9d2d727a9ddcec03444dc20aafd9f1e284cfdbe4",
+			"revisionTime": "2018-09-04T07:33:19Z"
 		},
 		{
-			"checksumSHA1": "epFeaAW3W176crE+Lr67Hka4W5g=",
+			"checksumSHA1": "GyGvI781B2eXgbCXsibc3Xr7dHw=",
 			"path": "github.com/sacloud/libsacloud/sacloud",
-			"revision": "1c75e3a1aa0ec8dfe435ec4fc309cfc8afb2b793",
-			"revisionTime": "2018-08-31T01:03:41Z"
+			"revision": "9d2d727a9ddcec03444dc20aafd9f1e284cfdbe4",
+			"revisionTime": "2018-09-04T07:33:19Z"
 		},
 		{
 			"checksumSHA1": "LmBnV3yfAhrU0ceC++K1oovT7kY=",
 			"path": "github.com/sacloud/libsacloud/sacloud/ostype",
-			"revision": "1c75e3a1aa0ec8dfe435ec4fc309cfc8afb2b793",
-			"revisionTime": "2018-08-31T01:03:41Z"
+			"revision": "9d2d727a9ddcec03444dc20aafd9f1e284cfdbe4",
+			"revisionTime": "2018-09-04T07:33:19Z"
 		},
 		{
 			"checksumSHA1": "WTBpxpedzjJAQKMVJ/w8/G72DHU=",
 			"path": "github.com/sacloud/libsacloud/utils/server",
-			"revision": "1c75e3a1aa0ec8dfe435ec4fc309cfc8afb2b793",
-			"revisionTime": "2018-08-31T01:03:41Z"
+			"revision": "9d2d727a9ddcec03444dc20aafd9f1e284cfdbe4",
+			"revisionTime": "2018-09-04T07:33:19Z"
 		},
 		{
 			"checksumSHA1": "rFnP8fart3FGUJK1OLNZuNk4Tmc=",
 			"path": "github.com/sacloud/libsacloud/utils/setup",
-			"revision": "1c75e3a1aa0ec8dfe435ec4fc309cfc8afb2b793",
-			"revisionTime": "2018-08-31T01:03:41Z"
+			"revision": "9d2d727a9ddcec03444dc20aafd9f1e284cfdbe4",
+			"revisionTime": "2018-09-04T07:33:19Z"
 		},
 		{
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -22,6 +22,9 @@ resource "sakuracloud_disk" "foobar" {
   source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
   # or
   # source_disk_id  = "<your-disk-id>"
+
+  # for storage isolation
+  #distant_from = ["<your-disk-id>"]
   
   # For "Modify Disk" API
   hostname          = "your-host-name"
@@ -50,6 +53,7 @@ Valid value is one of the following: [ "ssd" (default) / "hdd"]
 * `conector` - The disk connector of the resource.  
 Valid value is one of the following: [ "virtio" (default) / "ide"]
 * `size` - Size of the resource (unit:`GB`).
+* `distant_from` - The ID list of the Disks isolated from Disk.
 * `source_archive_id` - The ID of source Archive.
 * `source_disk_id` - The ID of source Disk.
 * `hostname` - The hostname to set with `"Modify Disk"` API.


### PR DESCRIPTION
指定ディスクと格納ストレージを隔離するためのパラメータ `distant_from`をディスクリソースに追加

#### 利用例

```tf
#ディスクの定義
resource sakuracloud_disk "disk01" {
  # ...

  # 指定ディスクと別ストレージに格納する
  distant_from = ["${sakuracloud_disk.diskXX.id}"]
}
```