### PR TITLE
Upgrade provider-SDK to pluginsdk-v0.12-early6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,38 +1,14 @@
 module github.com/sacloud/terraform-provider-sakuracloud
 
 require (
-	github.com/agext/levenshtein v1.2.2 // indirect
-	github.com/apparentlymart/go-cidr v1.0.0 // indirect
-	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 // indirect
-	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/aws/aws-sdk-go v1.16.36 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/golang/protobuf v1.3.0 // indirect
-	github.com/hashicorp/go-getter v1.1.0 // indirect
-	github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f // indirect
-	github.com/hashicorp/go-plugin v0.0.0-20190322172744-52e1c4730856 // indirect
-	github.com/hashicorp/hcl2 v0.0.0-20190327223817-3fb4ed0d9260 // indirect
-	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 // indirect
-	github.com/hashicorp/logutils v1.0.0 // indirect
-	github.com/hashicorp/terraform v0.11.13
-	github.com/mattn/go-colorable v0.1.1 // indirect
-	github.com/mitchellh/cli v1.0.0 // indirect
-	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/hashicorp/terraform v0.12.0-alpha4.0.20190401192225-916f900d1d56
 	github.com/mitchellh/go-homedir v1.0.0
-	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/goamz v0.0.0-20150317174335-caaaea8b30ee
-	github.com/mitchellh/hashstructure v1.0.0 // indirect
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
-	github.com/posener/complete v1.2.1 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 	github.com/sacloud/libsacloud v1.15.6
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
-	github.com/zclconf/go-cty v0.0.0-20190320224746-fd76348b9329 // indirect
-	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
-	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
-	google.golang.org/genproto v0.0.0-20190201180003-4b09977fb922 // indirect
-	google.golang.org/grpc v1.18.0 // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,38 @@
 module github.com/sacloud/terraform-provider-sakuracloud
 
 require (
-	github.com/hashicorp/terraform v0.12.0-beta1
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/apparentlymart/go-cidr v1.0.0 // indirect
+	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 // indirect
+	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/aws/aws-sdk-go v1.16.36 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/golang/protobuf v1.3.0 // indirect
+	github.com/hashicorp/go-getter v1.1.0 // indirect
+	github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f // indirect
+	github.com/hashicorp/go-plugin v0.0.0-20190322172744-52e1c4730856 // indirect
+	github.com/hashicorp/hcl2 v0.0.0-20190327223817-3fb4ed0d9260 // indirect
+	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform v0.11.13
+	github.com/mattn/go-colorable v0.1.1 // indirect
+	github.com/mitchellh/cli v1.0.0 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.0.0
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/goamz v0.0.0-20150317174335-caaaea8b30ee
+	github.com/mitchellh/hashstructure v1.0.0 // indirect
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
+	github.com/posener/complete v1.2.1 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 	github.com/sacloud/libsacloud v1.15.6
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
+	github.com/zclconf/go-cty v0.0.0-20190320224746-fd76348b9329 // indirect
+	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
+	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
+	google.golang.org/genproto v0.0.0-20190201180003-4b09977fb922 // indirect
+	google.golang.org/grpc v1.18.0 // indirect
+	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )

--- a/sakuracloud/data_source_sakuracloud_archive_test.go
+++ b/sakuracloud/data_source_sakuracloud_archive_test.go
@@ -21,7 +21,7 @@ func TestAccSakuraCloudDataSourceArchive_Basic(t *testing.T) {
 				Config: testAccCheckSakuraCloudDataSourceArchiveConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSakuraCloudArchiveDataSourceID("data.sakuracloud_archive.foobar"),
-					resource.TestCheckResourceAttr("data.sakuracloud_archive.foobar", "name", "Ubuntu Server 16.04.5 LTS 64bit"),
+					resource.TestCheckResourceAttr("data.sakuracloud_archive.foobar", "name", "Ubuntu Server 16.04.6 LTS 64bit"),
 					resource.TestCheckResourceAttr("data.sakuracloud_archive.foobar", "size", "20"),
 					resource.TestCheckResourceAttr("data.sakuracloud_archive.foobar", "zone", "tk1v"),
 					resource.TestCheckResourceAttr("data.sakuracloud_archive.foobar", "tags.#", "5"),

--- a/sakuracloud/data_source_sakuracloud_bucket_object_test.go
+++ b/sakuracloud/data_source_sakuracloud_bucket_object_test.go
@@ -70,8 +70,8 @@ resource "sakuracloud_bucket_object" "foobar" {
 }
 
 data "sakuracloud_bucket_object" "foobar" {
-  bucket = sakuracloud_bucket_object.foobar.bucket
-  key    = sakuracloud_bucket_object.foobar.key
+  bucket = "${sakuracloud_bucket_object.foobar.bucket}"
+  key    = "${sakuracloud_bucket_object.foobar.key}"
 }
 `, bucket, key)
 }

--- a/sakuracloud/data_source_sakuracloud_cdrom_test.go
+++ b/sakuracloud/data_source_sakuracloud_cdrom_test.go
@@ -21,14 +21,14 @@ func TestAccSakuraCloudDataSourceCDROM_Basic(t *testing.T) {
 				Config: testAccCheckSakuraCloudDataSourceCDROMConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSakuraCloudCDROMDataSourceID("data.sakuracloud_cdrom.foobar"),
-					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "name", "Ubuntu server 18.04.1 LTS 64bit"),
+					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "name", "Ubuntu Server 18.04.2 LTS 64bit"),
 					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "size", "5"),
 					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "tags.#", "5"),
 					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "tags.0", "arch-64bit"),
 					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "tags.1", "current-stable"),
 					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "tags.2", "distro-ubuntu"),
-					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "tags.3", "distro-ver-18.04.1"),
-					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "tags.4", "os-unix"),
+					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "tags.3", "distro-ver-18.04.2"),
+					resource.TestCheckResourceAttr("data.sakuracloud_cdrom.foobar", "tags.4", "os-linux"),
 				),
 			},
 			{
@@ -131,7 +131,7 @@ var testAccCheckSakuraCloudDataSourceCDROMConfig = `
 data "sakuracloud_cdrom" "foobar" {
     filter {
 	name = "Name"
-	values = ["Ubuntu Server 18"]
+	values = ["Ubuntu server 18.04.2 LTS 64bit"]
     }
 }`
 

--- a/sakuracloud/resource_sakuracloud_archive_test.go
+++ b/sakuracloud/resource_sakuracloud_archive_test.go
@@ -117,7 +117,7 @@ func TestAccImportSakuraCloudArchive(t *testing.T) {
 
 	resourceName := "sakuracloud_archive.foobar"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSakuraCloudArchiveDestroy,
@@ -144,7 +144,6 @@ resource "sakuracloud_archive" "foobar" {
     name = "myarchive"
     size = 20
     archive_file = "test/dummy.raw"
-    hash = md5(filebase64("test/dummy.raw"))
     description = "description"
     tags = ["tag1" , "tag2"]
 }
@@ -155,10 +154,9 @@ resource "sakuracloud_archive" "foobar" {
     name = "myarchive-upd"
     size = 20
     archive_file = "test/dummy-upd.raw"
-    hash = md5(filebase64("test/dummy-upd.raw"))
     description = "description-upd"
     tags = ["tag1-upd" , "tag2-upd"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 resource "sakuracloud_icon" "foobar" {
     name = "myicon"

--- a/sakuracloud/resource_sakuracloud_auto_backup_test.go
+++ b/sakuracloud/resource_sakuracloud_auto_backup_test.go
@@ -154,12 +154,12 @@ resource "sakuracloud_disk" "disk" {
 }
 resource "sakuracloud_auto_backup" "foobar" {
     name = "name_before"
-    disk_id = sakuracloud_disk.disk.id
+    disk_id = "${sakuracloud_disk.disk.id}"
     weekdays = ["wed","fri"]
     max_backup_num = 1
     description = "description_before"
     tags = ["hoge1", "hoge2"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -174,7 +174,7 @@ resource "sakuracloud_disk" "disk" {
 }
 resource "sakuracloud_auto_backup" "foobar" {
     name = "name_after"
-    disk_id = sakuracloud_disk.disk.id
+    disk_id = "${sakuracloud_disk.disk.id}"
     weekdays = ["fri","sun"]
     max_backup_num = 2
     description = "description_after"

--- a/sakuracloud/resource_sakuracloud_bridge_test.go
+++ b/sakuracloud/resource_sakuracloud_bridge_test.go
@@ -136,7 +136,7 @@ var testAccCheckSakuraCloudBridgeConfig_withSwitch = `
 resource "sakuracloud_switch" "foobar" {
     name = "myswitch"
     description = "Switch from TerraForm for SAKURA CLOUD"
-    bridge_id = sakuracloud_bridge.foobar.id
+    bridge_id = "${sakuracloud_bridge.foobar.id}"
 }
 resource "sakuracloud_bridge" "foobar" {
     name = "mybridge"

--- a/sakuracloud/resource_sakuracloud_cdrom_test.go
+++ b/sakuracloud/resource_sakuracloud_cdrom_test.go
@@ -168,7 +168,6 @@ resource "sakuracloud_cdrom" "foobar" {
     name = "mycdrom"
     size = 5
     iso_image_file = "test/dummy.iso"
-    hash = md5(filebase64("test/dummy.iso"))
     description = "description"
     tags = ["tag1" , "tag2"]
     icon_id = "${sakuracloud_icon.foobar.id}"
@@ -185,7 +184,6 @@ resource "sakuracloud_cdrom" "foobar" {
     name = "mycdrom-upd"
     size = 5
     iso_image_file = "test/dummy-upd.iso"
-    hash = md5(filebase64("test/dummy-upd.iso"))
     description = "description-upd"
     tags = ["tag1-upd" , "tag2-upd"]
 }`
@@ -193,12 +191,12 @@ resource "sakuracloud_cdrom" "foobar" {
 var testAccCheckSakuraCloudCDROMConfig_text_content = `
 resource "sakuracloud_cdrom" "foobar" {
     name = "mycdrom"
-    content = file("test/dummy.json")
+    content = "${file("test/dummy.json")}"
 }
 `
 var testAccCheckSakuraCloudCDROMConfig_text_content_upd = `
 resource "sakuracloud_cdrom" "foobar" {
     name = "mycdrom-upd"
-    content = file("test/dummy-upd.json")
+    content = "${file("test/dummy-upd.json")}"
 }
 `

--- a/sakuracloud/resource_sakuracloud_database_read_replica_test.go
+++ b/sakuracloud/resource_sakuracloud_database_read_replica_test.go
@@ -126,22 +126,22 @@ resource "sakuracloud_database" "foobar" {
     user_password = "DatabasePasswordUser397"
     replica_password = "DatabasePasswordUser397"
 
-    switch_id = sakuracloud_switch.sw.id
+    switch_id = "${sakuracloud_switch.sw.id}"
     ipaddress1 = "192.168.11.101"
     nw_mask_len = 24
     default_route = "192.168.11.1"
 
     name = "terraform-test-master-db"
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_database_read_replica" "foobar" {
-    master_id = sakuracloud_database.foobar.id
+    master_id = "${sakuracloud_database.foobar.id}"
     ipaddress1 = "192.168.11.111"
     name = "name_before"
     description = "description_before"
     tags = ["hoge1" , "hoge2"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -163,7 +163,7 @@ resource "sakuracloud_database" "foobar" {
     user_password = "DatabasePasswordUser397"
     replica_password = "DatabasePasswordUser397"
 
-    switch_id = sakuracloud_switch.sw.id
+    switch_id = "${sakuracloud_switch.sw.id}"
     ipaddress1 = "192.168.11.101"
     nw_mask_len = 24
     default_route = "192.168.11.1"
@@ -172,7 +172,7 @@ resource "sakuracloud_database" "foobar" {
 }
 
 resource "sakuracloud_database_read_replica" "foobar" {
-    master_id = sakuracloud_database.foobar.id
+    master_id = "${sakuracloud_database.foobar.id}"
     ipaddress1 = "192.168.11.111"
     name = "name_after"
     description = "description_after"

--- a/sakuracloud/resource_sakuracloud_database_test.go
+++ b/sakuracloud/resource_sakuracloud_database_test.go
@@ -214,7 +214,7 @@ resource "sakuracloud_database" "foobar" {
     backup_time = "00:00"
     backup_weekdays = ["mon","tue"]
 
-    switch_id = sakuracloud_switch.sw.id
+    switch_id = "${sakuracloud_switch.sw.id}"
     ipaddress1 = "192.168.11.101"
     nw_mask_len = 24
     default_route = "192.168.11.1"
@@ -222,7 +222,7 @@ resource "sakuracloud_database" "foobar" {
     name = "name_before"
     description = "description_before"
     tags = ["hoge1" , "hoge2"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -253,7 +253,7 @@ resource "sakuracloud_database" "foobar" {
     description = "description_after"
     tags = ["hoge1_after" , "hoge2_after"]
 
-    switch_id = sakuracloud_switch.sw.id
+    switch_id = "${sakuracloud_switch.sw.id}"
     ipaddress1 = "192.168.11.101"
     nw_mask_len = 24
     default_route = "192.168.11.1"

--- a/sakuracloud/resource_sakuracloud_disk.go
+++ b/sakuracloud/resource_sakuracloud_disk.go
@@ -119,9 +119,9 @@ func resourceSakuraCloudDisk() *schema.Resource {
 				Removed: "Use attribute in `sakuracloud_server` instead",
 			},
 			"disable_pw_auth": {
-				Type:       schema.TypeBool,
-				Optional:   true,
-				Removed: "Use attribute in `sakuracloud_server` instead",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Removed:  "Use attribute in `sakuracloud_server` instead",
 			},
 			"note_ids": {
 				Type:     schema.TypeList,

--- a/sakuracloud/resource_sakuracloud_disk_test.go
+++ b/sakuracloud/resource_sakuracloud_disk_test.go
@@ -180,10 +180,10 @@ resource "sakuracloud_disk" "foobar" {
     connector = "virtio"
     size = 20
     distant_from = ["111111111111"]
-    source_archive_id = data.sakuracloud_archive.ubuntu.id
+    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
     description = "Disk from TerraForm for SAKURA CLOUD"
     tags = ["hoge1" , "hoge2"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -205,7 +205,7 @@ resource "sakuracloud_disk" "foobar" {
     connector = "virtio"
     size = 20
     distant_from = ["111111111111"]
-    source_archive_id = data.sakuracloud_archive.ubuntu.id
+    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
     description = "Disk from TerraForm for SAKURA CLOUD"
     tags = ["hoge1" , "hoge2"]
 }`

--- a/sakuracloud/resource_sakuracloud_dns_record_test.go
+++ b/sakuracloud/resource_sakuracloud_dns_record_test.go
@@ -155,7 +155,7 @@ resource "sakuracloud_dns" "foobar" {
 }
 
 resource "sakuracloud_dns_record" "foobar" {
-    dns_id = sakuracloud_dns.foobar.id
+    dns_id = "${sakuracloud_dns.foobar.id}"
     name = "test2"
     type = "A"
     value = "192.168.0.2"
@@ -174,9 +174,9 @@ variable "ip_list" {
 }
 resource "sakuracloud_dns_record" "foobar" {
     count = 2
-    dns_id = sakuracloud_dns.foobar.id
+    dns_id = "${sakuracloud_dns.foobar.id}"
     name = "test"
     type = "A"
-    value = var.ip_list[count.index]
+    value = "${var.ip_list[count.index]}"
 }`, zone)
 }

--- a/sakuracloud/resource_sakuracloud_dns_test.go
+++ b/sakuracloud/resource_sakuracloud_dns_test.go
@@ -158,7 +158,7 @@ resource "sakuracloud_dns" "foobar" {
     zone = "%s"
     description = "DNS from TerraForm for SAKURA CLOUD"
     tags = ["tag1","tag2"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
     records {
       name = "test1"
       type = "A"

--- a/sakuracloud/resource_sakuracloud_gslb_server_test.go
+++ b/sakuracloud/resource_sakuracloud_gslb_server_test.go
@@ -80,8 +80,8 @@ resource "sakuracloud_gslb" "foobar" {
 }
 resource "sakuracloud_gslb_server" "foobar" {
     count = 2
-    gslb_id = sakuracloud_gslb.foobar.id
-    ipaddress = var.gslb_ip_list[count.index]
+    gslb_id = "${sakuracloud_gslb.foobar.id}"
+    ipaddress = "${var.gslb_ip_list[count.index]}"
 }`
 
 var testAccCheckSakuraCloudGSLBServerConfig_update = `
@@ -102,6 +102,6 @@ resource "sakuracloud_gslb" "foobar" {
 }
 resource "sakuracloud_gslb_server" "foobar" {
     count = 4
-    gslb_id = sakuracloud_gslb.foobar.id
-    ipaddress = var.gslb_ip_list[count.index]
+    gslb_id = "${sakuracloud_gslb.foobar.id}"
+    ipaddress = "${var.gslb_ip_list[count.index]}"
 }`

--- a/sakuracloud/resource_sakuracloud_gslb_test.go
+++ b/sakuracloud/resource_sakuracloud_gslb_test.go
@@ -229,7 +229,7 @@ resource "sakuracloud_gslb" "foobar" {
     }
     description = "GSLB from TerraForm for SAKURA CLOUD"
     tags = ["hoge1", "hoge2"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {

--- a/sakuracloud/resource_sakuracloud_icon_test.go
+++ b/sakuracloud/resource_sakuracloud_icon_test.go
@@ -179,7 +179,7 @@ resource "sakuracloud_icon" "foobar" {
 
 resource sakuracloud_switch "foobar" {
   name = "mySwitch"
-  icon_id = sakuracloud_icon.foobar.id
+  icon_id = "${sakuracloud_icon.foobar.id}"
 }
 `
 

--- a/sakuracloud/resource_sakuracloud_internet_test.go
+++ b/sakuracloud/resource_sakuracloud_internet_test.go
@@ -134,7 +134,7 @@ func testAccCheckSakuraCloudInternetDestroy(s *terraform.State) error {
 var testAccCheckSakuraCloudInternetConfig_basic = `
 resource "sakuracloud_internet" "foobar" {
     name = "myinternet"
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -200,19 +200,19 @@ func TestAccImportSakuraCloudInternet(t *testing.T) {
 var testAccCheckSakuraCloudInternetConfig_update = `
 resource "sakuracloud_server" "foobar" {
     name = "myserver"
-    disks = [sakuracloud_disk.foobar.id]
+    disks = ["${sakuracloud_disk.foobar.id}"]
     description = "Server from TerraForm for SAKURA CLOUD"
-    nic = sakuracloud_internet.foobar.switch_id
-    ipaddress = sakuracloud_internet.foobar.ipaddresses[0]
-    gateway = sakuracloud_internet.foobar.gateway
-    nw_mask_len = sakuracloud_internet.foobar.nw_mask_len
+    nic = "${sakuracloud_internet.foobar.switch_id}"
+    ipaddress = "${sakuracloud_internet.foobar.ipaddresses[0]}"
+    gateway = "${sakuracloud_internet.foobar.gateway}"
+    nw_mask_len = "${sakuracloud_internet.foobar.nw_mask_len}"
 }
 data "sakuracloud_archive" "ubuntu" {
     os_type = "ubuntu"
 }
 resource "sakuracloud_disk" "foobar"{
     name = "mydisk"
-    source_archive_id = data.sakuracloud_archive.ubuntu.id
+    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 
 resource "sakuracloud_internet" "foobar" {

--- a/sakuracloud/resource_sakuracloud_ipv4_ptr_test.go
+++ b/sakuracloud/resource_sakuracloud_ipv4_ptr_test.go
@@ -109,10 +109,10 @@ data sakuracloud_dns "dns" {
 }
 
 resource sakuracloud_dns_record "record01" {
-  dns_id = data.sakuracloud_dns.dns.id
+  dns_id = "${data.sakuracloud_dns.dns.id}"
   name   = "terraform-test-domain01"
   type   = "A"
-  value  = sakuracloud_server.server.ipaddress
+  value  = "${sakuracloud_server.server.ipaddress}"
 }
 
 resource sakuracloud_server "server" {
@@ -121,7 +121,7 @@ resource sakuracloud_server "server" {
 }
 
 resource "sakuracloud_ipv4_ptr" "foobar" {
-  ipaddress = sakuracloud_server.server.ipaddress
+  ipaddress = "${sakuracloud_server.server.ipaddress}"
   hostname  = "terraform-test-domain01.%s"
 }
 `
@@ -132,7 +132,7 @@ data sakuracloud_dns "dns" {
 }
 
 resource sakuracloud_dns_record "record01" {
-  dns_id = data.sakuracloud_dns.dns.id
+  dns_id = "${data.sakuracloud_dns.dns.id}"
   name   = "terraform-test-domain02"
   type   = "A"
   value  = sakuracloud_server.server.ipaddress
@@ -144,7 +144,7 @@ resource sakuracloud_server "server" {
 }
 
 resource "sakuracloud_ipv4_ptr" "foobar" {
-  ipaddress = sakuracloud_server.server.ipaddress
+  ipaddress = "${sakuracloud_server.server.ipaddress}"
   hostname  = "terraform-test-domain02.%s"
 }
 `

--- a/sakuracloud/resource_sakuracloud_loadbalancer_server_test.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer_server_test.go
@@ -84,19 +84,19 @@ resource "sakuracloud_switch" "sw" {
     name = "sw"
 }
 resource "sakuracloud_load_balancer" "foobar" {
-    switch_id = sakuracloud_switch.sw.id
+    switch_id = "${sakuracloud_switch.sw.id}"
     vrid = 1
     ipaddress1 = "192.168.11.101"
     nw_mask_len = 24
     name = "name"
 }
 resource "sakuracloud_load_balancer_vip" "vip1" {
-    load_balancer_id = sakuracloud_load_balancer.foobar.id
+    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
     vip = "192.168.11.201"
     port = 80
 }
 resource "sakuracloud_load_balancer_server" "server01"{
-    load_balancer_vip_id = sakuracloud_load_balancer_vip.vip1.id
+    load_balancer_vip_id = "${sakuracloud_load_balancer_vip.vip1.id}"
     ipaddress = "192.168.11.51"
     check_protocol = "http"
     check_path = "/"
@@ -109,24 +109,24 @@ resource "sakuracloud_switch" "sw" {
     name = "sw"
 }
 resource "sakuracloud_load_balancer" "foobar" {
-    switch_id = sakuracloud_switch.sw.id
+    switch_id = "${sakuracloud_switch.sw.id}"
     vrid = 1
     ipaddress1 = "192.168.11.101"
     nw_mask_len = 24
     name = "name"
 }
 resource "sakuracloud_load_balancer_vip" "vip1" {
-    load_balancer_id = sakuracloud_load_balancer.foobar.id
+    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
     vip = "192.168.11.201"
     port = 80
 }
 resource "sakuracloud_load_balancer_server" "server01"{
-    load_balancer_vip_id = sakuracloud_load_balancer_vip.vip1.id
+    load_balancer_vip_id = "${sakuracloud_load_balancer_vip.vip1.id}"
     ipaddress = "192.168.11.51"
     check_protocol = "ping"
 }
 resource "sakuracloud_load_balancer_server" "server02"{
-    load_balancer_vip_id = sakuracloud_load_balancer_vip.vip1.id
+    load_balancer_vip_id = "${sakuracloud_load_balancer_vip.vip1.id}"
     ipaddress = "192.168.11.52"
     check_protocol = "ping"
 }

--- a/sakuracloud/resource_sakuracloud_loadbalancer_test.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer_test.go
@@ -238,7 +238,7 @@ resource "sakuracloud_switch" "sw" {
     name = "sw"
 }
 resource "sakuracloud_load_balancer" "foobar" {
-    switch_id = sakuracloud_switch.sw.id
+    switch_id = "${sakuracloud_switch.sw.id}"
     vrid = 1
     ipaddress1 = "192.168.11.101"
     nw_mask_len = 24
@@ -286,7 +286,7 @@ resource "sakuracloud_switch" "sw" {
     name = "sw"
 }
 resource "sakuracloud_load_balancer" "foobar" {
-    switch_id = sakuracloud_switch.sw.id
+    switch_id = "${sakuracloud_switch.sw.id}"
     vrid = 1
     ipaddress1 = "192.168.11.101"
     nw_mask_len = 24
@@ -323,14 +323,14 @@ resource "sakuracloud_internet" "router" {
     name = "sw"
 }
 resource "sakuracloud_load_balancer" "foobar" {
-    switch_id = sakuracloud_internet.router.switch_id
+    switch_id = "${sakuracloud_internet.router.switch_id}"
     high_availability = true
     plan = "highspec"
     vrid = 1
-    ipaddress1 = sakuracloud_internet.router.ipaddresses[0]
-    ipaddress2 = sakuracloud_internet.router.ipaddresses[1]
-    nw_mask_len = sakuracloud_internet.router.nw_mask_len
-    default_route = sakuracloud_internet.router.gateway
+    ipaddress1 = "${sakuracloud_internet.router.ipaddresses[0]}"
+    ipaddress2 = "${sakuracloud_internet.router.ipaddresses[1]}"
+    nw_mask_len = "${sakuracloud_internet.router.nw_mask_len}"
+    default_route = "${sakuracloud_internet.router.gateway}"
 
     name = "name_before"
     description = "description_before"

--- a/sakuracloud/resource_sakuracloud_loadbalancer_vip_test.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer_vip_test.go
@@ -95,7 +95,7 @@ resource "sakuracloud_switch" "sw" {
     name = "sw"
 }
 resource "sakuracloud_load_balancer" "foobar" {
-    switch_id = sakuracloud_switch.sw.id
+    switch_id = "${sakuracloud_switch.sw.id}"
     vrid = 1
     ipaddress1 = "192.168.11.101"
     nw_mask_len = 24
@@ -106,7 +106,7 @@ resource "sakuracloud_load_balancer" "foobar" {
     tags = ["hoge1" , "hoge2"]
 }
 resource "sakuracloud_load_balancer_vip" "vip1" {
-    load_balancer_id = sakuracloud_load_balancer.foobar.id
+    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
     vip = "192.168.11.201"
     port = 80
     delay_loop = 100
@@ -114,7 +114,7 @@ resource "sakuracloud_load_balancer_vip" "vip1" {
     description  = "description"
 }
 resource "sakuracloud_load_balancer_vip" "vip2" {
-    load_balancer_id = sakuracloud_load_balancer.foobar.id
+    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
     vip = "192.168.11.202"
     port = 80
 }
@@ -125,7 +125,7 @@ resource "sakuracloud_switch" "sw" {
     name = "sw"
 }
 resource "sakuracloud_load_balancer" "foobar" {
-    switch_id = sakuracloud_switch.sw.id
+    switch_id = "${sakuracloud_switch.sw.id}"
     vrid = 1
     ipaddress1 = "192.168.11.101"
     nw_mask_len = 24
@@ -136,24 +136,24 @@ resource "sakuracloud_load_balancer" "foobar" {
     tags = ["hoge1" , "hoge2"]
 }
 resource "sakuracloud_load_balancer_vip" "vip1" {
-    load_balancer_id = sakuracloud_load_balancer.foobar.id
+    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
     vip = "192.168.11.201"
     port = 80
     delay_loop = 50
     sorry_server = "192.168.11.22"
 }
 resource "sakuracloud_load_balancer_vip" "vip2" {
-    load_balancer_id = sakuracloud_load_balancer.foobar.id
+    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
     vip = "192.168.11.202"
     port = 80
 }
 resource "sakuracloud_load_balancer_vip" "vip3" {
-    load_balancer_id = sakuracloud_load_balancer.foobar.id
+    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
     vip = "192.168.11.203"
     port = 80
 }
 resource "sakuracloud_load_balancer_vip" "vip4" {
-    load_balancer_id = sakuracloud_load_balancer.foobar.id
+    load_balancer_id = "${sakuracloud_load_balancer.foobar.id}"
     vip = "192.168.11.204"
     port = 80
 }

--- a/sakuracloud/resource_sakuracloud_mobile_gateway_test.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway_test.go
@@ -208,14 +208,14 @@ resource "sakuracloud_switch" "sw" {
 }
 
 resource "sakuracloud_mobile_gateway" "foobar" {
-  switch_id           = sakuracloud_switch.sw.id
+  switch_id           = "${sakuracloud_switch.sw.id}"
   private_ipaddress   = "192.168.11.101"
   private_nw_mask_len = 24
   internet_connection = true
   name                = "name_before"
   description         = "description_before"
   tags                = ["hoge1", "hoge2"]
-  icon_id             = sakuracloud_icon.foobar.id
+  icon_id             = "${sakuracloud_icon.foobar.id}"
 
   traffic_control {
     quota                = 256
@@ -228,19 +228,19 @@ resource "sakuracloud_mobile_gateway" "foobar" {
 }
 
 resource sakuracloud_mobile_gateway_static_route "r1" {
-  mobile_gateway_id = sakuracloud_mobile_gateway.foobar.id
+  mobile_gateway_id = "${sakuracloud_mobile_gateway.foobar.id}"
   prefix = "192.168.10.0/24"
   next_hop = "192.168.11.1"
 }
 
 resource sakuracloud_mobile_gateway_static_route "r2" {
-  mobile_gateway_id = sakuracloud_mobile_gateway.foobar.id
+  mobile_gateway_id = "${sakuracloud_mobile_gateway.foobar.id}"
   prefix = "192.168.10.0/25"
   next_hop = "192.168.11.2"
 }
 
 resource sakuracloud_mobile_gateway_static_route "r3" {
-  mobile_gateway_id = sakuracloud_mobile_gateway.foobar.id
+  mobile_gateway_id = "${sakuracloud_mobile_gateway.foobar.id}"
   prefix = "192.168.10.0/26"
   next_hop = "192.168.11.3"
 }
@@ -256,7 +256,7 @@ resource "sakuracloud_switch" "sw" {
     name = "sw"
 }
 resource "sakuracloud_mobile_gateway" "foobar" {
-  switch_id           = sakuracloud_switch.sw.id
+  switch_id           = "${sakuracloud_switch.sw.id}"
   private_ipaddress   = "192.168.11.101"
   private_nw_mask_len = 24
   internet_connection = false
@@ -271,7 +271,7 @@ resource "sakuracloud_switch" "sw" {
 }
 
 resource "sakuracloud_mobile_gateway" "foobar" {
-  switch_id           = sakuracloud_switch.sw.id
+  switch_id           = "${sakuracloud_switch.sw.id}"
   private_ipaddress   = "192.168.11.101"
   private_nw_mask_len = 24
   internet_connection = true

--- a/sakuracloud/resource_sakuracloud_nfs_test.go
+++ b/sakuracloud/resource_sakuracloud_nfs_test.go
@@ -110,7 +110,7 @@ resource "sakuracloud_switch" "sw" {
     name = "sw"
 }
 resource "sakuracloud_nfs" "foobar" {
-    switch_id     = sakuracloud_switch.sw.id
+    switch_id     = "${sakuracloud_switch.sw.id}"
     plan          = "500"
     ipaddress     = "192.168.11.101"
     nw_mask_len   = 24
@@ -118,7 +118,7 @@ resource "sakuracloud_nfs" "foobar" {
     name          = "name_before"
     description   = "description_before"
     tags          = ["hoge1" , "hoge2"]
-    icon_id       = sakuracloud_icon.foobar.id
+    icon_id       = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -132,7 +132,7 @@ resource "sakuracloud_switch" "sw" {
     name = "sw"
 }
 resource "sakuracloud_nfs" "foobar" {
-    switch_id     = sakuracloud_switch.sw.id
+    switch_id     = "${sakuracloud_switch.sw.id}"
     plan          = "500"
     ipaddress     = "192.168.11.101"
     nw_mask_len   = 24

--- a/sakuracloud/resource_sakuracloud_note_test.go
+++ b/sakuracloud/resource_sakuracloud_note_test.go
@@ -125,7 +125,7 @@ const testAccCheckSakuraCloudNoteConfig_basic = `
 resource "sakuracloud_note" "foobar" {
     name = "mynote"
     content = "content"
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {

--- a/sakuracloud/resource_sakuracloud_packet_filter_rule_test.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter_rule_test.go
@@ -154,7 +154,7 @@ resource "sakuracloud_packet_filter" "foobar" {
 }
 
 resource sakuracloud_packet_filter_rule "rule0" {
-    packet_filter_id = sakuracloud_packet_filter.foobar.id
+    packet_filter_id = "${sakuracloud_packet_filter.foobar.id}"
 
  	protocol    = "tcp"
 	source_nw   = "192.168.2.0"
@@ -165,7 +165,7 @@ resource sakuracloud_packet_filter_rule "rule0" {
 }
 
 resource sakuracloud_packet_filter_rule "rule1" {
-    packet_filter_id = sakuracloud_packet_filter.foobar.id
+    packet_filter_id = "${sakuracloud_packet_filter.foobar.id}"
 
 	protocol    = "tcp"
 	source_nw   = "192.168.2.0"
@@ -176,7 +176,7 @@ resource sakuracloud_packet_filter_rule "rule1" {
 }
 
 resource sakuracloud_packet_filter_rule "rule2" {
-    packet_filter_id = sakuracloud_packet_filter.foobar.id
+    packet_filter_id = "${sakuracloud_packet_filter.foobar.id}"
 
  	protocol    = "ip"
 	allow       = false
@@ -191,7 +191,7 @@ resource "sakuracloud_packet_filter" "foobar" {
 }
 
 resource sakuracloud_packet_filter_rule "rule0" {
-    packet_filter_id = sakuracloud_packet_filter.foobar.id
+    packet_filter_id = "${sakuracloud_packet_filter.foobar.id}"
 
    	protocol    = "udp"
   	source_nw   = "192.168.2.2"
@@ -202,7 +202,7 @@ resource sakuracloud_packet_filter_rule "rule0" {
 }
 
 resource sakuracloud_packet_filter_rule "rule1" {
-    packet_filter_id = sakuracloud_packet_filter.foobar.id
+    packet_filter_id = "${sakuracloud_packet_filter.foobar.id}"
 
    	protocol    = "udp"
   	source_nw   = "192.168.2.2"
@@ -213,7 +213,7 @@ resource sakuracloud_packet_filter_rule "rule1" {
 }
 
 resource sakuracloud_packet_filter_rule "rule2" {
-    packet_filter_id = sakuracloud_packet_filter.foobar.id
+    packet_filter_id = "${sakuracloud_packet_filter.foobar.id}"
 
   	protocol    = "ip"
 	allow       = false
@@ -228,7 +228,7 @@ resource "sakuracloud_packet_filter" "foobar" {
 }
 
 resource sakuracloud_packet_filter_rule "rule0" {
-    packet_filter_id = sakuracloud_packet_filter.foobar.id
+    packet_filter_id = "${sakuracloud_packet_filter.foobar.id}"
 
  	protocol    = "tcp"
 	source_nw   = "192.168.2.0"
@@ -239,7 +239,7 @@ resource sakuracloud_packet_filter_rule "rule0" {
 }
 
 resource sakuracloud_packet_filter_rule "rule2" {
-    packet_filter_id = sakuracloud_packet_filter.foobar.id
+    packet_filter_id = "${sakuracloud_packet_filter.foobar.id}"
 
  	protocol    = "ip"
 	allow       = false

--- a/sakuracloud/resource_sakuracloud_private_host_test.go
+++ b/sakuracloud/resource_sakuracloud_private_host_test.go
@@ -143,7 +143,7 @@ func testAccCheckSakuraCloudPrivateHostDestroy(s *terraform.State) error {
 var testAccCheckSakuraCloudPrivateHostConfig_Basic = `
 resource "sakuracloud_server" "foobar" {
     name = "myserver"
-    private_host_id = sakuracloud_private_host.foobar.id
+    private_host_id = "${sakuracloud_private_host.foobar.id}"
     graceful_shutdown_timeout = 5
     zone = "tk1a"
 }
@@ -154,7 +154,7 @@ resource "sakuracloud_private_host" "foobar" {
     zone = "tk1a"
 
     graceful_shutdown_timeout = 5
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -175,7 +175,7 @@ resource "sakuracloud_private_host" "foobar" {
 var testAccCheckSakuraCloudPrivateHostConfig_Destroy_Basic = `
 resource "sakuracloud_server" "foobar" {
     name = "myserver"
-    private_host_id = sakuracloud_private_host.foobar.id
+    private_host_id = "${sakuracloud_private_host.foobar.id}"
     zone = "tk1a"
     graceful_shutdown_timeout = 5
 }

--- a/sakuracloud/resource_sakuracloud_server_connector_test.go
+++ b/sakuracloud/resource_sakuracloud_server_connector_test.go
@@ -110,10 +110,10 @@ data "sakuracloud_cdrom" "foobar" {
 }
 
 resource sakuracloud_server_connector "foobar" {
-  server_id         = sakuracloud_server.foobar.id
-  disks             = [sakuracloud_disk.foobar[0].id]
-  packet_filter_ids = [sakuracloud_packet_filter.foobar[0].id]
-  cdrom_id          = data.sakuracloud_cdrom.foobar.id
+  server_id         = "${sakuracloud_server.foobar.id}"
+  disks             = ["${sakuracloud_disk.foobar.0.id}"]
+  packet_filter_ids = ["${sakuracloud_packet_filter.foobar.0.id}"]
+  cdrom_id          = "${data.sakuracloud_cdrom.foobar.id}"
 }
 `
 
@@ -138,10 +138,10 @@ data "sakuracloud_cdrom" "foobar" {
 }
 
 resource sakuracloud_server_connector "foobar" {
-  server_id         = sakuracloud_server.foobar.id
-  disks             = [sakuracloud_disk.foobar[0].id,sakuracloud_disk.foobar[1].id]
-  packet_filter_ids = [sakuracloud_packet_filter.foobar[0].id, sakuracloud_packet_filter.foobar[1].id]
-  cdrom_id          = data.sakuracloud_cdrom.foobar.id
+  server_id         = "${sakuracloud_server.foobar.id}"
+  disks             = ["${sakuracloud_disk.foobar.0.id}", "${sakuracloud_disk.foobar.1.id}"]
+  packet_filter_ids = ["${sakuracloud_packet_filter.foobar.0.id}", "${sakuracloud_packet_filter.foobar.1.id}"]
+  cdrom_id          = "${data.sakuracloud_cdrom.foobar.id}"
 }
 `
 

--- a/sakuracloud/resource_sakuracloud_server_test.go
+++ b/sakuracloud/resource_sakuracloud_server_test.go
@@ -196,7 +196,7 @@ func TestAccSakuraCloudServer_ConnectPacketFilters(t *testing.T) {
 				Config: testAccCheckSakuraCloudServerConfig_with_packet_filter_del,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "packet_filter_ids.0", ""),
+						"sakuracloud_server.foobar", "packet_filter_ids.#", "0"),
 				),
 			},
 		},
@@ -492,15 +492,15 @@ data "sakuracloud_archive" "ubuntu" {
 }
 resource "sakuracloud_disk" "foobar" {
     name = "mydisk"
-    source_archive_id = data.sakuracloud_archive.ubuntu.id
+    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 
 resource "sakuracloud_server" "foobar" {
     name = "myserver"
-    disks = [sakuracloud_disk.foobar.id]
+    disks = ["${sakuracloud_disk.foobar.id}"]
     description = "Server from TerraForm for SAKURA CLOUD"
     tags = ["tag1"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 
     hostname = "myserver"
     password = "p@ssw0rd"
@@ -524,12 +524,12 @@ data "sakuracloud_archive" "ubuntu" {
 
 resource "sakuracloud_disk" "foobar" {
     name = "mydisk"
-    source_archive_id = data.sakuracloud_archive.ubuntu.id
+    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 
 resource "sakuracloud_server" "foobar" {
     name = "myserver_after"
-    disks = [sakuracloud_disk.foobar.id]
+    disks = ["${sakuracloud_disk.foobar.id}"]
     core = 2
     memory = 2
     description = "Server from TerraForm for SAKURA CLOUD"
@@ -546,12 +546,12 @@ data "sakuracloud_archive" "ubuntu" {
 
 resource "sakuracloud_disk" "foobar" {
     name = "mydisk"
-    source_archive_id = data.sakuracloud_archive.ubuntu.id
+    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 
 resource "sakuracloud_server" "foobar" {
     name = "myserver"
-    disks = [sakuracloud_disk.foobar.id]
+    disks = ["${sakuracloud_disk.foobar.id}"]
     description = "Server from TerraForm for SAKURA CLOUD"
     additional_nics = [""]
     graceful_shutdown_timeout = 10
@@ -564,12 +564,12 @@ data "sakuracloud_archive" "ubuntu" {
 
 resource "sakuracloud_disk" "foobar" {
     name = "mydisk"
-    source_archive_id = data.sakuracloud_archive.ubuntu.id
+    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 
 resource "sakuracloud_server" "foobar" {
     name = "myserver"
-    disks = [sakuracloud_disk.foobar.id]
+    disks = ["${sakuracloud_disk.foobar.id}"]
     description = "Server from TerraForm for SAKURA CLOUD"
     additional_nics = ["","",""]
     graceful_shutdown_timeout = 10
@@ -583,12 +583,12 @@ data "sakuracloud_archive" "ubuntu" {
 
 resource "sakuracloud_disk" "foobar" {
     name = "mydisk"
-    source_archive_id = data.sakuracloud_archive.ubuntu.id
+    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 
 resource "sakuracloud_server" "foobar" {
     name = "myserver"
-    disks = [sakuracloud_disk.foobar.id]
+    disks = ["${sakuracloud_disk.foobar.id}"]
     description = "Server from TerraForm for SAKURA CLOUD"
     nic = "disconnect"
     additional_nics = [""]
@@ -611,7 +611,7 @@ resource "sakuracloud_server" "foobar" {
     name = "myserver"
     nic = "shared"
     additional_nics = [""]
-    packet_filter_ids = ["" , sakuracloud_packet_filter.foobar2.id]
+    packet_filter_ids = ["" , "${sakuracloud_packet_filter.foobar2.id}"]
     graceful_shutdown_timeout = 10
 }
 `
@@ -643,7 +643,7 @@ resource "sakuracloud_server" "foobar" {
     name = "myserver_upd"
     nic = "shared"
     additional_nics = [""]
-    packet_filter_ids = [sakuracloud_packet_filter.foobar1.id , sakuracloud_packet_filter.foobar2.id]
+    packet_filter_ids = ["${sakuracloud_packet_filter.foobar1.id}" , "${sakuracloud_packet_filter.foobar2.id}"]
     graceful_shutdown_timeout = 10
 }
 
@@ -676,7 +676,7 @@ resource "sakuracloud_server" "foobar" {
     name = "myserver_upd"
     nic = "shared"
     additional_nics = [""]
-    packet_filter_ids = [sakuracloud_packet_filter.foobar1.id]
+    packet_filter_ids = ["${sakuracloud_packet_filter.foobar1.id}"]
     graceful_shutdown_timeout = 10
 }
 
@@ -694,7 +694,7 @@ const testAccCheckSakuraCloudServerConfig_with_blank_disk = `
 resource "sakuracloud_server" "foobar" {
     name = "myserver_with_blank"
     nic = "shared"
-    disks = [sakuracloud_disk.foobar.id]
+    disks = ["${sakuracloud_disk.foobar.id}"]
     graceful_shutdown_timeout = 10
 }
 resource "sakuracloud_disk" "foobar" {
@@ -709,7 +709,7 @@ resource "sakuracloud_switch" "foobar" {
 resource "sakuracloud_server" "foobar" {
     name = "foobar"
     nic = "shared"
-    additional_nics = [sakuracloud_switch.foobar.id]
+    additional_nics = ["${sakuracloud_switch.foobar.id}"]
     graceful_shutdown_timeout = 10
 }
 `
@@ -720,7 +720,7 @@ resource "sakuracloud_switch" "foobar" {
 }
 resource "sakuracloud_server" "foobar" {
     name = "foobar"
-    nic = sakuracloud_switch.foobar.id
+    nic = "${sakuracloud_switch.foobar.id}"
     additional_nics = [""]
     graceful_shutdown_timeout = 10
 }
@@ -749,7 +749,7 @@ resource "sakuracloud_server" "foobar" {
     graceful_shutdown_timeout = 10
 }
 resource sakuracloud_simple_monitor "foobar" {
-  target = sakuracloud_server.foobar.ipaddress
+  target = "${sakuracloud_server.foobar.ipaddress}"
 
   health_check {
     protocol   = "ping"
@@ -770,7 +770,7 @@ resource "sakuracloud_server" "foobar" {
     graceful_shutdown_timeout = 10
 }
 resource sakuracloud_simple_monitor "foobar" {
-  target = sakuracloud_server.foobar.ipaddress
+  target = "${sakuracloud_server.foobar.ipaddress}"
 
   health_check {
     protocol   = "ping"
@@ -787,15 +787,15 @@ data "sakuracloud_archive" "ubuntu" {
 }
 resource "sakuracloud_disk" "foobar" {
     name = "mydisk"
-    source_archive_id = data.sakuracloud_archive.ubuntu.id
+    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 resource "sakuracloud_switch" "foobar" {
     name = "foobar"
 }
 resource "sakuracloud_server" "foobar" {
     name        = "foobar"
-    disks       = [sakuracloud_disk.foobar.id]
-    nic         = sakuracloud_switch.foobar.id
+    disks       = ["${sakuracloud_disk.foobar.id}"]
+    nic         = "${sakuracloud_switch.foobar.id}"
     ipaddress   = "192.168.0.2"
     nw_mask_len = 24
     gateway     = "192.168.0.1"
@@ -811,10 +811,10 @@ resource sakuracloud_switch "sw" {
 
 resource sakuracloud_server "switched" {
   name              = "sakuracloud_test_connect_to_switched"
-  nic               = sakuracloud_switch.sw[0].id
+  nic               = "${sakuracloud_switch.sw.0.id}"
   display_ipaddress = "192.2.0.1"
 
-  additional_nics                = [sakuracloud_switch.sw[1].id, sakuracloud_switch.sw[2].id]
+  additional_nics                = ["${sakuracloud_switch.sw.1.id}", "${sakuracloud_switch.sw.2.id}"]
   additional_display_ipaddresses = ["192.2.1.1", "192.2.2.1"]
 }
 `
@@ -826,9 +826,9 @@ resource sakuracloud_switch "sw" {
 
 resource sakuracloud_server "switched" {
   name              = "sakuracloud_test_connect_to_switched"
-  nic               = sakuracloud_switch.sw[0].id
+  nic               = "${sakuracloud_switch.sw.0.id}"
   display_ipaddress = "192.2.0.2"
-  additional_nics   = [sakuracloud_switch.sw[1].id, sakuracloud_switch.sw[2].id]
+  additional_nics   = ["${sakuracloud_switch.sw.1.id}", "${sakuracloud_switch.sw.2.id}"]
   additional_display_ipaddresses = ["192.2.1.2", "192.2.2.2"]
 }
 `

--- a/sakuracloud/resource_sakuracloud_sim_test.go
+++ b/sakuracloud/resource_sakuracloud_sim_test.go
@@ -180,7 +180,7 @@ resource "sakuracloud_sim" "foobar" {
     name = "name_before"
     description = "description_before"
     tags = ["hoge1" , "hoge2"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 
     iccid = "%s"
     passcode = "%s"
@@ -188,7 +188,7 @@ resource "sakuracloud_sim" "foobar" {
     carrier = ["softbank"]
 
     enabled = true
-    mobile_gateway_id = sakuracloud_mobile_gateway.mgw.id
+    mobile_gateway_id = "${sakuracloud_mobile_gateway.mgw.id}"
     ipaddress = "192.168.100.1"
 }
 
@@ -213,7 +213,7 @@ resource "sakuracloud_sim" "foobar" {
     carrier = ["kddi"]
 
     enabled = false
-    mobile_gateway_id = sakuracloud_mobile_gateway.mgw.id
+    mobile_gateway_id = "${sakuracloud_mobile_gateway.mgw.id}"
     ipaddress = "192.168.100.2"
 }`
 

--- a/sakuracloud/resource_sakuracloud_simple_monitor_test.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor_test.go
@@ -192,7 +192,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
     notify_email_html = true
     notify_slack_enabled = true
     notify_slack_webhook = "%s"
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -232,7 +232,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
     notify_email_html = true
     notify_slack_enabled = true
     notify_slack_webhook = "%s"
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {

--- a/sakuracloud/resource_sakuracloud_subnet_test.go
+++ b/sakuracloud/resource_sakuracloud_subnet_test.go
@@ -89,8 +89,8 @@ resource sakuracloud_internet "foobar" {
     name = "myinternet"
 }
 resource "sakuracloud_subnet" "foobar" {
-    internet_id = sakuracloud_internet.foobar.id
-    next_hop = sakuracloud_internet.foobar.min_ipaddress
+    internet_id = "${sakuracloud_internet.foobar.id}"
+    next_hop = "${sakuracloud_internet.foobar.min_ipaddress}"
 }`
 
 var testAccCheckSakuraCloudSubnetConfig_update = `
@@ -98,6 +98,6 @@ resource sakuracloud_internet "foobar" {
     name = "myinternet"
 }
 resource "sakuracloud_subnet" "foobar" {
-    internet_id = sakuracloud_internet.foobar.id
-    next_hop = sakuracloud_internet.foobar.max_ipaddress
+    internet_id = "${sakuracloud_internet.foobar.id}"
+    next_hop = "${sakuracloud_internet.foobar.max_ipaddress}"
 }`

--- a/sakuracloud/resource_sakuracloud_switch_test.go
+++ b/sakuracloud/resource_sakuracloud_switch_test.go
@@ -173,7 +173,7 @@ resource "sakuracloud_switch" "foobar" {
     name = "myswitch"
     description = "Switch from TerraForm for SAKURA CLOUD"
     tags = ["hoge1" , "hoge2"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -186,7 +186,7 @@ var testAccCheckSakuraCloudSwitchConfig_update = `
 resource "sakuracloud_server" "foobar" {
     name = "myserver"
     description = "Server from TerraForm for SAKURA CLOUD"
-    additional_nics = [sakuracloud_switch.foobar.id]
+    additional_nics = ["${sakuracloud_switch.foobar.id}"]
 }
 resource "sakuracloud_switch" "foobar" {
     name = "myswitch_upd"

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -295,7 +295,7 @@ func resourceSakuraCloudVPCRouterCreate(d *schema.ResourceData, meta interface{}
 			return client.VPCRouter.Create(opts)
 		},
 		AsyncWaitForCopy: func(id int64) (chan interface{}, chan interface{}, chan error) {
-			return client.VPCRouter.AsyncSleepWhileCopying(id, client.DefaultTimeoutDuration, 10)
+			return client.VPCRouter.AsyncSleepWhileCopying(id, client.DefaultTimeoutDuration, 20)
 		},
 		Delete: func(id int64) error {
 			_, err := client.VPCRouter.Delete(id)

--- a/sakuracloud/resource_sakuracloud_vpc_router_interface.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_interface.go
@@ -171,7 +171,7 @@ func resourceSakuraCloudVPCRouterInterfaceDelete(d *schema.ResourceData, meta in
 				err = nil
 				break
 			}
-			err = handleShutdown(client.VPCRouter, vpcRouter.ID, d, 60*time.Second)
+			err = handleShutdown(client.VPCRouter, vpcRouter.ID, d, client.DefaultTimeoutDuration)
 		}
 		if err != nil {
 			return fmt.Errorf("Error stopping SakuraCloud VPCRouter resource: %s", err)

--- a/sakuracloud/resource_sakuracloud_vpc_router_settings_test.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_settings_test.go
@@ -243,40 +243,40 @@ resource "sakuracloud_switch" "sw01"{
 resource "sakuracloud_vpc_router" "foobar" {
     name = "vpc_router_setting_test"
     plan = "premium"
-    switch_id = sakuracloud_internet.router1.switch_id
-    vip = sakuracloud_internet.router1.ipaddresses[0]
-    ipaddress1 = sakuracloud_internet.router1.ipaddresses[1]
-    ipaddress2 = sakuracloud_internet.router1.ipaddresses[2]
-    aliases = [sakuracloud_internet.router1.ipaddresses[3]]
+    switch_id = "${sakuracloud_internet.router1.switch_id}"
+    vip = "${sakuracloud_internet.router1.ipaddresses[0]}"
+    ipaddress1 = "${sakuracloud_internet.router1.ipaddresses[1]}"
+    ipaddress2 = "${sakuracloud_internet.router1.ipaddresses[2]}"
+    aliases = ["${sakuracloud_internet.router1.ipaddresses[3]}"]
     vrid = 1
 
 }
 resource "sakuracloud_vpc_router_interface" "eth1"{
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
     index = 1
-    switch_id = sakuracloud_switch.sw01.id
+    switch_id = "${sakuracloud_switch.sw01.id}"
     vip = "192.168.11.1"
     ipaddress = ["192.168.11.2" , "192.168.11.3"]
     nw_mask_len = 24
 }
 resource "sakuracloud_vpc_router_pptp" "pptp"{
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_id = sakuracloud_vpc_router_interface.eth1.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
 
     range_start = "192.168.11.101"
     range_stop = "192.168.11.150"
 }
 resource "sakuracloud_vpc_router_static_nat" "staticNAT1" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_id = sakuracloud_vpc_router_interface.eth1.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
 
-    global_address = sakuracloud_internet.router1.ipaddresses[3]
+    global_address = "${sakuracloud_internet.router1.ipaddresses[3]}"
     private_address = "192.168.11.11"
     description = "desc"
 }
 resource "sakuracloud_vpc_router_port_forwarding" "forward1" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_id = sakuracloud_vpc_router_interface.eth1.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
 
     protocol = "tcp"
     global_port = 10022
@@ -285,23 +285,23 @@ resource "sakuracloud_vpc_router_port_forwarding" "forward1" {
     description = "desc"
 }
 resource "sakuracloud_vpc_router_dhcp_server" "dhcp" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_index = sakuracloud_vpc_router_interface.eth1.index
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_index = "${sakuracloud_vpc_router_interface.eth1.index}"
 
     range_start = "192.168.11.151"
     range_stop  = "192.168.11.200"
     dns_servers = ["8.8.4.4", "8.8.8.8"]
 }
 resource "sakuracloud_vpc_router_dhcp_static_mapping" "dhcp_map" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_dhcp_server_id = sakuracloud_vpc_router_dhcp_server.dhcp.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_dhcp_server_id = "${sakuracloud_vpc_router_dhcp_server.dhcp.id}"
 
     ipaddress = "192.168.11.20"
     macaddress = "aa:bb:cc:aa:bb:cc"
 }
 resource "sakuracloud_vpc_router_l2tp" "l2tp" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_id = sakuracloud_vpc_router_interface.eth1.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
 
     pre_shared_secret = "hogehoge"
     range_start = "192.168.11.51"
@@ -309,12 +309,12 @@ resource "sakuracloud_vpc_router_l2tp" "l2tp" {
 
 }
 resource "sakuracloud_vpc_router_user" "user1" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
     name = "username"
     password = "password"
 }
 resource "sakuracloud_vpc_router_site_to_site_vpn" "s2s" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
     peer = "8.8.8.8"
     remote_id = "8.8.8.8"
     pre_shared_secret = "presharedsecret"
@@ -323,7 +323,7 @@ resource "sakuracloud_vpc_router_site_to_site_vpn" "s2s" {
 }
 
 resource "sakuracloud_vpc_router_firewall" "send_fw" {
-    vpc_router_id              = sakuracloud_vpc_router.foobar.id
+    vpc_router_id              = "${sakuracloud_vpc_router.foobar.id}"
     vpc_router_interface_index = 1
     direction = "send"
     expressions {
@@ -350,7 +350,7 @@ resource "sakuracloud_vpc_router_firewall" "send_fw" {
 }
 
 resource "sakuracloud_vpc_router_firewall" "receive_fw" {
-    vpc_router_id              = sakuracloud_vpc_router.foobar.id
+    vpc_router_id              = "${sakuracloud_vpc_router.foobar.id}"
     vpc_router_interface_index = 1
     direction = "receive"
     expressions {
@@ -376,8 +376,8 @@ resource "sakuracloud_vpc_router_firewall" "receive_fw" {
     }
 }
 resource "sakuracloud_vpc_router_static_route" "route" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_id = sakuracloud_vpc_router_interface.eth1.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
 
     prefix = "172.16.0.0/16"
     next_hop = "192.168.11.99"
@@ -394,40 +394,40 @@ resource "sakuracloud_switch" "sw01"{
 resource "sakuracloud_vpc_router" "foobar" {
     name = "vpc_router_setting_test"
     plan = "premium"
-    switch_id = sakuracloud_internet.router1.switch_id
-    vip = sakuracloud_internet.router1.ipaddresses[0]
-    ipaddress1 = sakuracloud_internet.router1.ipaddresses[1]
-    ipaddress2 = sakuracloud_internet.router1.ipaddresses[2]
-    aliases = [ sakuracloud_internet.router1.ipaddresses[3] ]
+    switch_id = "${sakuracloud_internet.router1.switch_id}"
+    vip = "${sakuracloud_internet.router1.ipaddresses[0]}"
+    ipaddress1 = "${sakuracloud_internet.router1.ipaddresses[1]}"
+    ipaddress2 = "${sakuracloud_internet.router1.ipaddresses[2]}"
+    aliases = [ "${sakuracloud_internet.router1.ipaddresses[3]}" ]
     vrid = 1
 
 }
 resource "sakuracloud_vpc_router_interface" "eth1"{
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
     index = 1
-    switch_id = sakuracloud_switch.sw01.id
+    switch_id = "${sakuracloud_switch.sw01.id}"
     vip = "192.168.11.1"
     ipaddress = ["192.168.11.2" , "192.168.11.3"]
     nw_mask_len = 24
 }
 resource "sakuracloud_vpc_router_pptp" "pptp"{
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_id = sakuracloud_vpc_router_interface.eth1.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
 
     range_start = "192.168.11.201"
     range_stop = "192.168.11.250"
 }
 resource "sakuracloud_vpc_router_static_nat" "staticNAT1" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_id = sakuracloud_vpc_router_interface.eth1.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
 
-    global_address = sakuracloud_internet.router1.ipaddresses[3]
+    global_address = "${sakuracloud_internet.router1.ipaddresses[3]}"
     private_address = "192.168.11.12"
     description = "desc"
 }
 resource "sakuracloud_vpc_router_port_forwarding" "forward1" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_id = sakuracloud_vpc_router_interface.eth1.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
 
     protocol = "udp"
     global_port = 10022
@@ -436,8 +436,8 @@ resource "sakuracloud_vpc_router_port_forwarding" "forward1" {
     description = "desc"
 }
 resource "sakuracloud_vpc_router_dhcp_server" "dhcp" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_index = sakuracloud_vpc_router_interface.eth1.index
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_index = "${sakuracloud_vpc_router_interface.eth1.index}"
 
     range_start = "192.168.11.151"
     range_stop = "192.168.11.200"
@@ -445,15 +445,15 @@ resource "sakuracloud_vpc_router_dhcp_server" "dhcp" {
     dns_servers = ["1.1.1.1", "2.2.2.2"]
 }
 resource "sakuracloud_vpc_router_dhcp_static_mapping" "dhcp_map" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_dhcp_server_id = sakuracloud_vpc_router_dhcp_server.dhcp.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_dhcp_server_id = "${sakuracloud_vpc_router_dhcp_server.dhcp.id}"
 
     ipaddress = "192.168.11.21"
     macaddress = "aa:bb:cc:aa:bb:cc"
 }
 resource "sakuracloud_vpc_router_l2tp" "l2tp" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_id = sakuracloud_vpc_router_interface.eth1.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
 
     pre_shared_secret = "hogehoge"
     range_start = "192.168.11.51"
@@ -461,12 +461,12 @@ resource "sakuracloud_vpc_router_l2tp" "l2tp" {
 
 }
 resource "sakuracloud_vpc_router_user" "user1" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
     name = "username"
     password = "password"
 }
 resource "sakuracloud_vpc_router_site_to_site_vpn" "s2s" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
     peer = "8.8.8.8"
     remote_id = "8.8.8.8"
     pre_shared_secret = "presharedsecret"
@@ -474,7 +474,7 @@ resource "sakuracloud_vpc_router_site_to_site_vpn" "s2s" {
     local_prefix = ["192.168.21.0/24"]
 }
 resource "sakuracloud_vpc_router_firewall" "send_fw" {
-    vpc_router_id              = sakuracloud_vpc_router.foobar.id
+    vpc_router_id              = "${sakuracloud_vpc_router.foobar.id}"
     vpc_router_interface_index = 1
     direction = "send"
     expressions {
@@ -501,7 +501,7 @@ resource "sakuracloud_vpc_router_firewall" "send_fw" {
 }
 
 resource "sakuracloud_vpc_router_firewall" "receive_fw" {
-    vpc_router_id              = sakuracloud_vpc_router.foobar.id
+    vpc_router_id              = "${sakuracloud_vpc_router.foobar.id}"
     vpc_router_interface_index = 1
     direction                  = "receive"
     expressions {
@@ -527,8 +527,8 @@ resource "sakuracloud_vpc_router_firewall" "receive_fw" {
     }
 }
 resource "sakuracloud_vpc_router_static_route" "route" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
-    vpc_router_interface_id = sakuracloud_vpc_router_interface.eth1.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
+    vpc_router_interface_id = "${sakuracloud_vpc_router_interface.eth1.id}"
 
     prefix = "172.16.0.0/16"
     next_hop = "192.168.11.99"
@@ -541,7 +541,7 @@ resource "sakuracloud_vpc_router" "foobar" {
     name = "vpc_router_setting_test"
 }
 resource "sakuracloud_vpc_router_site_to_site_vpn" "s2s" {
-    vpc_router_id = sakuracloud_vpc_router.foobar.id
+    vpc_router_id = "${sakuracloud_vpc_router.foobar.id}"
     peer = "8.8.8.8"
     remote_id = "8.8.8.8"
     pre_shared_secret = "presharedsecret"

--- a/sakuracloud/resource_sakuracloud_vpc_router_test.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_test.go
@@ -313,7 +313,7 @@ resource "sakuracloud_vpc_router" "foobar" {
     name = "name_before"
     description = "description_before"
     tags = ["hoge1" , "hoge2"]
-    icon_id = sakuracloud_icon.foobar.id
+    icon_id = "${sakuracloud_icon.foobar.id}"
     internet_connection = true
 }
 
@@ -348,15 +348,15 @@ resource "sakuracloud_vpc_router" "foobar" {
 
   internet_connection = true
 
-  switch_id  = sakuracloud_internet.router1.switch_id
-  vip        = sakuracloud_internet.router1.ipaddresses[0]
-  ipaddress1 = sakuracloud_internet.router1.ipaddresses[1]
-  ipaddress2 = sakuracloud_internet.router1.ipaddresses[2]
-  aliases    = [ sakuracloud_internet.router1.ipaddresses[3] ]
+  switch_id  = "${sakuracloud_internet.router1.switch_id}"
+  vip        = "${sakuracloud_internet.router1.ipaddresses[0]}"
+  ipaddress1 = "${sakuracloud_internet.router1.ipaddresses[1]}"
+  ipaddress2 = "${sakuracloud_internet.router1.ipaddresses[2]}"
+  aliases    = ["${sakuracloud_internet.router1.ipaddresses[3]}"]
   vrid       = 1
 
   interface {
-    switch_id   = sakuracloud_switch.sw.id
+    switch_id   = "${sakuracloud_switch.sw.id}"
     vip         = "192.168.11.1"
     ipaddress   = ["192.168.11.2" , "192.168.11.3"]
     nw_mask_len = 24 
@@ -430,7 +430,7 @@ resource "sakuracloud_vpc_router" "foobar" {
   }
 
   static_nat {
-    global_address  = sakuracloud_internet.router1.ipaddresses[3]
+    global_address  = "${sakuracloud_internet.router1.ipaddresses[3]}"
     private_address = "192.168.11.12"
     description     = "desc"
   }
@@ -464,11 +464,11 @@ resource "sakuracloud_vpc_router" "foobar" {
 
   internet_connection = true
 
-  switch_id  = sakuracloud_internet.router1.switch_id
-  vip        = sakuracloud_internet.router1.ipaddresses[0]
-  ipaddress1 = sakuracloud_internet.router1.ipaddresses[1]
-  ipaddress2 = sakuracloud_internet.router1.ipaddresses[2]
-  aliases    = [ sakuracloud_internet.router1.ipaddresses[3] ]
+  switch_id  = "${sakuracloud_internet.router1.switch_id}"
+  vip        = "${sakuracloud_internet.router1.ipaddresses[0]}"
+  ipaddress1 = "${sakuracloud_internet.router1.ipaddresses[1]}"
+  ipaddress2 = "${sakuracloud_internet.router1.ipaddresses[2]}"
+  aliases    = [ "${sakuracloud_internet.router1.ipaddresses[3]}" ]
   vrid       = 1
 }
 `


### PR DESCRIPTION
based on https://github.com/sacloud/terraform-provider-sakuracloud/issues/324#issuecomment-478795447

provider SDKとして`github.com/hashicorp/terraform@pluginsdk-v0.12-early6`を利用する。
これによりTerraform v0.10/v0.11との互換性を保ったままv0.12対応される。