### PR TITLE
シンプル監視でのポート番号をComputed=trueに変更

### DIFF
--- a/sakuracloud/resource_sakuracloud_simple_monitor.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor.go
@@ -74,6 +74,7 @@ func resourceSakuraCloudSimpleMonitor() *schema.Resource {
 						"port": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 						"qname": {
 							Type:     schema.TypeString,
@@ -452,9 +453,7 @@ func setSimpleMonitorResourceData(d *schema.ResourceData, client *APIClient, dat
 		healthCheck["status"] = readHealthCheck.Status
 		healthCheck["host_header"] = readHealthCheck.Host
 		healthCheck["port"] = port
-		if port != "" || readHealthCheck.Port != "80" {
-			healthCheck["port"] = readHealthCheck.Port
-		}
+		healthCheck["port"] = readHealthCheck.Port
 		healthCheck["username"] = readHealthCheck.BasicAuthUsername
 		healthCheck["password"] = readHealthCheck.BasicAuthPassword
 	case "https":
@@ -462,9 +461,7 @@ func setSimpleMonitorResourceData(d *schema.ResourceData, client *APIClient, dat
 		healthCheck["status"] = readHealthCheck.Status
 		healthCheck["host_header"] = readHealthCheck.Host
 		healthCheck["port"] = port
-		if port != "" || readHealthCheck.Port != "443" {
-			healthCheck["port"] = readHealthCheck.Port
-		}
+		healthCheck["port"] = readHealthCheck.Port
 		healthCheck["sni"] = strings.ToLower(readHealthCheck.SNI) == "true"
 		healthCheck["username"] = readHealthCheck.BasicAuthUsername
 		healthCheck["password"] = readHealthCheck.BasicAuthPassword
@@ -472,17 +469,11 @@ func setSimpleMonitorResourceData(d *schema.ResourceData, client *APIClient, dat
 		healthCheck["port"] = port
 		healthCheck["port"] = readHealthCheck.Port
 	case "ssh":
-		if port != "" || readHealthCheck.Port != "22" {
-			healthCheck["port"] = readHealthCheck.Port
-		}
+		healthCheck["port"] = readHealthCheck.Port
 	case "smtp":
-		if port != "" || readHealthCheck.Port != "25" {
-			healthCheck["port"] = readHealthCheck.Port
-		}
+		healthCheck["port"] = readHealthCheck.Port
 	case "pop3":
-		if port != "" || readHealthCheck.Port != "110" {
-			healthCheck["port"] = readHealthCheck.Port
-		}
+		healthCheck["port"] = readHealthCheck.Port
 
 	case "snmp":
 		healthCheck["community"] = readHealthCheck.Community

--- a/sakuracloud/resource_sakuracloud_simple_monitor_test.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor_test.go
@@ -25,6 +25,8 @@ func TestAccResourceSakuraCloudSimpleMonitor(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "health_check.0.protocol", "https"),
 					resource.TestCheckResourceAttr(
+						"sakuracloud_simple_monitor.foobar", "health_check.0.port", "8443"),
+					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "health_check.0.delay_loop", "60"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "health_check.0.sni", "true"),
@@ -53,6 +55,10 @@ func TestAccResourceSakuraCloudSimpleMonitor(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSakuraCloudSimpleMonitorExists("sakuracloud_simple_monitor.foobar", &monitor),
 					testAccCheckSakuraCloudSimpleMonitorAttributesUpdated(&monitor),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_simple_monitor.foobar", "health_check.0.protocol", "http"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_simple_monitor.foobar", "health_check.0.port", "80"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "health_check.0.host_header", "libsacloud.com"),
 					resource.TestCheckResourceAttr(
@@ -178,6 +184,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
     target = "terraform.io"
     health_check {
         protocol = "https"
+        port = 8443
         delay_loop = 60
         path = "/"
         status = "200"
@@ -205,6 +212,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
     target = "terraform.io"
     health_check {
         protocol = "http"
+        port = 80
         delay_loop = 120
         path = "/"
         status = "200"


### PR DESCRIPTION
( based on: #466 )

## 変更内容

ポート番号のスキーマ定義を以下のようにする。

```go
"port": {
	Type:     schema.TypeInt,
	Optional: true,
	Computed: true, # これを追加
},
```

これにより、portが未指定、またはゼロ値の時は算出された値が設定されるようになる。  
また、これまではport省略時、かつデフォルトのポート番号を持つプロトコルの場合、tfstateにportを保持していなかったが、今回の変更によりportに値を持つプロトコルの場合は常にtfstateに値が保持されるようになる。

## 影響/副作用

以下のような場合に変更が検知されなくなる。

1: 以下のtfファイルを用いて`terraform apply`を実行

```hcl
resource "sakuracloud_simple_monitor" "example" {
  target = "www.example.com"
  health_check {
    protocol = "smtp"
    port = 26 # デフォルトポート以外を明示
  }
}
```

2: tfファイルを以下のように変更してapply実行

```hcl
resource "sakuracloud_simple_monitor" "example" {
  target = "www.example.com"
  health_check {
    protocol = "smtp"
    # portを未指定にする
  }
}
```

結果は以下のようにportの変更を検知しない。

```bash
$ terraform apply
sakuracloud_simple_monitor.test: Refreshing state... [id=xxxxxxxxxxxxx]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

portの指定を未指定とした場合、portはデフォルト値が設定されるように思えるが現在の実装だとそうならない。

しかし実際のユースケースとしてはこの挙動が問題になるケースは少ないと思われるため、現時点ではこの挙動には対応せず、将来必要になったら対応を検討する。