### PR TITLE
コア専有プラン

### DIFF
--- a/build_docs/docs/configuration/resources/data/server.md
+++ b/build_docs/docs/configuration/resources/data/server.md
@@ -28,6 +28,7 @@ data "sakuracloud_server" "myserver" {
 | `disks`  | ディスクID          | - | 
 | `core`   | CPUコア数           | - | 
 | `memory` | メモリ(GB単位)       | - | 
+| `commitment` | コアプラン       | - | 
 | `interface_driver`  | NICドライバ  | - |
 | `nic`    | 基本NIC | - |
 | `display_ipaddress`    | 基本NIC 表示用IPアドレス | - |

--- a/build_docs/docs/configuration/resources/server.md
+++ b/build_docs/docs/configuration/resources/server.md
@@ -14,6 +14,9 @@ resource "sakuracloud_server" "myserver" {
 
   #メモリサイズ(GB)
   #memory = 1
+  
+  # コアプラン(共用or専有)
+  #commitment = "standard"
 
   #NICドライバ(virtio or e1000)
   #interface_driver = "virtio"
@@ -66,6 +69,7 @@ resource "sakuracloud_server" "myserver" {
 | `disks`  | ◯   | ディスクID          | -   | リスト(文字列) | サーバに接続するディスクのID |
 | `core`   | -   | CPUコア数           | 1   | 数値 | 指定可能な値は[こちら](http://cloud.sakura.ad.jp/specification/server-disk/)のプラン一覧を参照ください |
 | `memory` | -   | メモリ(GB単位)       | 1  | 数値 | 指定可能な値は[こちら](http://cloud.sakura.ad.jp/specification/server-disk/)のプラン一覧を参照ください |
+| `commitment` | -   | コアプラン       | `standard`  | `standard`<br />`dedicatedcpu` | standard:共用, dedicatedcpu:専有 |
 | `interface_driver` | -   | NICドライバ       | `virtio`  | `virtio`<br />`e1000` | - |
 | `nic` | - | 基本NIC | `shared` | `shared`(共有セグメント)<br />`[switch_id]`(スイッチのID)<br />`"disconnect"`(接続なし)|eth0の上流NWとの接続方法を指定する。 |
 | `display_ipaddress`| - | 基本NIC:表示用IPアドレス | - | 文字列 | コントロールパネルに表示される表示用IPアドレス、`nic`にスイッチのIDが指定されている場合のみ有効 |

--- a/build_docs/docs/configuration/resources/server.md
+++ b/build_docs/docs/configuration/resources/server.md
@@ -69,7 +69,7 @@ resource "sakuracloud_server" "myserver" {
 | `disks`  | ◯   | ディスクID          | -   | リスト(文字列) | サーバに接続するディスクのID |
 | `core`   | -   | CPUコア数           | 1   | 数値 | 指定可能な値は[こちら](http://cloud.sakura.ad.jp/specification/server-disk/)のプラン一覧を参照ください |
 | `memory` | -   | メモリ(GB単位)       | 1  | 数値 | 指定可能な値は[こちら](http://cloud.sakura.ad.jp/specification/server-disk/)のプラン一覧を参照ください |
-| `commitment` | -   | コアプラン       | `standard`  | `standard`<br />`dedicatedcpu` | standard:共用, dedicatedcpu:専有 |
+| `commitment` | -   | コアプラン       | `standard`  | `standard`<br />`dedicatedcpu` | `standard`:共用<br /> `dedicatedcpu`:コア専有 |
 | `interface_driver` | -   | NICドライバ       | `virtio`  | `virtio`<br />`e1000` | - |
 | `nic` | - | 基本NIC | `shared` | `shared`(共有セグメント)<br />`[switch_id]`(スイッチのID)<br />`"disconnect"`(接続なし)|eth0の上流NWとの接続方法を指定する。 |
 | `display_ipaddress`| - | 基本NIC:表示用IPアドレス | - | 文字列 | コントロールパネルに表示される表示用IPアドレス、`nic`にスイッチのIDが指定されている場合のみ有効 |

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/sacloud/terraform-provider-sakuracloud
 
 require (
-	github.com/hashicorp/terraform v0.12.0-alpha4.0.20190410234817-9e158400c228
+	github.com/hashicorp/terraform v0.12.0-rc1
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/mattn/go-tty v0.0.0-20190418143243-a87bf4b22d6e // indirect
 	github.com/mitchellh/go-homedir v1.0.0
@@ -9,10 +9,9 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud v1.21.1
+	github.com/sacloud/libsacloud v1.22.2
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
-	golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480 // indirect
-	golang.org/x/sys v0.0.0-20190418153312-f0ce4c0180be // indirect
+	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )

--- a/sakuracloud/data_source_sakuracloud_server.go
+++ b/sakuracloud/data_source_sakuracloud_server.go
@@ -55,6 +55,10 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"commitment": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"disks": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/website/docs/d/server.html.markdown
+++ b/website/docs/d/server.html.markdown
@@ -31,6 +31,7 @@ data "sakuracloud_server" "foobar" {
 * `name` - The name of the resource.
 * `core` - The number of cores.
 * `memory` - The size of memory (unit:`GB`).
+* `commitment` - The plan of assignment of CPU to VM.
 * `disks` - The ID list of the Disks connected to Server.
 * `interface_driver` - The name of network interface driver.
 * `nic` - The primary NIC's connection destination.

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -18,6 +18,7 @@ resource "sakuracloud_server" "foobar" {
   name                = "foobar"
   # core              = 1
   # memory            = 1
+  # commmitment       = "standard"
   disks               = [sakuracloud_disk.foobar.id]
   # interface_driver  = "virtio"
   
@@ -81,6 +82,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the resource.
 * `core` - (Optional) The number of cores (default:`1`).
 * `memory` - (Optional) The size of memory (unit:`GB`, default:`1`).
+* `commitment` - (Optional) The plan of assignment of CPU to VM(default:`standard`).  
+Valid value is one of the following: [ "standard" (default) / "dedicatedcpu"]
 * `disks` - (Optional) The ID list of the Disks connected to Server.
 * `interface_driver` - (Optional) The name of network interface driver.  
 Valid value is one of the following: [ "virtio" (default) / "e1000"]
@@ -115,6 +118,7 @@ The following attributes are exported:
 * `name` - The name of the resource.
 * `core` - The number of cores.
 * `memory` - The size of memory (unit:`GB`).
+* `commitment` - The plan of assignment of CPU to VM.
 * `disks` - The ID list of the Disks connected to Server.
 * `interface_driver` - The name of network interface driver.
 * `nic` - The primary NIC's connection destination.


### PR DESCRIPTION
コア専有プランを利用可能にする。

```tf
resource "sakuracloud_server" "example" {
  name  = "example"

  #コア数
  #core = 1

  #メモリサイズ(GB)
  #memory = 1
  
  # コアプラン(共用or専有)
  commitment = "standard" # 共用の場合(デフォルト)
  #commitment = "dedicatedcpu" # コア専有の場合
```

**利用上の注意**: 

- 提供ゾーンは`is1b`と`tk1a`のみ
- `commitment`を変更した際はサーバのIDが変更となる
- `commitment`を変更した際、サーバが起動していると再起動が行われる

**実装上の注意**: `commitment`の追加に伴いサーバリソースのスキーマバージョンを上げ、`MigrateState`の実装を追加している。`MigrateState`はTerraform v0.12で非推奨(`StateUpgraders`の利用を推奨)となっているが、Terraform v0.12の正式版がまだリリースされていないことを踏まえ`MigrateState`の実装を選択している。