### PR TITLE
SIMマルチキャリア対応

### DIFF
--- a/build_docs/docs/configuration/resources/sim.md
+++ b/build_docs/docs/configuration/resources/sim.md
@@ -14,6 +14,7 @@ resource "sakuracloud_sim" "sim" {
     iccid    = "<SIMに記載されているICCID>"
     passcode = "<SIMに記載されているPasscode>"
     imei     = "<端末識別番号(IMEIロックする場合のみ)>"
+    carrier  = ["softbank", "kddi", "docomo"]
     #enabled  = true
     
     mobile_gateway_id = "${sakuracloud_mobile_gateway.mgw.id}" # 接続するモバイルゲートウェイのID
@@ -36,6 +37,7 @@ resource sakuracloud_mobile_gateway "mgw" {
 | `iccid`             | ◯   | ICCID             | -        | 文字列                  | - |
 | `passcode`          | ◯   | パスコード         | -        | 文字列                  | - |
 | `imei`              | -   | IMEI(端末識別番号)  | - | 文字列 | - |
+| `carrier`           | ◯  | キャリア  | - | リスト(文字列)<br />`docomo` <br />`kddi` <br />`softbank` | 1つ以上必須、3つまで |
 | `enabled`           | -   | 有効/無効          | `true` | `true`<br />`false`| - |
 | `mobile_gateway_id` | -   | モバイルゲートウェイID  | - | 文字列 | - |
 | `ipaddress`         | -   | IPアドレス  | - | 文字列 | - |

--- a/sakuracloud/resource_sakuracloud_sim_test.go
+++ b/sakuracloud/resource_sakuracloud_sim_test.go
@@ -59,6 +59,10 @@ func TestAccResourceSakuraCloudSIM(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_sim.foobar", "description", "description_before"),
 					resource.TestCheckResourceAttr(
+						"sakuracloud_sim.foobar", "carrier.#", "1"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_sim.foobar", "carrier.0", "softbank"),
+					resource.TestCheckResourceAttr(
 						"sakuracloud_sim.foobar", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_sim.foobar", "tags.0", "hoge1"),
@@ -82,6 +86,10 @@ func TestAccResourceSakuraCloudSIM(t *testing.T) {
 						"sakuracloud_sim.foobar", "name", "name_after"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_sim.foobar", "description", "description_after"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_sim.foobar", "carrier.#", "1"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_sim.foobar", "carrier.0", "kddi"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_sim.foobar", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -177,6 +185,7 @@ resource "sakuracloud_sim" "foobar" {
     iccid = "%s"
     passcode = "%s"
     imei = "%s"
+    carrier = ["softbank"]
 
     enabled = true
     mobile_gateway_id = "${sakuracloud_mobile_gateway.mgw.id}"
@@ -201,6 +210,8 @@ resource "sakuracloud_sim" "foobar" {
     passcode = "%s"
     imei = "%s"
 
+    carrier = ["kddi"]
+
     enabled = false
     mobile_gateway_id = "${sakuracloud_mobile_gateway.mgw.id}"
     ipaddress = "192.168.100.2"
@@ -215,5 +226,6 @@ resource "sakuracloud_sim" "foobar" {
     iccid = "%s"
     passcode = "%s"
     imei = "%s"
+    carrier = ["softbank"]
     enabled = false
 }`

--- a/vendor/github.com/sacloud/libsacloud/api/base_api.go
+++ b/vendor/github.com/sacloud/libsacloud/api/base_api.go
@@ -138,7 +138,7 @@ func (api *baseAPI) filterBy(key string, value interface{}, multiple bool) *base
 			if f, ok := state.Filter[key]; ok {
 				if s, ok := f.(string); ok && s != "" {
 					if v, ok := value.(string); ok {
-						state.Filter[key] = fmt.Sprintf("%s %s", s, v)
+						state.Filter[key] = fmt.Sprintf("%s%%20%s", s, v)
 						return
 					}
 				}

--- a/vendor/github.com/sacloud/libsacloud/api/sim.go
+++ b/vendor/github.com/sacloud/libsacloud/api/sim.go
@@ -204,6 +204,37 @@ func (api *SIMAPI) Logs(id int64, body interface{}) ([]sacloud.SIMLog, error) {
 	return res.Logs, nil
 }
 
+// GetNetworkOperator 通信キャリア 取得
+func (api *SIMAPI) GetNetworkOperator(id int64) (*sacloud.SIMNetworkOperatorConfigs, error) {
+
+	var (
+		method = "GET"
+		uri    = fmt.Sprintf("%s/%d/sim/network_operator_config", api.getResourceURL(), id)
+	)
+
+	res := &sacloud.SIMNetworkOperatorConfigs{}
+	err := api.baseAPI.request(method, uri, nil, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// SetNetworkOperator 通信キャリア 設定
+func (api *SIMAPI) SetNetworkOperator(id int64, opConfig ...*sacloud.SIMNetworkOperatorConfig) (bool, error) {
+
+	var (
+		method = "PUT"
+		uri    = fmt.Sprintf("%s/%d/sim/network_operator_config", api.getResourceURL(), id)
+	)
+
+	err := api.baseAPI.request(method, uri, &sacloud.SIMNetworkOperatorConfigs{NetworkOperatorConfigs: opConfig}, nil)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // Monitor アクティビティーモニター(Up/Down link BPS)取得
 func (api *SIMAPI) Monitor(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	var (

--- a/vendor/github.com/sacloud/libsacloud/libsacloud.go
+++ b/vendor/github.com/sacloud/libsacloud/libsacloud.go
@@ -2,4 +2,4 @@
 package libsacloud
 
 // Version バージョン
-const Version = "1.0.0"
+const Version = "1.3.0"

--- a/vendor/github.com/sacloud/libsacloud/sacloud/sim.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/sim.go
@@ -7,6 +7,15 @@ import (
 	"time"
 )
 
+const (
+	// SIMOperatorsKDDI KDDI
+	SIMOperatorsKDDI = "KDDI"
+	// SIMOperatorsDOCOMO Docomo
+	SIMOperatorsDOCOMO = "NTT DOCOMO"
+	// SIMOperatorsSoftBank SoftBank
+	SIMOperatorsSoftBank = "SoftBank"
+)
+
 // SIM SIM(CommonServiceItem)
 type SIM struct {
 	*Resource        // ID
@@ -99,6 +108,18 @@ type SIMLog struct {
 	ResourceID    string     `json:"resource_id,omitempty"`
 	IMEI          string     `json:"imei,omitempty"`
 	IMSI          string     `json:"imsi,omitempty"`
+}
+
+// SIMNetworkOperatorConfig SIM通信キャリア設定
+type SIMNetworkOperatorConfig struct {
+	Allow       bool   `json:"allow,omitempty"`
+	CountryCode string `json:"country_code,omitempty"`
+	Name        string `json:"name,omitempty"`
+}
+
+// SIMNetworkOperatorConfigs SIM通信キャリア設定 リクエストパラメータ
+type SIMNetworkOperatorConfigs struct {
+	NetworkOperatorConfigs []*SIMNetworkOperatorConfig `json:"network_operator_config,omitempty"`
 }
 
 // CreateNewSIM SIM作成

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -835,40 +835,52 @@
 			"revisionTime": "2017-10-31T07:53:02Z"
 		},
 		{
-			"checksumSHA1": "TAD66bYm8QQgSbLDHFn8uBXg/hg=",
+			"checksumSHA1": "cHSqx9eSltUBTsZ73TSqqShhiOA=",
 			"path": "github.com/sacloud/libsacloud",
-			"revision": "108b1efe4b4d106fee6760bdf1847c4f92e1a92e",
-			"revisionTime": "2018-10-29T07:01:06Z"
+			"revision": "249671887191f0a26bcc49c016d9ce841b12c877",
+			"revisionTime": "2018-12-04T07:47:50Z",
+			"version": "v1.3.0",
+			"versionExact": "v1.3.0"
 		},
 		{
-			"checksumSHA1": "9DWJijrRy+K9cU4eq6avioXesuk=",
+			"checksumSHA1": "xDPS+QpQxrOnaOWcpWB9fncnu8c=",
 			"path": "github.com/sacloud/libsacloud/api",
-			"revision": "108b1efe4b4d106fee6760bdf1847c4f92e1a92e",
-			"revisionTime": "2018-10-29T07:01:06Z"
+			"revision": "249671887191f0a26bcc49c016d9ce841b12c877",
+			"revisionTime": "2018-12-04T07:47:50Z",
+			"version": "v1.3.0",
+			"versionExact": "v1.3.0"
 		},
 		{
-			"checksumSHA1": "kR63nGmLFAAse/7rbP/snjWC+8Q=",
+			"checksumSHA1": "44nHjeg7hEFaJDxNyj06pEbnaM0=",
 			"path": "github.com/sacloud/libsacloud/sacloud",
-			"revision": "108b1efe4b4d106fee6760bdf1847c4f92e1a92e",
-			"revisionTime": "2018-10-29T07:01:06Z"
+			"revision": "249671887191f0a26bcc49c016d9ce841b12c877",
+			"revisionTime": "2018-12-04T07:47:50Z",
+			"version": "v1.3.0",
+			"versionExact": "v1.3.0"
 		},
 		{
 			"checksumSHA1": "LmBnV3yfAhrU0ceC++K1oovT7kY=",
 			"path": "github.com/sacloud/libsacloud/sacloud/ostype",
-			"revision": "108b1efe4b4d106fee6760bdf1847c4f92e1a92e",
-			"revisionTime": "2018-10-29T07:01:06Z"
+			"revision": "249671887191f0a26bcc49c016d9ce841b12c877",
+			"revisionTime": "2018-12-04T07:47:50Z",
+			"version": "v1.3.0",
+			"versionExact": "v1.3.0"
 		},
 		{
 			"checksumSHA1": "WTBpxpedzjJAQKMVJ/w8/G72DHU=",
 			"path": "github.com/sacloud/libsacloud/utils/server",
-			"revision": "108b1efe4b4d106fee6760bdf1847c4f92e1a92e",
-			"revisionTime": "2018-10-29T07:01:06Z"
+			"revision": "249671887191f0a26bcc49c016d9ce841b12c877",
+			"revisionTime": "2018-12-04T07:47:50Z",
+			"version": "v1.3.0",
+			"versionExact": "v1.3.0"
 		},
 		{
 			"checksumSHA1": "rFnP8fart3FGUJK1OLNZuNk4Tmc=",
 			"path": "github.com/sacloud/libsacloud/utils/setup",
-			"revision": "108b1efe4b4d106fee6760bdf1847c4f92e1a92e",
-			"revisionTime": "2018-10-29T07:01:06Z"
+			"revision": "249671887191f0a26bcc49c016d9ce841b12c877",
+			"revisionTime": "2018-12-04T07:47:50Z",
+			"version": "v1.3.0",
+			"versionExact": "v1.3.0"
 		},
 		{
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",

--- a/website/docs/r/sim.html.markdown
+++ b/website/docs/r/sim.html.markdown
@@ -19,6 +19,7 @@ resource sakuracloud_sim "foobar" {
     iccid    = "<your-iccid>"
     passcode = "<your-passcode>"
     # imei     = "<imei>"
+    carrier  = ["docomo", "kddi", "softbank"]
     # enabled  = true
 
     # connect to the Mobile Gateway 
@@ -43,6 +44,8 @@ The following arguments are supported:
 * `iccid` - (Required) The ICCID of the SIM.  
 * `passcode` - (Required) The Passcode of the SIM.  
 * `imei` - (Optional) The IMEI of the device that allows communication.
+* `carrier` - (Required) The list of Carrier name.  
+Valid values are in followings: [ "docomo" / "kddi" / "softbank"]
 * `enabled` - (Optional) The flag of enable/disable the Server.
 * `mobile_gateway_id` - (Optional) The ID of the Mobile Gateway to which the SIM belongs.
 * `ipaddress` - (Optional) The IP address of the SIM. Used when connect to mobile gateway.


### PR DESCRIPTION
To fix #393 

SIMでのマルチキャリア設定をサポートする。

** *Note* **

キャリアは設定必須、かつTerraformではList型に対しデフォルト値を設定できない。
このためこの変更は後方互換性がなく、既存のSIMユーザーは`carrier`の記述をtfファイルに行う必要がある。
