### PR TITLE
エンハンスドロードバランサへの機能追加

### DIFF
--- a/build_docs/docs/configuration/resources/proxylb.md
+++ b/build_docs/docs/configuration/resources/proxylb.md
@@ -18,10 +18,16 @@ resource "sakuracloud_proxylb" "foobar" {
     host_header = "example.com"
     delay_loop  = 10
   }
-
+  
   bind_ports {
-    proxy_mode = "https"
-    port       = 443
+    proxy_mode        = "http"
+    port              = 80
+    redirect_to_https = true
+  }
+  bind_ports {
+    proxy_mode    = "https"
+    port          = 443
+    support_http2 = true
   }
   
   sorry_server {
@@ -84,6 +90,8 @@ resource "sakuracloud_proxylb" "foobar" {
 |---------------|:---:|--------------------|:--------:|------------------------|----------------------------------------------|
 | `proxy_mode`    | ◯   | プロキシ方式 | -        | `http`<br />`https`| - |
 | `port`        | ◯  | ポート番号 | - | 数値 | - |
+| `redirect_to_https`  | -  | HTTPSへのリダイレクト | - | bool | `proxy_mode`が`http`の場合のみ有効 |
+| `support_http2`      | -  | HTTP/2のサポート | - | bool | `proxy_mode`が`https`の場合のみ有効  |
 
 ### `health_check`
 

--- a/build_docs/docs/configuration/resources/proxylb_acme.md
+++ b/build_docs/docs/configuration/resources/proxylb_acme.md
@@ -1,0 +1,77 @@
+# エンハンスドロードバランサ Let's Encrypt設定(sakuracloud_proxylb_acme)
+
+---
+
+**全ゾーン共通のグローバルリソースです。**
+
+エンハンスドロードバランサにてLet's Encryptで証明書を取得するための設定を行うリソースです。
+
+### 設定例
+
+```hcl
+resource "sakuracloud_proxylb_acme" "cert" {
+  proxylb_id = sakuracloud_proxylb.foobar.id
+  accept_tos = true
+  common_name = "foobar.example.com"
+  update_delay_sec = 120
+}
+
+resource "sakuracloud_proxylb" "foobar" {
+  name         = "foobar"
+  plan         = 1000 
+  vip_failover = true # default: false
+
+  bind_ports {
+    proxy_mode        = "http"
+    port              = 80
+  }
+  bind_ports {
+    proxy_mode    = "https"
+    port          = 443
+  }
+  
+  servers {
+    ipaddress = "133.242.0.3"
+    port = 80
+  }
+  servers {
+    ipaddress = "133.242.0.4"
+    port = 80
+  }
+}
+```
+
+## `sakuracloud_proxylb_acme`
+
+### パラメーター
+
+|パラメーター         |必須  |名称           |初期値     |設定値                    |補足                                          |
+|-------------------|:---:|---------------|:--------:|------------------------|----------------------------------------------|
+| `proxylb_id`            | ◯   | エンハンスドロードバランサID        | -        | 文字列                  | - |
+| `accept_tos`            | ◯   | 利用規約への同意 | -        | Let's Encryptの[利用規約](https://letsencrypt.org/repository/)への同意     | `true`の場合のみ証明書の発行を行う |
+| `common_name`    | ◯   | コモンネーム | -        | -     | 証明書発行対象となるFQDN |
+| `update_delay_sec`      | -   | 更新待ち秒数  | -        | 0                  | エンハンスドロードバランサへのLet's Encrpt設定投入までの待ち時間 ([注1](#注1))    |
+
+#### 注1 更新待ち秒数について
+
+エンハンスドロードバランサでLet's Encryptでの証明書取得を行うには、`common_name`で指定したFQDNがエンハンスドロードバランサのVIPまたはFQDNを指している必要があります。  
+参考: [さくらのクラウドマニュアル - Let's Encrypt証明書自動インストール・更新機能](https://manual.sakura.ad.jp/cloud/appliance/enhanced-lb/#let-s-encrypt)
+
+TerraformにてDNSレコードの登録を行う場合、レコード作成直後にコモンネームの解決をできない場合があります。  
+この項目はそのような場合のために待ち時間を指定するものです。
+
+### 属性
+
+|属性名          | 名称             | 補足                                        |
+|---------------|-----------------|--------------------------------------------|
+| `id`          | ID              | エンハンスドロードバランサのIDが設定される                                          |
+| `certificate`  | 証明書 | 発行された証明書(sakuracloud_proxylbにて参照できる値と同じ)    |
+
+### `certificate`
+
+|パラメーター  |名称          |初期値   |設定値                 |補足                                          |
+|------------|--------------|:------:|---------------------|----------------------------------------------|
+| `server_cert`      | サーバ証明書 | -      | 文字列               | -|
+| `intermediate_cert`| 中間証明書   | - | 文字列 | - |
+| `private_key`      | 秘密鍵      | - | 文字列 | - |
+| `additional_certificates`| 追加証明書      | - | リスト | 詳細は[`certificate`](#certificate)を参照 |

--- a/build_docs/docs/index.md
+++ b/build_docs/docs/index.md
@@ -56,6 +56,7 @@
     - [DNS](configuration/resources/dns/)
     - [IPv4逆引きレコード](configuration/resources/ipv4_ptr/)
     - [エンハンスドロードバランサ](configuration/resources/proxylb/)
+    - [エンハンスドロードバランサ(Let's Encrypt設定)](configuration/resources/proxylb_acme/)
     - [GSLB](configuration/resources/gslb/)
     - [シンプル監視](configuration/resources/simple_monitor/)
     - [自動バックアップ](configuration/resources/auto_backup/)

--- a/build_docs/mkdocs.yml
+++ b/build_docs/mkdocs.yml
@@ -49,6 +49,7 @@ pages:
       - DNS: configuration/resources/dns.md
       - IPv4逆引きレコード: configuration/resources/ipv4_ptr.md
       - エンハンスドロードバランサ: configuration/resources/proxylb.md
+      - エンハンスドロードバランサ(Let's Encrypt設定): configuration/resources/proxylb_acme.md
       - GSLB: configuration/resources/gslb.md
       - シンプル監視: configuration/resources/simple_monitor.md
       - 自動バックアップ: configuration/resources/auto_backup.md

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud v1.23.0
+	github.com/sacloud/libsacloud v1.24.0
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect

--- a/sakuracloud/data_source_sakuracloud_proxylb.go
+++ b/sakuracloud/data_source_sakuracloud_proxylb.go
@@ -68,6 +68,14 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"redirect_to_https": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"support_http2": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -135,6 +135,7 @@ func Provider() terraform.ResourceProvider {
 			"sakuracloud_packet_filter":                  resourceSakuraCloudPacketFilter(),
 			"sakuracloud_packet_filter_rule":             resourceSakuraCloudPacketFilterRule(),
 			"sakuracloud_proxylb":                        resourceSakuraCloudProxyLB(),
+			"sakuracloud_proxylb_acme":                   resourceSakuraCloudProxyLBACME(),
 			"sakuracloud_private_host":                   resourceSakuraCloudPrivateHost(),
 			"sakuracloud_sim":                            resourceSakuraCloudSIM(),
 			"sakuracloud_simple_monitor":                 resourceSakuraCloudSimpleMonitor(),

--- a/sakuracloud/resource_sakuracloud_proxylb_acme.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_acme.go
@@ -1,0 +1,210 @@
+package sakuracloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/sacloud/libsacloud/api"
+	"github.com/sacloud/libsacloud/sacloud"
+)
+
+func resourceSakuraCloudProxyLBACME() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSakuraCloudProxyLBACMECreate,
+		Read:   resourceSakuraCloudProxyLBACMERead,
+		Delete: resourceSakuraCloudProxyLBACMEDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"proxylb_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateSakuracloudIDType,
+			},
+			"accept_tos": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				ForceNew:    true,
+				Description: "If you set this flag to true, you accept the current Let's Encrypt terms of service(see: https://letsencrypt.org/repository/)",
+			},
+			"common_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"update_delay_sec": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"certificate": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server_cert": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"intermediate_cert": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"additional_certificates": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"server_cert": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"intermediate_cert": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"private_key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceSakuraCloudProxyLBACMECreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*APIClient)
+	proxyLBID := d.Get("proxylb_id").(string)
+
+	sakuraMutexKV.Lock(proxyLBID)
+	defer sakuraMutexKV.Unlock(proxyLBID)
+	proxyLB, err := client.ProxyLB.Read(toSakuraCloudID(proxyLBID))
+	if err != nil {
+		return fmt.Errorf("Couldn't find SakuraCloud ProxyLB resource: %s", err)
+	}
+
+	// clear
+	proxyLB.Settings.ProxyLB.LetsEncrypt = sacloud.ProxyLBACMESetting{
+		Enabled: false,
+	}
+
+	tos := d.Get("accept_tos").(bool)
+	commonName := d.Get("common_name").(string)
+	updateDelaySec := d.Get("update_delay_sec").(int)
+	if tos {
+		proxyLB.Settings.ProxyLB.LetsEncrypt = sacloud.ProxyLBACMESetting{
+			Enabled:    true,
+			CommonName: commonName,
+		}
+	}
+
+	if updateDelaySec > 0 {
+		time.Sleep(time.Duration(updateDelaySec) * time.Second)
+	}
+	if _, err := client.ProxyLB.Update(proxyLB.ID, proxyLB); err != nil {
+		return fmt.Errorf("Error creating SakuraCloud ProxyLB ACME resource: %s", err)
+	}
+	if _, err := client.ProxyLB.RenewLetsEncryptCert(proxyLB.ID); err != nil {
+		return fmt.Errorf("Error updating SakuraCloud ProxyLB ACME resource: %s", err)
+	}
+
+	d.SetId(proxyLBID)
+	return resourceSakuraCloudProxyLBACMERead(d, meta)
+}
+
+func resourceSakuraCloudProxyLBACMERead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*APIClient)
+	proxyLB, err := client.ProxyLB.Read(toSakuraCloudID(d.Id()))
+	if err != nil {
+		if sacloudErr, ok := err.(api.Error); ok && sacloudErr.ResponseCode() == 404 {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Couldn't find SakuraCloud ProxyLBACME resource: %s", err)
+	}
+
+	return setProxyLBACMEResourceData(d, client, proxyLB)
+}
+
+func resourceSakuraCloudProxyLBACMEDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*APIClient)
+	proxyLBID := d.Get("proxylb_id").(string)
+
+	sakuraMutexKV.Lock(proxyLBID)
+	defer sakuraMutexKV.Unlock(proxyLBID)
+	proxyLB, err := client.ProxyLB.Read(toSakuraCloudID(proxyLBID))
+	if err != nil {
+		if sacloudErr, ok := err.(api.Error); ok && sacloudErr.ResponseCode() == 404 {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Couldn't find SakuraCloud ProxyLBACME resource: %s", err)
+	}
+
+	// clear
+	proxyLB.Settings.ProxyLB.LetsEncrypt = sacloud.ProxyLBACMESetting{
+		Enabled: false,
+	}
+
+	if _, err := client.ProxyLB.Update(proxyLB.ID, proxyLB); err != nil {
+		return fmt.Errorf("Error deleting SakuraCloud ProxyLB ACME resource: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func setProxyLBACMEResourceData(d *schema.ResourceData, client *APIClient, data *sacloud.ProxyLB) error {
+	// certificates
+	var cert *sacloud.ProxyLBCertificates
+	var err error
+	for i := 0; i < 5; i++ { // 作成直後はcertが空になるため数回リトライする
+		cert, err = client.ProxyLB.GetCertificates(data.ID)
+		if err != nil {
+			// even if certificate is deleted, it will not result in an error
+			return err
+		}
+		if cert.ServerCertificate != "" {
+			break
+		}
+		time.Sleep(10 * time.Second)
+	}
+
+	proxylbCert := map[string]interface{}{
+		"server_cert":       cert.ServerCertificate,
+		"intermediate_cert": cert.IntermediateCertificate,
+		"private_key":       cert.PrivateKey,
+		//"common_name":       cert.CertificateCommonName,
+		//"end_date":          cert.CertificateEndDate.Format(time.RFC3339),
+	}
+	if len(cert.AdditionalCerts) > 0 {
+		var certs []interface{}
+		for _, cert := range cert.AdditionalCerts {
+			certs = append(certs, map[string]interface{}{
+				"server_cert":       cert.ServerCertificate,
+				"intermediate_cert": cert.IntermediateCertificate,
+				"private_key":       cert.PrivateKey,
+				//"common_name":       cert.CertificateCommonName,
+				//"end_date":          cert.CertificateEndDate.Format(time.RFC3339),
+			})
+		}
+		proxylbCert["additional_certificates"] = certs
+	} else {
+		proxylbCert["additional_certificates"] = []interface{}{}
+	}
+
+	d.Set("certificate", []interface{}{proxylbCert})
+	return nil
+}

--- a/sakuracloud/resource_sakuracloud_proxylb_acme_test.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_acme_test.go
@@ -1,0 +1,90 @@
+package sakuracloud
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/sacloud/libsacloud/sacloud"
+)
+
+const (
+	envProxyLBACMEDomain = "SAKURACLOUD_PROXYLB_ACME_DOMAIN"
+)
+
+var proxyLBDomain string
+
+func TestAccResourceSakuraCloudProxyLBACME(t *testing.T) {
+
+	if domain, ok := os.LookupEnv(envProxyLBACMEDomain); ok {
+		proxyLBDomain = domain
+	} else {
+		t.Skipf("ENV %q is requilred. skip", envProxyLBACMEDomain)
+		return
+	}
+
+	var proxylb sacloud.ProxyLB
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckSakuraCloudProxyLBConfig_acme, proxyLBDomain, proxyLBDomain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSakuraCloudProxyLBExists("sakuracloud_proxylb.foobar", &proxylb),
+				),
+			},
+		},
+	})
+}
+
+var testAccCheckSakuraCloudProxyLBConfig_acme = `
+resource "sakuracloud_proxylb" "foobar" {
+  name = "terraform-test-proxylb-acme"
+  plan = 100
+  vip_failover = true
+  health_check {
+    protocol = "http"
+    delay_loop = 10
+    host_header = "usacloud.jp"
+    path = "/"
+  }
+  bind_ports {
+    proxy_mode = "http"
+    port       = 80
+  }
+  bind_ports {
+    proxy_mode = "https"
+    port       = 443
+  }
+  servers {
+      ipaddress = "${sakuracloud_server.server01.ipaddress}"
+      port = 80
+  }
+}
+
+resource sakuracloud_proxylb_acme "foobar" {
+  proxylb_id = sakuracloud_proxylb.foobar.id
+  accept_tos = true
+  common_name = "acme-acctest.%s"
+  update_delay_sec = 120
+}
+
+resource sakuracloud_server "server01" {
+  name = "terraform-test-server01"
+  graceful_shutdown_timeout = 10
+}
+
+data sakuracloud_dns "zone" {
+  name_selectors = ["%s"]
+}
+
+resource "sakuracloud_dns_record" "record" {
+  dns_id = data.sakuracloud_dns.zone.id
+  name   = "acme-acctest"
+  type   = "CNAME"
+  value  = "${sakuracloud_proxylb.foobar.fqdn}."
+  ttl    = 10
+}
+`

--- a/website/docs/d/proxylb.html.markdown
+++ b/website/docs/d/proxylb.html.markdown
@@ -47,6 +47,8 @@ Attributes for Bind-Ports:
 
 * `proxy_mode` - Proxy protocol.  
 * `port` - Port number used in tcp proxy.
+* `redirect_to_https` - The flag for enable to redirect to https.
+* `support_http2` - The flag for enable to support HTTP/2.
 
 ### Health Check
 

--- a/website/docs/r/proxylb.html.markdown
+++ b/website/docs/r/proxylb.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_proxylb"
-sidebar_current: "docs-sakuracloud-resource-global-proxylb-setting"
+sidebar_current: "docs-sakuracloud-resource-global-proxylb"
 description: |-
   Provides a SakuraCloud ProxyLB resource. This can be used to create, update, and delete ProxyLBs.
 ---
@@ -26,13 +26,15 @@ resource "sakuracloud_proxylb" "foobar" {
   }
 
   bind_ports {
-    proxy_mode = "https"
-    port       = 443
+    proxy_mode    = "https"
+    port          = 443
+    support_http2 = true
   }
 
   sorry_server {
-    ipaddress = "192.2.0.1"
-    port      = 80
+    ipaddress         = "192.2.0.1"
+    port              = 80
+    redirect_to_https = true
   }
 
   servers {
@@ -82,6 +84,8 @@ Attributes for Bind-Ports:
 * `proxy_mode` - (Required) Proxy protocol.  
 Valid value is one of the following: [ "http" / "https"]
 * `port` - (Required) Port number used in tcp proxy.
+* `redirect_to_https` - (Optional) The flag for enable to redirect to https.
+* `support_http2` - (Optional) The flag for enable to support HTTP/2.
 
 
 ### Health Check

--- a/website/docs/r/proxylb_acme.html.markdown
+++ b/website/docs/r/proxylb_acme.html.markdown
@@ -1,0 +1,79 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_proxylb_acme"
+sidebar_current: "docs-sakuracloud-resource-global-proxylb-acme"
+description: |-
+  Provides a SakuraCloud ProxyLB resource. This can be used to create, update, and delete ProxyLBs.
+---
+
+# sakuracloud\_proxylb
+
+Provides a SakuraCloud ProxyLB(Enhanced-LoadBalancer) resource. This can be used to create, update, and delete ProxyLBs.
+
+## Example Usage
+
+```hcl
+resource "sakuracloud_proxylb_acme" "cert" {
+  proxylb_id = sakuracloud_proxylb.foobar.id
+  accept_tos = true
+  common_name = "foobar.example.com"
+  update_delay_sec = 120
+}
+
+resource "sakuracloud_proxylb" "foobar" {
+  name         = "foobar"
+  plan         = 1000 
+  vip_failover = true # default: false
+
+  bind_ports {
+    proxy_mode        = "http"
+    port              = 80
+  }
+  bind_ports {
+    proxy_mode    = "https"
+    port          = 443
+  }
+  
+  servers {
+    ipaddress = "133.242.0.3"
+    port = 80
+  }
+  servers {
+    ipaddress = "133.242.0.4"
+    port = 80
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `proxylb_id` - (Required) The ID of target ProxyLB resource.  
+* `accept_tos` - (Required) The flag for accept Let's Encrypt's [Terms of Service](https://letsencrypt.org/repository/).  
+* `common_name` - (Require) The FQDN of target domain.  
+* `update_delay_sec` - (Optional) The wait time for update settings.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+* `proxylb_id` - The ID of target ProxyLB resource.  
+* `common_name` - The FQDN of target domain.  
+* `certificate` - Certificate used to terminate SSL/TSL. It contains some attributes to [Certificate](#certificate).
+
+### Certificate
+
+* `server_cert` - The server certificate.
+* `intermediate_cert` - The intermediate certificate.
+* `private_key` - The private key.
+* `additional_certificates` - Additional certificates.
+
+## Import
+
+ProxyLB ACME can be imported using the ProxyLB ID.
+
+```
+$ terraform import sakuracloud_proxylb_acme.foobar <proxylb_id>
+```

--- a/website/sakuracloud.erb
+++ b/website/sakuracloud.erb
@@ -224,6 +224,9 @@
             <li<%= sidebar_current("docs-sakuracloud-resource-global-proxylb") %>>
               <a href="/docs/providers/sakuracloud/r/proxylb.html">sakuracloud_proxylb</a>
             </li>
+            <li<%= sidebar_current("docs-sakuracloud-resource-global-proxylb-acme") %>>
+              <a href="/docs/providers/sakuracloud/r/proxylb_acme.html">sakuracloud_proxylb_acme</a>
+            </li>
             <li<%= sidebar_current("docs-sakuracloud-resource-global-gslb-setting") %>>
               <a href="/docs/providers/sakuracloud/r/gslb.html">sakuracloud_gslb</a>
             </li>


### PR DESCRIPTION
以下の機能に対応する。

- 100/500CPSプラン対応
- HTTPSへのリダイレクト
- HTTP/2のサポート
- Let's Encrypt対応

### Note: Let's Encrypt対応

リソース`sakuracloud_proxylb`内で対応するとELB自体のFQDN/IPアドレスが作成時に割り当てられるためにCommonNameの解決が出来ない。

このため、新しいリソース`sakuracloud_proxylb_acme`を追加することで対応する。

- `accept_tos`フィールド(bool)を設けLet's Encrypt側の利用規約への同意を明示的に行う。falseの場合(デフォルト)はLet's Encryptの設定を行わない。もしすでに設定されていた場合はクリアする。
- DNSレコードの伝播待ちのため、作成時にのみ有効な待ち時間を設定できるフィールドを設ける。これにより、`sakuracloud_proxylb`を参照してDNSレコードを作成する場合に対応する。
- `sakuracloud_proxylb`の`certificate`フィールドの各値はLet's Encryptを使用すると上書きされるため、`Computed: true`に変更する。

### 利用例

```tf
# エンハンスドロードバランサの定義
resource "sakuracloud_proxylb" "foobar" {
  name = "terraform-test-proxylb-acme"
  plan = 100
  vip_failover = true
  health_check {
    protocol = "http"
    delay_loop = 10
    host_header = "usacloud.jp"
    path = "/"
  }

  # Let's Encryptを利用するにはhttp/https両方のbind_portsが必要
  bind_ports {
    proxy_mode = "http"
    port       = 80

    redirect_to_https = true
  }
  bind_ports {
    proxy_mode = "https"
    port       = 443

    support_https = true
  }
  servers {
      ipaddress = "${sakuracloud_server.server01.ipaddress}"
      port = 80
  }
}

# エンハンスドロードバランサでのLet's Encrypt設定
resource sakuracloud_proxylb_acme "foobar" {
  proxylb_id = sakuracloud_proxylb.foobar.id
  accept_tos = true # 規約への同意
  common_name = "www.example.com"
  update_delay_sec = 120
}

resource sakuracloud_server "server01" {
  name = "terraform-test-server01"
  graceful_shutdown_timeout = 10
}

# エンハンスドロードバランサのVIP/FQDNを解決するためのDNSレコード設定
data sakuracloud_dns "zone" {
  name_selectors = ["example.com"]
}

resource "sakuracloud_dns_record" "record" {
  dns_id = data.sakuracloud_dns.zone.id
  name   = "www"
  type   = "CNAME"
  value  = "${sakuracloud_proxylb.foobar.fqdn}."
  ttl    = 10
}

```