### PR TITLE
パラメータ追加: APIリクエストタイムアウト

### DIFF
--- a/build_docs/docs/configuration/provider.md
+++ b/build_docs/docs/configuration/provider.md
@@ -15,6 +15,8 @@ provider sakuracloud {
   # timeout         = 20  # 単位:分
   # api_root_url    = "https://secure.sakura.ad.jp/cloud/zone"  
   # trace           = false
+  
+  # api_request_timeout = 60 # 単位:秒
 }
 ```
 
@@ -31,6 +33,7 @@ provider sakuracloud {
 |`retry_interval` | -   | リトライ時待機時間    | `5`     |数値(秒)|環境変数`SAKURACLOUD_RETRY_INTERVAL`での指定も可  |
 |`timeout`        | -   | タイムアウト         | `20`     | 数値(分) |環境変数`SAKURACLOUD_TIMEOUT`での指定も可|
 |`api_root_url`   | -   | さくらのクラウドAPI ルートURL | -        |文字列|テストなどのためにAPIのルートAPIを変更したい場合に設定する。<br />末尾にスラッシュを含めないでください。<br />指定しない場合のルートURLは`https://secure.sakura.ad.jp/cloud/zone`<br />環境変数`SAKURACLOUD_API_ROOT_URL`での指定も可  |
+|`api_request_timeout` | -   | APIリクエストタイムアウト         | `60`     | 数値(秒) |環境変数`SAKURACLOUD_API_REQUEST_TIMEOUT`での指定も可|
 |`trace`          | -   | トレースフラグ       | `false`     |`true`<br />`false`|(開発者向け)詳細ログの出力ON/OFFを指定します。 <br />環境変数`SAKURACLOUD_TRACE_MODE`での指定も可|
 
 各パラメータとも環境変数での指定が可能です。

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud v1.18.1
+	github.com/sacloud/libsacloud v1.19.1
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 )

--- a/sakuracloud/config.go
+++ b/sakuracloud/config.go
@@ -1,6 +1,7 @@
 package sakuracloud
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/sacloud/libsacloud/api"
@@ -17,6 +18,7 @@ type Config struct {
 	APIRootURL        string
 	RetryMax          int
 	RetryInterval     int
+	APIRequestTimeout int
 }
 
 // APIClient for SakuraCloud API
@@ -42,6 +44,11 @@ func (c *Config) NewClient() *APIClient {
 	}
 	if c.TimeoutMinute > 0 {
 		client.DefaultTimeoutDuration = time.Duration(c.TimeoutMinute) * time.Minute
+	}
+	if c.APIRequestTimeout > 0 {
+		client.HTTPClient = &http.Client{
+			Timeout: time.Duration(c.APIRequestTimeout) * time.Second,
+		}
 	}
 
 	if c.TraceMode {

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -66,6 +66,11 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_TIMEOUT"}, 20),
 			},
+			"api_request_timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_API_REQUEST_TIMEOUT"}, 60),
+			},
 			"trace": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -165,6 +170,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		APIRootURL:        d.Get("api_root_url").(string),
 		RetryMax:          d.Get("retry_max").(int),
 		RetryInterval:     d.Get("retry_interval").(int),
+		APIRequestTimeout: d.Get("api_request_timeout").(int),
 	}
 
 	return config.NewClient(), nil

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,4 +37,5 @@ The following arguments are supported:
 * `retry_max` - (Optional) The number of retries when an error (status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_MAX` environment variable. Default value is `10`.
 * `retry_interval` - (Optional) The retry interval (seconds) when an error (status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_INTERVAL` environment variable. Default value is `5`.
 * `timeout` - (Optional) The status change wait time in API call (minutes). It can also be sourced from the `SAKURACLOUD_TIMEOUT` environment variable. Default value is `20`.
+* `api_request_timeout` - (Optional) The maximum wait time in API call (seconds). It can also be sourced from the `SAKURACLOUD_API_REQUEST_TIMEOUT` environment variable. Default value is `60`.
 * `trace` - (Optional) The flag of output logs at API call. It can also be sourced from the `SAKURACLOUD_TRACE_MODE` environment variable. 


### PR DESCRIPTION
APIリクエスト時に利用する*http.Clientのタイムアウトを指定可能にする。

```hcl
provider sakuracloud {
  token  = "your API token"
  secret = "your API secret"
  zone   = "target zone"
  
  api_request_timeout = 60 # 単位:秒
}
```