### PR TITLE
APIクライアントの分離

### DIFF
--- a/sakuracloud/resource_sakuracloud_loadbalancer.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer.go
@@ -181,12 +181,7 @@ func loadBalancerServerValueSchema() map[string]*schema.Schema {
 }
 
 func resourceSakuraCloudLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*APIClient)
-
-	zone, ok := d.GetOk("zone")
-	if ok {
-		client.Zone = zone.(string)
-	}
+	client := getSacloudAPIClient(d, meta)
 
 	opts := &sacloud.CreateLoadBalancerValue{}
 

--- a/sakuracloud/resource_sakuracloud_mobile_gateway.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway.go
@@ -157,12 +157,7 @@ func resourceSakuraCloudMobileGateway() *schema.Resource {
 }
 
 func resourceSakuraCloudMobileGatewayCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*APIClient)
-
-	zone, ok := d.GetOk("zone")
-	if ok {
-		client.Zone = zone.(string)
-	}
+	client := getSacloudAPIClient(d, meta)
 
 	var switchID int64
 	var ip string

--- a/sakuracloud/resource_sakuracloud_nfs.go
+++ b/sakuracloud/resource_sakuracloud_nfs.go
@@ -100,12 +100,7 @@ func resourceSakuraCloudNFS() *schema.Resource {
 }
 
 func resourceSakuraCloudNFSCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*APIClient)
-
-	zone, ok := d.GetOk("zone")
-	if ok {
-		client.Zone = zone.(string)
-	}
+	client := getSacloudAPIClient(d, meta)
 
 	opts := &sacloud.CreateNFSValue{}
 

--- a/sakuracloud/structure_test.go
+++ b/sakuracloud/structure_test.go
@@ -1,0 +1,29 @@
+package sakuracloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSacloudAPIClient(t *testing.T) {
+
+	config := &Config{
+		AccessToken:       "token",
+		AccessTokenSecret: "secret",
+		Zone:              "test",
+	}
+	originalClient := config.NewClient()
+
+	assert.Equal(t, "test", originalClient.Zone)
+
+	resourceData := mapToResourceData(map[string]interface{}{
+		"zone": "dummy",
+	})
+	clonedClient := getSacloudAPIClient(resourceData, originalClient)
+
+	assert.Equal(t, originalClient.AccessToken, clonedClient.AccessToken)
+	assert.Equal(t, originalClient.AccessTokenSecret, clonedClient.AccessTokenSecret)
+	assert.Equal(t, "dummy", clonedClient.Zone)
+	assert.Equal(t, "test", originalClient.Zone)
+}


### PR DESCRIPTION
リソースの操作時に利用するAPIクライアントの設定が適切に行えていない部分を修正する。

===

現在の実装は1プロバイダーごとに1つのAPIクライアントのインスタンスを作成し各リソースのCRUD操作で共有している。
また、APIクライアントが利用するゾーンはAPIクライアントのフィールド`Zone`として保持している。
もしAPIクライアントのZoneが変更された場合には影響が全体に及ぶ。

このため、ゾーンを変更する可能性のあるリソースではAPIクライアントの提供する`Clone()`メソッドを利用してそれぞれがAPIクライアントのクローンを作成して利用することでこの問題を回避している。
`Clone()`メソッド呼び出しは各リソースの実装で直接行うのではなく、ラッパーである`getSacloudAPIClient`メソッドを利用するようにしている。

https://github.com/sacloud/terraform-provider-sakuracloud/blob/v1.11.1/sakuracloud/structure.go#L68-L79

しかし、以下のリソースでは適切に`Clone()`(のラッパー)の呼び出しが行えていない。  

- NFSのCreate操作
- ロードバランサのCreate操作
- モバイルゲートウェイ のCreate操作
