### PR TITLE
エンハンスドロードバランサの正式版対応

### DIFF
--- a/build_docs/docs/configuration/resources/data/proxylb.md
+++ b/build_docs/docs/configuration/resources/data/proxylb.md
@@ -29,7 +29,9 @@ data "sakuracloud_proxylb" "proxylb" {
 |---------------|-----------------|--------------------------------------------|
 | `id`          | ID              | -                                          |
 | `plan`        | プラン    | -                                          |
-| `vip`        | VIP       | ロードバランサに割り当てられたグローバルIP    |
+| `vip_failover` | VIPフェイルオーバ | - |
+| `vip`        | VIP       | ロードバランサに割り当てられたグローバルIP(`vip_failover`が`false`の場合のみ有効)    |
+| `fqdn`        | VIP       | ロードバランサに割り当てられたグローバルIP(`vip_failover`が`true`の場合のみ有効)    |
 | `proxy_networks`  | プロキシ元ネットワーク | プロキシ元IP(CIDR)のリスト    |
 | `name`            |  エンハンスドロードバランサ名        | - |
 | `bind_ports`      |  待ち受けポート  | -        | 

--- a/build_docs/docs/configuration/resources/proxylb.md
+++ b/build_docs/docs/configuration/resources/proxylb.md
@@ -8,7 +8,9 @@
 
 ```hcl
 resource "sakuracloud_proxylb" "foobar" {
-  name = "foobar"
+  name         = "foobar"
+  plan         = 1000 
+  vip_failover = true # default: false
 
   health_check {
     protocol    = "http"
@@ -28,18 +30,30 @@ resource "sakuracloud_proxylb" "foobar" {
   }
 
   servers {
-      ipaddress = "133.242.0.3"
-      port = 80
+    ipaddress = "133.242.0.3"
+    port = 80
   }
   servers {
-      ipaddress = "133.242.0.4"
-      port = 80
+    ipaddress = "133.242.0.4"
+    port = 80
   }
 
   certificate {
     server_cert = file("server.crt")
     private_key = file("server.key")    
     # intermediate_cert = file("intermediate.crt")
+    
+    additional_certificates {
+      server_cert = file("server2.crt")
+      private_key = file("server2.key")    
+      # intermediate_cert = file("intermediate2.crt")
+    }
+    
+    additional_certificates {
+      server_cert = file("server3.crt")
+      private_key = file("server3.key")    
+      # intermediate_cert = file("intermediate3.crt")
+    }
   }
 }
 ```
@@ -52,6 +66,7 @@ resource "sakuracloud_proxylb" "foobar" {
 |-------------------|:---:|---------------|:--------:|------------------------|----------------------------------------------|
 | `name`            | ◯   | エンハンスドロードバランサ名        | -        | 文字列                  | - |
 | `plan`            | -   | プラン        | `1000`        | `1000`<br />`5000`<br />`10000`<br />`50000`<br />`100000`     | - |
+| `vip_failover`    | -   | VIPフェイルオーバ | `false`        | `true` or `false`     | - |
 | `bind_ports`      | ◯   | 待ち受けポート  | -        | リスト                  | 詳細は[`bind_ports`](#bind_ports)を参照    |
 | `health_check`    | ◯   | ヘルスチェック  | -        | マップ                  | 詳細は[`health_check`](#health_check)を参照    |
 | `sorry_server`     | -   | ソーリーサーバ  | -      | マップ| 詳細は[`sorry_server`](#sorry_server)を参照 |
@@ -101,14 +116,24 @@ resource "sakuracloud_proxylb" "foobar" {
 |パラメーター  |必須  |名称          |初期値   |設定値                 |補足                                          |
 |------------|:---:|--------------|:------:|---------------------|----------------------------------------------|
 | `server_cert`      | ◯  | サーバ証明書 | -      | 文字列               | -|
-| `intermediate_cert`| ◯  | 中間証明書   | - | 文字列 | - |
+| `intermediate_cert`| -  | 中間証明書   | - | 文字列 | - |
 | `private_key`      | ◯  | 秘密鍵      | - | 文字列 | - |
+| `additional_certificates`| -  | 追加証明書      | - | リスト | 詳細は[`certificate`](#certificate)を参照 |
+
+`certificate`は以下の属性を持ちます。(`additional_certificates`配下の各要素も同様です)
+
+|属性名          | 名称             | 補足                                        |
+|---------------|-----------------|--------------------------------------------|
+| `common_name` | Common Name | -                                          |
+| `end_date`    | 有効期限     | -                                          |
+
 
 ### 属性
 
 |属性名          | 名称             | 補足                                        |
 |---------------|-----------------|--------------------------------------------|
 | `id`          | ID              | -                                          |
-| `vip`        | VIP       | ロードバランサに割り当てられたグローバルIP    |
+| `vip`        | VIP       | ロードバランサに割り当てられたグローバルIP(`vip_failover`が`false`の場合のみ有効)    |
+| `fqdn`        | VIP       | ロードバランサに割り当てられたグローバルIP(`vip_failover`が`true`の場合のみ有効)    |
 | `proxy_networks`  | プロキシ元ネットワーク | プロキシ元IP(CIDR)のリスト    |
 

--- a/build_docs/docs/configuration/resources/proxylb.md
+++ b/build_docs/docs/configuration/resources/proxylb.md
@@ -120,13 +120,6 @@ resource "sakuracloud_proxylb" "foobar" {
 | `private_key`      | ◯  | 秘密鍵      | - | 文字列 | - |
 | `additional_certificates`| -  | 追加証明書      | - | リスト | 詳細は[`certificate`](#certificate)を参照 |
 
-`certificate`は以下の属性を持ちます。(`additional_certificates`配下の各要素も同様です)
-
-|属性名          | 名称             | 補足                                        |
-|---------------|-----------------|--------------------------------------------|
-| `common_name` | Common Name | -                                          |
-| `end_date`    | 有効期限     | -                                          |
-
 
 ### 属性
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud v1.17.3
+	github.com/sacloud/libsacloud v1.18.1
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect

--- a/sakuracloud/data_source_sakuracloud_proxylb.go
+++ b/sakuracloud/data_source_sakuracloud_proxylb.go
@@ -132,14 +132,6 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"common_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"end_date": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"additional_certificates": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -154,14 +146,6 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 										Computed: true,
 									},
 									"private_key": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"common_name": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"end_date": {
 										Type:     schema.TypeString,
 										Computed: true,
 									},

--- a/sakuracloud/data_source_sakuracloud_proxylb.go
+++ b/sakuracloud/data_source_sakuracloud_proxylb.go
@@ -51,6 +51,10 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"vip_failover": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"bind_ports": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -128,6 +132,42 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"common_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"end_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"additional_certificates": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"server_cert": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"intermediate_cert": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"private_key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"common_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"end_date": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -163,6 +203,10 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"vip": {
 				Type:     schema.TypeString,

--- a/sakuracloud/resource_sakuracloud_proxylb.go
+++ b/sakuracloud/resource_sakuracloud_proxylb.go
@@ -3,7 +3,6 @@ package sakuracloud
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -126,14 +125,6 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"common_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"end_date": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"additional_certificates": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -150,14 +141,6 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 									"private_key": {
 										Type:     schema.TypeString,
 										Required: true,
-									},
-									"common_name": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"end_date": {
-										Type:     schema.TypeString,
-										Computed: true,
 									},
 								},
 							},
@@ -580,8 +563,8 @@ func setProxyLBResourceData(d *schema.ResourceData, client *APIClient, data *sac
 		"server_cert":       cert.ServerCertificate,
 		"intermediate_cert": cert.IntermediateCertificate,
 		"private_key":       cert.PrivateKey,
-		"common_name":       cert.CertificateCommonName,
-		"end_date":          cert.CertificateEndDate.Format(time.RFC3339),
+		//"common_name":       cert.CertificateCommonName,
+		//"end_date":          cert.CertificateEndDate.Format(time.RFC3339),
 	}
 	if len(cert.AdditionalCerts) > 0 {
 		var certs []interface{}
@@ -590,8 +573,8 @@ func setProxyLBResourceData(d *schema.ResourceData, client *APIClient, data *sac
 				"server_cert":       cert.ServerCertificate,
 				"intermediate_cert": cert.IntermediateCertificate,
 				"private_key":       cert.PrivateKey,
-				"common_name":       cert.CertificateCommonName,
-				"end_date":          cert.CertificateEndDate.Format(time.RFC3339),
+				//"common_name":       cert.CertificateCommonName,
+				//"end_date":          cert.CertificateEndDate.Format(time.RFC3339),
 			})
 		}
 		proxylbCert["additional_certificates"] = certs
@@ -600,6 +583,5 @@ func setProxyLBResourceData(d *schema.ResourceData, client *APIClient, data *sac
 	}
 
 	d.Set("certificates", []interface{}{proxylbCert})
-
 	return nil
 }

--- a/sakuracloud/resource_sakuracloud_proxylb.go
+++ b/sakuracloud/resource_sakuracloud_proxylb.go
@@ -95,7 +95,6 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
-				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ipaddress": {
@@ -113,7 +112,6 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
-				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"server_cert": {
@@ -475,6 +473,7 @@ func resourceSakuraCloudProxyLBUpdate(d *schema.ResourceData, meta interface{}) 
 				ServerCertificate:       values.Get("server_cert").(string),
 				IntermediateCertificate: values.Get("intermediate_cert").(string),
 				PrivateKey:              values.Get("private_key").(string),
+				AdditionalCerts:         []*sacloud.ProxyLBCertificate{},
 			}
 
 			if rawAdditionalCerts, ok := getListFromResource(values, "additional_certificates"); ok && len(rawAdditionalCerts) > 0 {

--- a/sakuracloud/resource_sakuracloud_proxylb_test.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -41,6 +42,10 @@ func TestAccResourceSakuraCloudProxyLB(t *testing.T) {
 						"sakuracloud_proxylb.foobar", "name", "terraform-test-proxylb"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_proxylb.foobar", "plan", "5000"),
+					resource.TestMatchResourceAttr(
+						"sakuracloud_proxylb.foobar", "fqdn", regexp.MustCompile(`.+\.sakura\.ne\.jp$`)),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_proxylb.foobar", "vip_failover", "true"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_proxylb.foobar", "health_check.0.protocol", "http"),
 					resource.TestCheckResourceAttr(
@@ -173,6 +178,7 @@ func TestAccImportSakuraCloudProxyLB(t *testing.T) {
 		}
 		expects := map[string]string{
 			"name":                      "terraform-test-proxylb-import",
+			"vip_failover":              "true",
 			"health_check.0.protocol":   "tcp",
 			"health_check.0.delay_loop": "20",
 			"description":               "ProxyLB from TerraForm for SAKURA CLOUD",
@@ -192,7 +198,7 @@ func TestAccImportSakuraCloudProxyLB(t *testing.T) {
 		if err := compareStateMulti(s[0], expects); err != nil {
 			return err
 		}
-		return stateNotEmptyMulti(s[0], "vip", "proxy_networks.0")
+		return stateNotEmptyMulti(s[0], "fqdn", "proxy_networks.0")
 	}
 
 	resourceName := "sakuracloud_proxylb.foobar"
@@ -219,6 +225,7 @@ var testAccCheckSakuraCloudProxyLBConfig_basic = `
 resource "sakuracloud_proxylb" "foobar" {
   name = "terraform-test-proxylb"
   plan = 5000
+  vip_failover = true
   health_check {
     protocol = "http"
     delay_loop = 10
@@ -257,6 +264,7 @@ var testAccCheckSakuraCloudProxyLBConfig_update = `
 resource "sakuracloud_proxylb" "foobar" {
   name = "terraform-test-proxylb-upd"
   plan = 5000
+  vip_failover = true
   health_check {
     protocol = "tcp"
     delay_loop = 20
@@ -284,6 +292,7 @@ resource sakuracloud_server "server01" {
 var testAccCheckSakuraCloudProxyLBConfig_import = `
 resource "sakuracloud_proxylb" "foobar" {
   name = "terraform-test-proxylb-import"
+  vip_failover = true
   health_check {
     protocol = "tcp"
     delay_loop = 20

--- a/website/docs/d/proxylb.html.markdown
+++ b/website/docs/d/proxylb.html.markdown
@@ -31,6 +31,7 @@ The following attributes are exported:
 * `id` - The ID of the resource.
 * `name` - Name of the resource.
 * `plan` - The plan of the resource.
+* `vip_failover` - The flag of enable VIP Fail-Over.  
 * `bind_ports` - The external listen ports. It contains some attributes to [Bind Ports](#bind-ports).
 * `health_check` - The health check rules. It contains some attributes to [Health Check](#health-check).
 * `sorry_server` - The pair of IPAddress and port number of sorry-server.
@@ -67,5 +68,6 @@ Attributes for Health Check:
 * `server_cert` - The server certificate.
 * `intermediate_cert` - The intermediate certificate.
 * `private_key` - The private key.
-
-
+* `common_name` - The common name of certificates.  
+* `end_date` - End date.  
+* `additional_certificates` - The additional certificates.

--- a/website/docs/d/proxylb.html.markdown
+++ b/website/docs/d/proxylb.html.markdown
@@ -68,6 +68,4 @@ Attributes for Health Check:
 * `server_cert` - The server certificate.
 * `intermediate_cert` - The intermediate certificate.
 * `private_key` - The private key.
-* `common_name` - The common name of certificates.  
-* `end_date` - End date.  
 * `additional_certificates` - The additional certificates.

--- a/website/docs/r/proxylb.html.markdown
+++ b/website/docs/r/proxylb.html.markdown
@@ -107,11 +107,6 @@ Valid value is one of the following: [ "http" / "tcp" ]
 * `private_key` - (Optional) The private key.
 * `additional_certificates` - (Optional) Additional certificates.
 
-Certificate has following attributes:
-
-- `common_name` - The common name of certificates.  
-- `end_date` - End date.  
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/proxylb.html.markdown
+++ b/website/docs/r/proxylb.html.markdown
@@ -14,7 +14,9 @@ Provides a SakuraCloud ProxyLB(Enhanced-LoadBalancer) resource. This can be used
 
 ```hcl
 resource "sakuracloud_proxylb" "foobar" {
-  name = "foobar"
+  name         = "foobar"
+  plan         = 1000 
+  vip_failover = false
 
   health_check {
     protocol    = "http"
@@ -34,18 +36,24 @@ resource "sakuracloud_proxylb" "foobar" {
   }
 
   servers {
-      ipaddress = "133.242.0.3"
-      port = 80
+    ipaddress = "133.242.0.3"
+    port = 80
   }
   servers {
-      ipaddress = "133.242.0.4"
-      port = 80
+    ipaddress = "133.242.0.4"
+    port = 80
   }
 
   certificate {
     server_cert = file("server.crt")
     private_key = file("server.key")    
     # intermediate_cert = file("intermediate.crt")
+    
+    additional_certificates {
+      server_cert = file("server2.crt")
+      private_key = file("server2.key")    
+      # intermediate_cert = file("intermediate2.crt")
+    }
   }
 }
 ```
@@ -57,6 +65,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the resource.  
 * `plan` - (Optional) The plan of the resource.
 Valid value is one of the following: [ 1000 (default) / 5000 / 10000 / 50000 / 100000 ]  
+* `vip_failover` - (Optional) The flag of enable VIP Fail-Over.  
 * `bind_ports` - (Required) The external listen ports. It contains some attributes to [Bind Ports](#bind-ports).
 * `health_check` - (Required) The health check rules. It contains some attributes to [Health Check](#health-check).
 * `sorry_server` - (Optional) The pair of IPAddress and port number of sorry-server.
@@ -96,6 +105,12 @@ Valid value is one of the following: [ "http" / "tcp" ]
 * `server_cert` - (Required) The server certificate.
 * `intermediate_cert` - (Optional) The intermediate certificate.
 * `private_key` - (Optional) The private key.
+* `additional_certificates` - (Optional) Additional certificates.
+
+Certificate has following attributes:
+
+- `common_name` - The common name of certificates.  
+- `end_date` - End date.  
 
 ## Attributes Reference
 
@@ -104,11 +119,15 @@ The following attributes are exported:
 * `id` - The ID of the resource.
 * `name` - Name of the resource.
 * `plan` - The plan of the resource.
+* `vip_failover` - The flag of enable VIP Fail-Over.  
 * `bind_ports` - The external listen ports. It contains some attributes to [Bind Ports](#bind-ports).
 * `health_check` - The health check rules. It contains some attributes to [Health Check](#health-check).
 * `sorry_server` - The pair of IPAddress and port number of sorry-server.
 * `servers` - Real servers. It contains some attributes to [Servers](#servers).
 * `certificate` - Certificate used to terminate SSL/TSL. It contains some attributes to [Certificate](#certificate).
+* `vip` - The VirtualIPAddress that was assigned. This attribute only valid when `vip_failover` is set to `false`.  
+* `fqdn` - The FQDN that was assigned. This attribute only valid when `vip_failover` is set to `true`.  
+* `proxy_networks` - ProxyLB network address.   
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon.


### PR DESCRIPTION
To fix #425 

- 再作成なしでのプラン変更対応(IDは変更される)
- `vip_failover`パラメータの追加
- SNI対応として`additional_certificates`パラメータ追加
- ~`certificate`で`common_name`と`end_date`を参照可能に~
- `vip_failover`の設定に応じて`vip`と`fqdn`の何れかを参照可能に

Acceptance test results:

```console
$ export SAKURACLOUD_PROXYLB_SERVER0=xxx.xxx.xxx.xxx
$ export SAKURACLOUD_PROXYLB_SERVER1=zzz.zzz.zzz.zzz
$ TESTARGS="-run=ProxyLB -count=1" make testacc

TF_ACC=1 go test ./ -v -run=ProxyLB -count=1 -timeout 240m ; \
	TF_ACC=1 go test ./sakuracloud -v -run=ProxyLB -timeout 240m
?   	github.com/sacloud/terraform-provider-sakuracloud	[no test files]
=== RUN   TestAccSakuraCloudDataSourceProxyLB_Basic
=== PAUSE TestAccSakuraCloudDataSourceProxyLB_Basic
=== RUN   TestAccResourceSakuraCloudProxyLB
=== PAUSE TestAccResourceSakuraCloudProxyLB
=== RUN   TestAccImportSakuraCloudProxyLB
=== PAUSE TestAccImportSakuraCloudProxyLB
=== CONT  TestAccSakuraCloudDataSourceProxyLB_Basic
=== CONT  TestAccResourceSakuraCloudProxyLB
=== CONT  TestAccImportSakuraCloudProxyLB
--- PASS: TestAccImportSakuraCloudProxyLB (8.84s)
--- PASS: TestAccSakuraCloudDataSourceProxyLB_Basic (13.25s)
--- PASS: TestAccResourceSakuraCloudProxyLB (41.54s)
PASS
ok  	github.com/sacloud/terraform-provider-sakuracloud/sakuracloud	41.577s

```