### PR TITLE
Use fixed terraform version until terraform v0.12 is released

### DIFF
--- a/tools/terraform-version/main.go
+++ b/tools/terraform-version/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-
-	"github.com/hashicorp/terraform/version"
+	//"github.com/hashicorp/terraform/version"
 )
 
 func main() {
-	fmt.Print(version.Version)
+	//fmt.Print(version.Version)
+	fmt.Print("0.11.13")
 }


### PR DESCRIPTION
現在リンクしているTerraform provider SDKはバージョンとしてv0.12.0を返す。
この値を使ってDockerイメージのビルドを行なっているが、まだv0.12がリリースされていないためビルドに失敗する。

このため、v0.12が正式リリースされるまでの間`tools/terraform-version`にて固定の値(正式リリース済みの最新バージョン)を返すようにする。