### PR TITLE
api_request_timeoutパラメータのデフォルト値変更

### DIFF
--- a/build_docs/docs/configuration/provider.md
+++ b/build_docs/docs/configuration/provider.md
@@ -16,7 +16,7 @@ provider sakuracloud {
   # api_root_url    = "https://secure.sakura.ad.jp/cloud/zone"  
   # trace           = false
   
-  # api_request_timeout    = 60 # 単位:秒
+  # api_request_timeout    = 300 # 単位:秒
   # api_request_rate_limit = 5  # 秒あたりの最大APIリクエスト数
 }
 ```
@@ -34,7 +34,7 @@ provider sakuracloud {
 |`retry_interval` | -   | リトライ時待機時間    | `5`     |数値(秒)|環境変数`SAKURACLOUD_RETRY_INTERVAL`での指定も可  |
 |`timeout`        | -   | タイムアウト         | `20`     | 数値(分) |環境変数`SAKURACLOUD_TIMEOUT`での指定も可|
 |`api_root_url`   | -   | さくらのクラウドAPI ルートURL | -        |文字列|テストなどのためにAPIのルートAPIを変更したい場合に設定する。<br />末尾にスラッシュを含めないでください。<br />指定しない場合のルートURLは`https://secure.sakura.ad.jp/cloud/zone`<br />環境変数`SAKURACLOUD_API_ROOT_URL`での指定も可  |
-|`api_request_timeout` | -   | APIリクエストタイムアウト         | `60`     | 数値(秒) |環境変数`SAKURACLOUD_API_REQUEST_TIMEOUT`での指定も可|
+|`api_request_timeout` | -   | APIリクエストタイムアウト         | `300`     | 数値(秒) |環境変数`SAKURACLOUD_API_REQUEST_TIMEOUT`での指定も可|
 |`api_request_rate_limit` | -   | APIリクエストレートリミット         | `5`     | 数値(`1`〜`10`) | 秒あたりのさくらのクラウドAPIリクエスト最大数。環境変数`SAKURACLOUD_RATE_LIMIT`での指定も可|
 |`trace`          | -   | トレースフラグ       | `false`     |`true`<br />`false`|(開発者向け)詳細ログの出力ON/OFFを指定します。 <br />環境変数`SAKURACLOUD_TRACE_MODE`での指定も可|
 

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -69,7 +69,7 @@ func Provider() terraform.ResourceProvider {
 			"api_request_timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_API_REQUEST_TIMEOUT"}, 60),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_API_REQUEST_TIMEOUT"}, 300),
 			},
 			"api_request_rate_limit": {
 				Type:         schema.TypeInt,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,6 +37,6 @@ The following arguments are supported:
 * `retry_max` - (Optional) The number of retries when an error (status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_MAX` environment variable. Default value is `10`.
 * `retry_interval` - (Optional) The retry interval (seconds) when an error (status=`503`) occurs in the API call. It can also be sourced from the `SAKURACLOUD_RETRY_INTERVAL` environment variable. Default value is `5`.
 * `timeout` - (Optional) The status change wait time in API call (minutes). It can also be sourced from the `SAKURACLOUD_TIMEOUT` environment variable. Default value is `20`.
-* `api_request_timeout` - (Optional) The maximum wait time in API call (seconds). It can also be sourced from the `SAKURACLOUD_API_REQUEST_TIMEOUT` environment variable. Default value is `60`.
+* `api_request_timeout` - (Optional) The maximum wait time in API call (seconds). It can also be sourced from the `SAKURACLOUD_API_REQUEST_TIMEOUT` environment variable. Default value is `300`.
 * `api_request_rate_limit` - (Optional) The maximum count of API request rate limit. It can also be sourced from the `SAKURACLOUD_RATE_LIMIT` environment variable. Default value is `5`.
 * `trace` - (Optional) The flag of output logs at API call. It can also be sourced from the `SAKURACLOUD_TRACE_MODE` environment variable. 


### PR DESCRIPTION
(fixes #447)

`api_request_timeout`のデフォルト値を60から300へ変更する。

この値を長くする/無制限にするとフェイルファスト出来ず好ましくないが、
現在のデフォルト値60秒だとディスクの修正などの一部のAPIリクエストでタイムアウトが発生する場合がある。

このため十分に大きく、かつ大きすぎない値として300をデフォルト値としておく。
この値はエラー報告が多いようであれば再度調整する。