### PR TITLE
APIリクエストでのレートリミット設定

### DIFF
--- a/build_docs/docs/configuration/provider.md
+++ b/build_docs/docs/configuration/provider.md
@@ -16,7 +16,8 @@ provider sakuracloud {
   # api_root_url    = "https://secure.sakura.ad.jp/cloud/zone"  
   # trace           = false
   
-  # api_request_timeout = 60 # 単位:秒
+  # api_request_timeout    = 60 # 単位:秒
+  # api_request_rate_limit = 5  # 秒あたりの最大APIリクエスト数
 }
 ```
 
@@ -34,11 +35,12 @@ provider sakuracloud {
 |`timeout`        | -   | タイムアウト         | `20`     | 数値(分) |環境変数`SAKURACLOUD_TIMEOUT`での指定も可|
 |`api_root_url`   | -   | さくらのクラウドAPI ルートURL | -        |文字列|テストなどのためにAPIのルートAPIを変更したい場合に設定する。<br />末尾にスラッシュを含めないでください。<br />指定しない場合のルートURLは`https://secure.sakura.ad.jp/cloud/zone`<br />環境変数`SAKURACLOUD_API_ROOT_URL`での指定も可  |
 |`api_request_timeout` | -   | APIリクエストタイムアウト         | `60`     | 数値(秒) |環境変数`SAKURACLOUD_API_REQUEST_TIMEOUT`での指定も可|
+|`api_request_rate_limit` | -   | APIリクエストレートリミット         | `5`     | 数値(`1`〜`10`) | 秒あたりのさくらのクラウドAPIリクエスト最大数。環境変数`SAKURACLOUD_RATE_LIMIT`での指定も可|
 |`trace`          | -   | トレースフラグ       | `false`     |`true`<br />`false`|(開発者向け)詳細ログの出力ON/OFFを指定します。 <br />環境変数`SAKURACLOUD_TRACE_MODE`での指定も可|
 
 各パラメータとも環境変数での指定が可能です。
 
-`token`と`secret`を環境変数で指定した場合、プロバイダ設定の記述は不要です。
+`token`と`secret`を環境変数で指定した場合、プロバイダ設定の記述は省略可能です。
 
 #### 環境変数の指定例
 

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,17 @@ module github.com/sacloud/terraform-provider-sakuracloud
 
 require (
 	github.com/hashicorp/terraform v0.12.0-alpha4.0.20190410234817-9e158400c228
+	github.com/mattn/go-isatty v0.0.7 // indirect
+	github.com/mattn/go-tty v0.0.0-20190407112021-83fae09cc007 // indirect
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/goamz v0.0.0-20150317174335-caaaea8b30ee
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud v1.20.0
+	github.com/sacloud/libsacloud v1.21.0
+	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
+	golang.org/x/crypto v0.0.0-20190417174047-f416ebab96af // indirect
+	golang.org/x/sys v0.0.0-20190416152802-12500544f89f // indirect
 )

--- a/sakuracloud/config.go
+++ b/sakuracloud/config.go
@@ -10,16 +10,17 @@ import (
 
 // Config type of SakuraCloud Config
 type Config struct {
-	AccessToken       string
-	AccessTokenSecret string
-	Zone              string
-	TimeoutMinute     int
-	TraceMode         bool
-	AcceptLanguage    string
-	APIRootURL        string
-	RetryMax          int
-	RetryInterval     int
-	APIRequestTimeout int
+	AccessToken         string
+	AccessTokenSecret   string
+	Zone                string
+	TimeoutMinute       int
+	TraceMode           bool
+	AcceptLanguage      string
+	APIRootURL          string
+	RetryMax            int
+	RetryInterval       int
+	APIRequestTimeout   int
+	APIRequestRateLimit int
 }
 
 // APIClient for SakuraCloud API
@@ -46,11 +47,15 @@ func (c *Config) NewClient() *APIClient {
 	if c.TimeoutMinute > 0 {
 		client.DefaultTimeoutDuration = time.Duration(c.TimeoutMinute) * time.Minute
 	}
+
+	httpClient := &http.Client{}
 	if c.APIRequestTimeout > 0 {
-		client.HTTPClient = &http.Client{
-			Timeout: time.Duration(c.APIRequestTimeout) * time.Second,
-		}
+		httpClient.Timeout = time.Duration(c.APIRequestTimeout) * time.Second
 	}
+	if c.APIRequestRateLimit > 0 {
+		httpClient.Transport = &api.RateLimitRoundTripper{RateLimitPerSec: c.APIRequestRateLimit}
+	}
+	client.HTTPClient = httpClient
 
 	if c.TraceMode {
 		client.TraceMode = true

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -71,6 +71,12 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_API_REQUEST_TIMEOUT"}, 60),
 			},
+			"api_request_rate_limit": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				DefaultFunc:  schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_RATE_LIMIT"}, 5),
+				ValidateFunc: validation.IntBetween(1, 10),
+			},
 			"trace": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -162,15 +168,16 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	config := Config{
-		AccessToken:       d.Get("token").(string),
-		AccessTokenSecret: d.Get("secret").(string),
-		Zone:              d.Get("zone").(string),
-		TimeoutMinute:     d.Get("timeout").(int),
-		TraceMode:         d.Get("trace").(bool),
-		APIRootURL:        d.Get("api_root_url").(string),
-		RetryMax:          d.Get("retry_max").(int),
-		RetryInterval:     d.Get("retry_interval").(int),
-		APIRequestTimeout: d.Get("api_request_timeout").(int),
+		AccessToken:         d.Get("token").(string),
+		AccessTokenSecret:   d.Get("secret").(string),
+		Zone:                d.Get("zone").(string),
+		TimeoutMinute:       d.Get("timeout").(int),
+		TraceMode:           d.Get("trace").(bool),
+		APIRootURL:          d.Get("api_root_url").(string),
+		RetryMax:            d.Get("retry_max").(int),
+		RetryInterval:       d.Get("retry_interval").(int),
+		APIRequestTimeout:   d.Get("api_request_timeout").(int),
+		APIRequestRateLimit: d.Get("api_request_rate_limit").(int),
 	}
 
 	return config.NewClient(), nil

--- a/sakuracloud/provider_test.go
+++ b/sakuracloud/provider_test.go
@@ -12,8 +12,9 @@ import (
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
 var (
-	testDefaultTargetZone  = "is1b"
-	testDefaultAPIRetryMax = "30"
+	testDefaultTargetZone   = "is1b"
+	testDefaultAPIRetryMax  = "30"
+	testDefaultAPIRateLimit = "5"
 )
 
 func init() {
@@ -58,5 +59,9 @@ func testAccPreCheck(t *testing.T) {
 
 	if v := os.Getenv("SAKURACLOUD_RETRY_MAX"); v == "" {
 		os.Setenv("SAKURACLOUD_RETRY_MAX", testDefaultAPIRetryMax)
+	}
+
+	if v := os.Getenv("SAKURACLOUD_RATE_LIMIT"); v == "" {
+		os.Setenv("SAKURACLOUD_RATE_LIMIT", testDefaultAPIRateLimit)
 	}
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -38,4 +38,5 @@ The following arguments are supported:
 * `retry_interval` - (Optional) The retry interval (seconds) when an error (status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_INTERVAL` environment variable. Default value is `5`.
 * `timeout` - (Optional) The status change wait time in API call (minutes). It can also be sourced from the `SAKURACLOUD_TIMEOUT` environment variable. Default value is `20`.
 * `api_request_timeout` - (Optional) The maximum wait time in API call (seconds). It can also be sourced from the `SAKURACLOUD_API_REQUEST_TIMEOUT` environment variable. Default value is `60`.
+* `api_request_rate_limit` - (Optional) The maximum count of API request rate limit. It can also be sourced from the `SAKURACLOUD_RATE_LIMIT` environment variable. Default value is `5`.
 * `trace` - (Optional) The flag of output logs at API call. It can also be sourced from the `SAKURACLOUD_TRACE_MODE` environment variable. 


### PR DESCRIPTION
さくらのクラウドAPIの呼び出しにレートリミットを設ける。
秒あたりの最大リクエスト数を指定可能にする。

#### 設定例

```hcl
provider sakuracloud {
  token  = "your API token"
  secret = "your API secret"
  zone   = "target zone"

  api_request_rate_limit = 5  # デフォルト5, 最大10
}
```

環境変数`SAKURACLOUD_RATE_LIMIT`でも指定可能。