### PR TITLE
APIトレースログ用にプレフィックス設定

### DIFF
--- a/sakuracloud/config.go
+++ b/sakuracloud/config.go
@@ -1,6 +1,7 @@
 package sakuracloud
 
 import (
+	"log"
 	"net/http"
 	"time"
 
@@ -53,6 +54,7 @@ func (c *Config) NewClient() *APIClient {
 
 	if c.TraceMode {
 		client.TraceMode = true
+		log.SetPrefix("[DEBUG] ")
 	}
 	client.UserAgent = "Terraform for SakuraCloud/v" + Version
 


### PR DESCRIPTION
プロバイダーの`trace`属性や環境変数`SAKURACLOUD_TRACE_MODE`の設定でさくらのクラウドAPIのトレースログを出力する際のプレフィックスとして`[DEBUG]`を設定する。
