### PR TITLE
石狩第1ゾーンの利用可能リソース拡大

### DIFF
--- a/sakuracloud/data_source_sakuracloud_database.go
+++ b/sakuracloud/data_source_sakuracloud_database.go
@@ -112,7 +112,7 @@ func dataSourceSakuraCloudDatabase() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateZone([]string{"tk1a", "is1b"}),
+				ValidateFunc: validateZone([]string{"tk1a", "is1b", "is1a"}),
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_auto_backup.go
+++ b/sakuracloud/resource_sakuracloud_auto_backup.go
@@ -63,7 +63,7 @@ func resourceSakuraCloudAutoBackup() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Description:  "target SakuraCloud zone",
-				ValidateFunc: validateZone([]string{"is1b", "tk1a"}),
+				ValidateFunc: validateZone([]string{"is1b", "tk1a", "is1a"}),
 			},
 		},
 	}


### PR DESCRIPTION
- 自動バックアップ
- データベース（データソース)

なお現時点では自動バックアップはis1aを指定できるものの利用不可となっている。
ref: https://cloud-news.sakura.ad.jp/2018/08/01/autobackup-release/