### PR TITLE
VNC接続情報の追加

### DIFF
--- a/build_docs/docs/configuration/resources/data/server.md
+++ b/build_docs/docs/configuration/resources/data/server.md
@@ -48,3 +48,6 @@ data "sakuracloud_server" "myserver" {
 | `dns_servers`           | 基本NIC:DNSサーバ        | eth0の属するセグメントの推奨ネームサーバのリスト|
 | `nw_address`            | 基本NIC:ネットワークアドレス | eth0のIPアドレスのネットワークアドレス          |
 | `private_host_name`     | 専有ホスト名 | -          |
+| `vnc_host`     | VNCホスト名 | -          |
+| `vnc_port`     | VNCポート番号 | -          |
+| `vnc_password`     | VNCパスワード | -          |

--- a/build_docs/docs/configuration/resources/server.md
+++ b/build_docs/docs/configuration/resources/server.md
@@ -112,3 +112,6 @@ resource "sakuracloud_server" "myserver" {
 | `dns_servers`           | 基本NIC:DNSサーバ        | eth0の属するセグメントの推奨ネームサーバのリスト|
 | `nw_address`            | 基本NIC:ネットワークアドレス | eth0のIPアドレスのネットワークアドレス          |
 | `private_host_name`     | 専有ホスト名 | -          |
+| `vnc_host`     | VNCホスト名 | -          |
+| `vnc_port`     | VNCポート番号 | -          |
+| `vnc_password`     | VNCパスワード | -          |

--- a/sakuracloud/data_source_sakuracloud_server.go
+++ b/sakuracloud/data_source_sakuracloud_server.go
@@ -159,8 +159,9 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 				Computed: true,
 			},
 			"vnc_password": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_server.go
+++ b/sakuracloud/data_source_sakuracloud_server.go
@@ -150,6 +150,18 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"vnc_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vnc_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"vnc_password": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -219,8 +219,9 @@ func resourceSakuraCloudServer() *schema.Resource {
 				Computed: true,
 			},
 			"vnc_password": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -210,6 +210,18 @@ func resourceSakuraCloudServer() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"vnc_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vnc_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"vnc_password": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -994,6 +1006,20 @@ func setServerResourceData(d *schema.ResourceData, client *APIClient, data *sacl
 		}
 
 		d.SetConnInfo(connInfo)
+	}
+
+	d.Set("vnc_host", "")
+	d.Set("vnc_port", 0)
+	d.Set("vnc_password", "")
+
+	if data.IsUp() {
+		vncRes, err := client.Server.GetVNCProxy(data.ID)
+		if err != nil {
+			return fmt.Errorf("Get VNCProxy info is failed: %s", err)
+		}
+		d.Set("vnc_host", vncRes.IOServerHost)
+		d.Set("vnc_port", forceAtoI(vncRes.Port))
+		d.Set("vnc_password", vncRes.Password)
 	}
 
 	setPowerManageTimeoutValueToState(d)

--- a/website/docs/d/server.html.markdown
+++ b/website/docs/d/server.html.markdown
@@ -52,4 +52,7 @@ data "sakuracloud_server" "foobar" {
 * `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
+* `vnc_host`     - The hostname of VNC server.
+* `vnc_port`     - The port number of VNC server.
+* `vnc_password` - The password of VNC server.
 

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -139,6 +139,9 @@ The following attributes are exported:
 * `tags` - The tag list of the resources.
 * `icon_id` - The ID of the icon of the resource.
 * `zone` - The ID of the zone to which the resource belongs.
+* `vnc_host`     - The hostname of VNC server.
+* `vnc_port`     - The port number of VNC server.
+* `vnc_password` - The password of VNC server.
 
 ## Import
 


### PR DESCRIPTION
`sakuracloud_server`(リソース、データソースとも)でvnc接続情報を参照可能にする。

- vnc_host : VNC接続先ホスト名
- vnc_password: パスワード
 - vnc_port: ポート番号
