### PR TITLE
allow for define gslb_servers on sakuracloud_gslb

### DIFF
--- a/build_docs/docs/configuration/resources/gslb.md
+++ b/build_docs/docs/configuration/resources/gslb.md
@@ -26,25 +26,26 @@ resource "sakuracloud_gslb" "gslb" {
   #sorry_server = "192.0.2.254"
   description = "GSLB from terraform for SAKURA CLOUD"
   tags        = ["tag1", "tag2"]
+  
+  servers {
+    ipaddress = "192.0.2.1"
+    #weight    = 1
+    #enabled   = true
+  }
+  servers {
+    ipaddress = "192.0.2.2"
+    #weight    = 1
+    #enabled   = true
+  }
 }
 
-#GSLB配下のサーバ1
-resource "sakuracloud_gslb_server" "gslb_server01" {
-  gslb_id   = sakuracloud_gslb.gslb.id
-  ipaddress = "192.0.2.1"
-  #weight    = 1
-  #enabled   = true
-}
-
-
-#GSLB配下のサーバ2
-resource "sakuracloud_gslb_server" "gslb_server02" {
-  gslb_id   = sakuracloud_gslb.gslb.id
-  ipaddress = "192.0.2.2"
-  #weight    = 1
-  #enabled   = true
-}
-
+#GSLB配下のサーバ(後方互換のため以下の書き方も可能になっています)
+#resource "sakuracloud_gslb_server" "gslb_server01" {
+#  gslb_id   = sakuracloud_gslb.gslb.id
+#  ipaddress = "192.0.2.1"
+#  #weight    = 1
+#  #enabled   = true
+#}
 ```
 
 ## `sakuracloud_gslb`
@@ -72,6 +73,16 @@ resource "sakuracloud_gslb_server" "gslb_server02" {
 | `status`      | △   | レスポンスコード | - | 文字列 | プロトコルが`http`または`https`の場合のみ有効かつ必須 |
 | `port`        | △   | ポート番号 | - | 数値 | プロトコルが`tcp`の場合のみ有効かつ必須 |
 
+### `servers`
+
+この要素は最大6つまで指定可能です。  
+
+|パラメーター  |必須  |名称          |初期値   |設定値                 |補足                                          |
+|------------|:---:|--------------|:------:|---------------------|----------------------------------------------|
+| `ipaddress`| ◯   | IPアドレス     | -      | 文字列               | 監視対象サーバのIPアドレス|
+| `enabled`  | -   | 有効          | `true` | `true`<br />`false` | - |
+| `weight`   | -   | 重み          | `1`    | 数値                 | 重み付け応答が有効な場合のみ有効。`1`〜`10000`|
+
 ### 属性
 
 |属性名          | 名称             | 補足                                        |
@@ -79,6 +90,9 @@ resource "sakuracloud_gslb_server" "gslb_server02" {
 | `id`          | ID              | -                                          |
 | `fqdn`        | GSLB-FQDN       | GSLB作成時に割り当てられるFQDN<br />ロードバランシングしたいホスト名をFQDNのCNAMEとしてDNS登録する    |
 
+**注意**  
+
+同一のGSLBに対し`servers`属性と`sakuracloud_gslb_server`リソースの併用はできません。
 
 
 ## `sakuracloud_gslb_server`

--- a/sakuracloud/resource_sakuracloud_gslb.go
+++ b/sakuracloud/resource_sakuracloud_gslb.go
@@ -2,6 +2,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -76,6 +77,15 @@ func resourceSakuraCloudGSLB() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"servers": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 6,
+				Elem: &schema.Resource{
+					Schema: gslbServerValueSchemas,
+				},
+			},
 			"icon_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -93,6 +103,24 @@ func resourceSakuraCloudGSLB() *schema.Resource {
 			},
 		},
 	}
+}
+
+var gslbServerValueSchemas = map[string]*schema.Schema{
+	"ipaddress": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	},
+	"weight": {
+		Type:         schema.TypeInt,
+		Optional:     true,
+		ValidateFunc: validation.IntBetween(1, 10000),
+		Default:      1,
+	},
 }
 
 func resourceSakuraCloudGSLBCreate(d *schema.ResourceData, meta interface{}) error {
@@ -142,6 +170,12 @@ func resourceSakuraCloudGSLBCreate(d *schema.ResourceData, meta interface{}) err
 	rawTags := d.Get("tags").([]interface{})
 	if rawTags != nil {
 		opts.Tags = expandTags(client, rawTags)
+	}
+
+	for _, s := range d.Get("servers").([]interface{}) {
+		v := s.(map[string]interface{})
+		server := expandGSLBServer(&resourceMapValue{value: v})
+		opts.AddGSLBServer(server)
 	}
 
 	gslb, err := client.GSLB.Create(opts)
@@ -240,6 +274,16 @@ func resourceSakuraCloudGSLBUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
+	if d.HasChange("servers") {
+		gslb.ClearGSLBServer()
+
+		for _, s := range d.Get("servers").([]interface{}) {
+			v := s.(map[string]interface{})
+			server := expandGSLBServer(&resourceMapValue{value: v})
+			gslb.AddGSLBServer(server)
+		}
+	}
+
 	gslb, err = client.GSLB.Update(gslb.ID, gslb)
 	if err != nil {
 		return fmt.Errorf("Failed to create SakuraCloud GSLB resource: %s", err)
@@ -279,6 +323,17 @@ func setGSLBResourceData(d *schema.ResourceData, client *APIClient, data *saclou
 	healthCheck["protocol"] = data.Settings.GSLB.HealthCheck.Protocol
 	healthCheck["delay_loop"] = data.Settings.GSLB.DelayLoop
 	d.Set("health_check", []interface{}{healthCheck})
+
+	var servers = []interface{}{}
+	for _, server := range data.Settings.GSLB.Servers {
+		v := map[string]interface{}{}
+		v["ipaddress"] = server.IPAddress
+		v["enabled"] = strings.ToLower(server.Enabled) == "true"
+		weight, _ := strconv.Atoi(server.Weight)
+		v["weight"] = weight
+		servers = append(servers, v)
+	}
+	d.Set("servers", servers)
 
 	d.Set("sorry_server", data.Settings.GSLB.SorryServer)
 	d.Set("icon_id", data.GetIconStrID())

--- a/sakuracloud/resource_sakuracloud_gslb_server.go
+++ b/sakuracloud/resource_sakuracloud_gslb_server.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/sacloud/libsacloud/api"
 	"github.com/sacloud/libsacloud/sacloud"
 )
@@ -18,34 +17,23 @@ func resourceSakuraCloudGSLBServer() *schema.Resource {
 		Create: resourceSakuraCloudGSLBServerCreate,
 		Read:   resourceSakuraCloudGSLBServerRead,
 		Delete: resourceSakuraCloudGSLBServerDelete,
-
-		Schema: map[string]*schema.Schema{
-			"gslb_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validateSakuracloudIDType,
-			},
-			"ipaddress": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-			},
-			"enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  true,
-			},
-			"weight": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(1, 10000),
-				ForceNew:     true,
-				Default:      1,
-			},
-		},
+		Schema: gslbServerResourceSchema(),
 	}
+}
+
+func gslbServerResourceSchema() map[string]*schema.Schema {
+	s := mergeSchemas(map[string]*schema.Schema{
+		"gslb_id": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validateSakuracloudIDType,
+		},
+	}, gslbServerValueSchemas)
+	for _, v := range s {
+		v.ForceNew = true
+	}
+	return s
 }
 
 func resourceSakuraCloudGSLBServerCreate(d *schema.ResourceData, meta interface{}) error {
@@ -148,12 +136,25 @@ func gslbServerIDHash(gslbID string, s *sacloud.GSLBServer) string {
 	return fmt.Sprintf("gslbserver-%d", hashcode.String(buf.String()))
 }
 
-func expandGSLBServer(d *schema.ResourceData) *sacloud.GSLBServer {
+func expandGSLBServer(d resourceValueGetable) *sacloud.GSLBServer {
 	var gslb = sacloud.GSLB{}
-	server := gslb.CreateGSLBServer(d.Get("ipaddress").(string))
-	if !d.Get("enabled").(bool) {
+	var ipaddress string
+	var enabled bool
+	var weight int
+	if v, ok := d.GetOk("ipaddress"); ok {
+		ipaddress = v.(string)
+	}
+	if v, ok := d.GetOk("weight"); ok {
+		weight = v.(int)
+	}
+	if v, ok := d.GetOk("enabled"); ok {
+		enabled = v.(bool)
+	}
+
+	server := gslb.CreateGSLBServer(ipaddress)
+	if !enabled {
 		server.Enabled = "False"
 	}
-	server.Weight = fmt.Sprintf("%d", d.Get("weight").(int))
+	server.Weight = fmt.Sprintf("%d", weight)
 	return server
 }

--- a/sakuracloud/resource_sakuracloud_gslb_test.go
+++ b/sakuracloud/resource_sakuracloud_gslb_test.go
@@ -31,6 +31,18 @@ func TestAccResourceSakuraCloudGSLB(t *testing.T) {
 						"sakuracloud_gslb.foobar", "health_check.0.delay_loop", "10"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "health_check.0.host_header", "terraform.io"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.0.ipaddress", "1.1.1.1"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.0.weight", "1"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.1.ipaddress", "2.2.2.2"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.1.weight", "2"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.1.enabled", "false"),
 					resource.TestCheckResourceAttrPair(
 						"sakuracloud_gslb.foobar", "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -52,6 +64,18 @@ func TestAccResourceSakuraCloudGSLB(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "health_check.0.host_header", "update.terraform.io"),
 					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.0.ipaddress", "2.2.2.2"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.0.weight", "2"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.1.ipaddress", "3.3.3.3"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.1.weight", "3"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.1.enabled", "false"),
+					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "icon_id", ""),
 				),
 			},
@@ -69,6 +93,20 @@ func TestAccResourceSakuraCloudGSLB(t *testing.T) {
 						"sakuracloud_gslb.foobar", "health_check.0.delay_loop", "20"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_gslb.foobar", "health_check.0.host_header", "update.terraform.io"),
+
+					// gslb.servers is set compted=true, so left following values
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.0.ipaddress", "2.2.2.2"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.0.weight", "2"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.1.ipaddress", "3.3.3.3"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.1.weight", "3"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_gslb.foobar", "servers.1.enabled", "false"),
 				),
 			},
 		},
@@ -179,6 +217,16 @@ resource "sakuracloud_gslb" "foobar" {
         status = "200"
     }
     sorry_server = "8.8.8.8"
+    servers {
+        ipaddress = "1.1.1.1"
+        weight    = 1
+        enabled   = true
+    }
+    servers {
+        ipaddress = "2.2.2.2"
+        weight    = 2
+        enabled   = false
+    }
     description = "GSLB from TerraForm for SAKURA CLOUD"
     tags = ["hoge1", "hoge2"]
     icon_id = sakuracloud_icon.foobar.id
@@ -199,6 +247,16 @@ resource "sakuracloud_gslb" "foobar" {
         host_header = "update.terraform.io"
         path = "/"
         status = "200"
+    }
+    servers {
+        ipaddress = "2.2.2.2"
+        weight    = 2
+        enabled   = true
+    }
+    servers {
+        ipaddress = "3.3.3.3"
+        weight    = 3
+        enabled   = false
     }
     sorry_server = "8.8.4.4"
     description = "GSLB from TerraForm for SAKURA CLOUD"

--- a/sakuracloud/structure.go
+++ b/sakuracloud/structure.go
@@ -15,6 +15,25 @@ type resourceValueGetable interface {
 	GetOk(key string) (interface{}, bool)
 }
 
+type resourceMapValue struct {
+	value map[string]interface{}
+}
+
+func (r *resourceMapValue) GetOk(key string) (interface{}, bool) {
+	v, ok := r.value[key]
+	return v, ok
+}
+
+func mergeSchemas(schemas ...map[string]*schema.Schema) map[string]*schema.Schema {
+	m := map[string]*schema.Schema{}
+	for _, schema := range schemas {
+		for k, v := range schema {
+			m[k] = v
+		}
+	}
+	return m
+}
+
 func getSacloudAPIClient(d resourceValueGetable, meta interface{}) *APIClient {
 	c := meta.(*APIClient)
 	client := c.Clone()

--- a/website/docs/r/gslb.html.markdown
+++ b/website/docs/r/gslb.html.markdown
@@ -25,6 +25,18 @@ resource "sakuracloud_gslb" "foobar" {
     status      = "200"
   }
 
+  servers {
+    ipaddress = "192.0.2.1"
+    #weight    = 1
+    #enabled   = true
+  }
+  
+  servers {
+    ipaddress = "192.0.2.2"
+    #weight    = 1
+    #enabled   = true
+  }
+
   sorry_server = "192.2.0.1"
 
   description = "description"
@@ -38,6 +50,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.
 * `health_check` - (Required) Health check rules. It contains some attributes to [Health Check](#health-check).
+* `servers` - (Optional) Real servers. It contains some attributes to [Servers](#servers).
 * `weighted` - (Optional) The flag for enable/disable weighting (default:`true`).
 * `sorry_server` - (Optional) The hostname or IP address of sorry server.
 * `description` - (Optional) The description of the resource.
@@ -55,6 +68,12 @@ Valid value is one of the following: [ "http" / "https" / "ping" / "tcp" ]
 * `path` - (Optional) The request path used in http/https health check access.
 * `status` - (Optional) HTTP status code expected by health check access.
 * `port` - (Optional) Port number used in tcp health check access.
+
+### Servers
+
+* `ipaddress` - (Required) The IP address of the GSLB Server.
+* `enabled` - (Optional) The flag for enable/disable the GSLB Server (default:`true`).
+* `weight` - (Optional) The weight of GSLB server used when weighting is enabled in the GSLB.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR makes possible to define gslb_server as nested resource on `sakuracloud_gslb`.

#### example

```tf
resource "sakuracloud_gslb" "foobar" {
    name = "example.com"
    health_check {
        protocol = "https"
        delay_loop = 20
        host_header = "sorry.example.com"
        path = "/"
        status = "200"
    }
    servers {
        ipaddress = "192.2.0.1"
        weight    = 1
        enabled   = true
    }
    servers {
        ipaddress = "192.2.0.2"
        weight    = 1
        enabled   = true
    }
}
```