### PR TITLE
Allow for define nested resources on sakuracloud_mobile_gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+go.sum
 .mailmap
 .env
 bin/terraform-provider-sakuracloud*

--- a/build_docs/docs/configuration/resources/mobile_gateway.md
+++ b/build_docs/docs/configuration/resources/mobile_gateway.md
@@ -30,23 +30,20 @@ resource "sakuracloud_mobile_gateway" "mgw" {
     slack_webhook        = "https://hooks.slack.com/services/xxx/xxx/xxx"
     auto_traffic_shaping = true
   }
+  
+  static_route {
+    prefix   = "192.168.10.0/24"
+    next_hop = "192.168.11.201"
+  }
 }
 
-# スタティックルートの定義
-resource "sakuracloud_mobile_gateway_static_route" "route01" {
-  mobile_gateway_id = sakuracloud_mobile_gateway.mgw.id
-
-  prefix   = "192.168.10.0/24"
-  next_hop = "192.168.11.201"
-}
-
-# スタティックルートの定義
-resource "sakuracloud_mobile_gateway_static_route" "route02" {
-  mobile_gateway_id = sakuracloud_mobile_gateway.mgw.id
-
-  prefix   = "192.168.10.0/26"
-  next_hop = "192.168.11.202"
-}
+# スタティックルートの定義(terraform v0.11)
+#resource "sakuracloud_mobile_gateway_static_route" "route01" {
+#  mobile_gateway_id = sakuracloud_mobile_gateway.mgw.id
+#
+#  prefix   = "192.168.10.0/24"
+#  next_hop = "192.168.11.201"
+#}
 
 # SIMルートの定義
 resource "sakuracloud_mobile_gateway_sim_route" "r3" {

--- a/sakuracloud/resource_sakuracloud_mobile_gateway.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway.go
@@ -106,6 +106,23 @@ func resourceSakuraCloudMobileGateway() *schema.Resource {
 					},
 				},
 			},
+			"static_route": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"prefix": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"next_hop": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 			"icon_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -257,6 +274,32 @@ func resourceSakuraCloudMobileGatewayCreate(d *schema.ResourceData, meta interfa
 		if err != nil {
 			return fmt.Errorf("Failed to wait SakuraCloud MobileGateway boot: %s", err)
 		}
+	}
+
+	// static route
+	if staticRoutes, ok := getListFromResource(d, "static_route"); ok && len(staticRoutes) > 0 {
+		for _, rawStaticRoutes := range staticRoutes {
+			values := mapToResourceData(rawStaticRoutes.(map[string]interface{}))
+			staticRoute := expandMobileGatewayStaticRoute(values)
+
+			// check duplicated
+			for _, sr := range mgw.Settings.MobileGateway.StaticRoutes {
+				if sr.Prefix == staticRoute.Prefix {
+					return fmt.Errorf("prefix %q already exists", sr.Prefix)
+				}
+			}
+
+			mgw.Settings.MobileGateway.StaticRoutes = append(mgw.Settings.MobileGateway.StaticRoutes, staticRoute)
+		}
+	}
+
+	mgw, err = client.MobileGateway.UpdateSetting(mgw.ID, mgw)
+	if err != nil {
+		return fmt.Errorf("Failed to enable SakuraCloud MobileGatewayStaticRoute resource: %s", err)
+	}
+	_, err = client.MobileGateway.Config(mgw.ID)
+	if err != nil {
+		return fmt.Errorf("Couldn'd apply SakuraCloud MobileGateway config: %s", err)
 	}
 
 	// boot
@@ -452,6 +495,35 @@ func resourceSakuraCloudMobileGatewayUpdate(d *schema.ResourceData, meta interfa
 		}
 	}
 
+	// static route
+	if d.HasChange("static_route") {
+		mgw.Settings.MobileGateway.StaticRoutes = []*sacloud.MGWStaticRoute{}
+		if staticRoutes, ok := getListFromResource(d, "static_route"); ok && len(staticRoutes) > 0 {
+			for _, rawStaticRoutes := range staticRoutes {
+				values := mapToResourceData(rawStaticRoutes.(map[string]interface{}))
+				staticRoute := expandMobileGatewayStaticRoute(values)
+
+				// check duplicated
+				for _, sr := range mgw.Settings.MobileGateway.StaticRoutes {
+					if sr.Prefix == staticRoute.Prefix {
+						return fmt.Errorf("prefix %q already exists", sr.Prefix)
+					}
+				}
+				mgw.Settings.MobileGateway.StaticRoutes = append(mgw.Settings.MobileGateway.StaticRoutes, staticRoute)
+			}
+		}
+
+		mgw, err = client.MobileGateway.UpdateSetting(mgw.ID, mgw)
+		if err != nil {
+			return fmt.Errorf("Failed to enable SakuraCloud MobileGatewayStaticRoute resource: %s", err)
+		}
+		_, err = client.MobileGateway.Config(mgw.ID)
+		if err != nil {
+			return fmt.Errorf("Couldn'd apply SakuraCloud MobileGateway config: %s", err)
+		}
+
+	}
+
 	if needRestart {
 		_, err = client.MobileGateway.Boot(mgw.ID)
 		if err != nil {
@@ -563,6 +635,17 @@ func setMobileGatewayResourceData(d *schema.ResourceData, client *APIClient, dat
 
 	d.Set("dns_server1", resolver.SimGroup.DNS1)
 	d.Set("dns_server2", resolver.SimGroup.DNS2)
+
+	if data.HasStaticRoutes() {
+		var staticRoutes []map[string]interface{}
+		for _, r := range data.Settings.MobileGateway.StaticRoutes {
+			staticRoutes = append(staticRoutes, map[string]interface{}{
+				"prefix":   r.Prefix,
+				"next_hop": r.NextHop,
+			})
+		}
+		d.Set("static_route", staticRoutes)
+	}
 
 	d.Set("name", data.Name)
 	d.Set("icon_id", data.GetIconStrID())

--- a/sakuracloud/resource_sakuracloud_mobile_gateway_sim_route.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway_sim_route.go
@@ -152,7 +152,7 @@ func mgwSIMRouteIDHash(mgwID string, s *sacloud.MobileGatewaySIMRoute) string {
 	return fmt.Sprintf("%d", hashcode.String(buf.String()))
 }
 
-func expandMobileGatewaySIMRoute(d *schema.ResourceData) *sacloud.MobileGatewaySIMRoute {
+func expandMobileGatewaySIMRoute(d resourceValueGetable) *sacloud.MobileGatewaySIMRoute {
 
 	var simRoute = &sacloud.MobileGatewaySIMRoute{
 		Prefix:     d.Get("prefix").(string),

--- a/sakuracloud/resource_sakuracloud_mobile_gateway_static_route.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway_static_route.go
@@ -162,7 +162,7 @@ func mgwStaticRouteIDHash(mgwID string, s *sacloud.MGWStaticRoute) string {
 	return fmt.Sprintf("%d", hashcode.String(buf.String()))
 }
 
-func expandMobileGatewayStaticRoute(d *schema.ResourceData) *sacloud.MGWStaticRoute {
+func expandMobileGatewayStaticRoute(d resourceValueGetable) *sacloud.MGWStaticRoute {
 
 	var staticRoute = &sacloud.MGWStaticRoute{
 		Prefix:  d.Get("prefix").(string),


### PR DESCRIPTION
* SIMルートについてはSIMリソースにモバイルゲートウェイへの参照が必要なため循環参照となる。このため従来通り子リソースでの定義のみサポートする。