### PR TITLE
Terraform v0.12.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/sacloud/terraform-provider-sakuracloud
 
 require (
-	github.com/hashicorp/terraform v0.12.0-rc1
+	github.com/hashicorp/terraform v0.12.1
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/mattn/go-tty v0.0.0-20190418143243-a87bf4b22d6e // indirect
 	github.com/mitchellh/go-homedir v1.0.0

--- a/tools/terraform-version/main.go
+++ b/tools/terraform-version/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	//"github.com/hashicorp/terraform/version"
+
+	"github.com/hashicorp/terraform/version"
 )
 
 func main() {
-	//fmt.Print(version.Version)
-	fmt.Print("0.11.13")
+	fmt.Print(version.Version)
 }


### PR DESCRIPTION
- Terraform v0.12.1を利用
- Terraform v0.12がリリースされるまで固定値を用いていた暫定対応部分を除去