### PR TITLE
marker_tag関連コードの除去

### DIFF
--- a/build_docs/docs/configuration/provider.md
+++ b/build_docs/docs/configuration/provider.md
@@ -32,8 +32,6 @@ provider sakuracloud {
 |`timeout`        | -   | タイムアウト         | `20`     | 数値(分) |環境変数`SAKURACLOUD_TIMEOUT`での指定も可|
 |`api_root_url`   | -   | さくらのクラウドAPI ルートURL | -        |文字列|テストなどのためにAPIのルートAPIを変更したい場合に設定する。<br />末尾にスラッシュを含めないでください。<br />指定しない場合のルートURLは`https://secure.sakura.ad.jp/cloud/zone`<br />環境変数`SAKURACLOUD_API_ROOT_URL`での指定も可  |
 |`trace`          | -   | トレースフラグ       | `false`     |`true`<br />`false`|(開発者向け)詳細ログの出力ON/OFFを指定します。 <br />環境変数`SAKURACLOUD_TRACE_MODE`での指定も可|
-|`use_marker_tags`| -   | マーカータグ利用有無  | `false`     |`true`<br />`false`| (v1.4で廃止) Terraformで作成されたリソースであるかの判別用に全てのリソースにタグを付与するかを指定<br />環境変数`SAKURACLOUD_USE_MARKER_TAGS`での指定も可|
-|`marker_tag_name`| -   | マーカータグ名       | `@terraform`|文字列| (v1.4で廃止) `use_marker_tags`がtrueの場合のタグ名 <br />環境変数`SAKURACLOUD_MARKER_TAG_NAME`での指定も可|
 
 各パラメータとも環境変数での指定が可能です。
 

--- a/build_docs/docs/upgrade_to_v20.md
+++ b/build_docs/docs/upgrade_to_v20.md
@@ -16,3 +16,7 @@ Terraform v0.12以前のバージョンをご利用中の場合、Terraform v0.1
 # terraform v0.12以前のバージョン向けのtfファイルをv0.12向けに書き換え
 $ terraform 0.12upgrade
 ```
+
+## marker_tags機能の除去
+   
+v1.4でmarker_tags機能のソースが除去されました。 

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -66,16 +66,6 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_TIMEOUT"}, 20),
 			},
-			"use_marker_tags": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Removed:  "Use `tags` in the each resources instead",
-			},
-			"marker_tag_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Removed:  "Use `tags` in the each resources instead",
-			},
 			"trace": {
 				Type:        schema.TypeBool,
 				Optional:    true,


### PR DESCRIPTION
To fix #337 

`Removed`とマークされていたmarker_tag関連のコードを除去する。