### PR TITLE
エンハンスドロードバランサ更新

### DIFF
--- a/build_docs/docs/configuration/resources/data/proxylb.md
+++ b/build_docs/docs/configuration/resources/data/proxylb.md
@@ -31,6 +31,7 @@ data "sakuracloud_proxylb" "proxylb" {
 | `plan`        | プラン    | -                                          |
 | `vip_failover` | VIPフェイルオーバ | - |
 | `sticky_session` | セッション維持 | - |
+| `timeout`         | 実サーバ通信タイムアウト | - |
 | `vip`        | VIP       | ロードバランサに割り当てられたグローバルIP(`vip_failover`が`false`の場合のみ有効)    |
 | `fqdn`        | VIP       | ロードバランサに割り当てられたグローバルIP(`vip_failover`が`true`の場合のみ有効)    |
 | `proxy_networks`  | プロキシ元ネットワーク | プロキシ元IP(CIDR)のリスト    |

--- a/build_docs/docs/configuration/resources/proxylb.md
+++ b/build_docs/docs/configuration/resources/proxylb.md
@@ -8,9 +8,11 @@
 
 ```hcl
 resource "sakuracloud_proxylb" "foobar" {
-  name         = "foobar"
-  plan         = 1000 
-  vip_failover = true # default: false
+  name           = "foobar"
+  plan           = 1000 
+  vip_failover   = true # default: false
+  sticky_session = true # default: false
+  timeout        = 10
 
   health_check {
     protocol    = "http"
@@ -75,9 +77,10 @@ resource "sakuracloud_proxylb" "foobar" {
 |パラメーター         |必須  |名称           |初期値     |設定値                    |補足                                          |
 |-------------------|:---:|---------------|:--------:|------------------------|----------------------------------------------|
 | `name`            | ◯   | エンハンスドロードバランサ名        | -        | 文字列                  | - |
-| `plan`            | -   | プラン        | `1000`        | `1000`<br />`5000`<br />`10000`<br />`50000`<br />`100000`     | - |
+| `plan`            | -   | プラン        | `1000`        | `1000`<br />`5000`<br />`10000`<br />`50000`<br />`100000`<br />`400000`     | - |
 | `vip_failover`    | -   | VIPフェイルオーバ | `false`        | `true` or `false`     | - |
 | `sticky_session`    | -   | セッション維持 | `false`        | `true` or `false`     | - |
+| `timeout`         | -   | 実サーバ通信タイムアウト | `10`        | `10`から`600`までの数値     | 登録済みの実サーバからの応答タイムアウト時間(秒数) |
 | `bind_ports`      | ◯   | 待ち受けポート  | -        | リスト                  | 詳細は[`bind_ports`](#bind_ports)を参照    |
 | `health_check`    | ◯   | ヘルスチェック  | -        | マップ                  | 詳細は[`health_check`](#health_check)を参照    |
 | `sorry_server`     | -   | ソーリーサーバ  | -      | マップ| 詳細は[`sorry_server`](#sorry_server)を参照 |

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud v1.26.1
+	github.com/sacloud/libsacloud v1.27.1
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect

--- a/sakuracloud/data_source_sakuracloud_proxylb.go
+++ b/sakuracloud/data_source_sakuracloud_proxylb.go
@@ -59,6 +59,10 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"timeout": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"bind_ports": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/sakuracloud/resource_sakuracloud_proxylb.go
+++ b/sakuracloud/resource_sakuracloud_proxylb.go
@@ -2,7 +2,6 @@ package sakuracloud
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -26,18 +25,10 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 				Required: true,
 			},
 			"plan": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  1000,
-				ValidateFunc: validateIntInWord([]string{
-					strconv.Itoa(int(sacloud.ProxyLBPlan100)),
-					strconv.Itoa(int(sacloud.ProxyLBPlan500)),
-					strconv.Itoa(int(sacloud.ProxyLBPlan1000)),
-					strconv.Itoa(int(sacloud.ProxyLBPlan5000)),
-					strconv.Itoa(int(sacloud.ProxyLBPlan10000)),
-					strconv.Itoa(int(sacloud.ProxyLBPlan50000)),
-					strconv.Itoa(int(sacloud.ProxyLBPlan100000)),
-				}),
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1000,
+				ValidateFunc: validation.IntInSlice(sacloud.AllowProxyLBPlans),
 			},
 			"vip_failover": {
 				Type:     schema.TypeBool,

--- a/sakuracloud/resource_sakuracloud_proxylb_test.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_test.go
@@ -49,6 +49,8 @@ func TestAccResourceSakuraCloudProxyLB(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_proxylb.foobar", "sticky_session", "true"),
 					resource.TestCheckResourceAttr(
+						"sakuracloud_proxylb.foobar", "timeout", "30"),
+					resource.TestCheckResourceAttr(
 						"sakuracloud_proxylb.foobar", "health_check.0.protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_proxylb.foobar", "health_check.0.delay_loop", "10"),
@@ -92,6 +94,8 @@ func TestAccResourceSakuraCloudProxyLB(t *testing.T) {
 						"sakuracloud_proxylb.foobar", "name", "terraform-test-proxylb-upd"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_proxylb.foobar", "sticky_session", "false"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_proxylb.foobar", "timeout", "10"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_proxylb.foobar", "health_check.0.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
@@ -240,6 +244,7 @@ resource "sakuracloud_proxylb" "foobar" {
   plan = 5000
   vip_failover = true
   sticky_session = true
+  timeout = 30
   health_check {
     protocol = "http"
     delay_loop = 10

--- a/website/docs/d/proxylb.html.markdown
+++ b/website/docs/d/proxylb.html.markdown
@@ -33,6 +33,7 @@ The following attributes are exported:
 * `plan` - The plan of the resource.
 * `vip_failover` - The flag of enable VIP Fail-Over.  
 * `sticky_session` - The flag of enable Sticky-Session.  
+* `timeout` - Timeout seconds. 
 * `bind_ports` - The external listen ports. It contains some attributes to [Bind Ports](#bind-ports).
 * `health_check` - The health check rules. It contains some attributes to [Health Check](#health-check).
 * `sorry_server` - The pair of IPAddress and port number of sorry-server.

--- a/website/docs/r/proxylb.html.markdown
+++ b/website/docs/r/proxylb.html.markdown
@@ -14,10 +14,12 @@ Provides a SakuraCloud ProxyLB(Enhanced-LoadBalancer) resource. This can be used
 
 ```hcl
 resource "sakuracloud_proxylb" "foobar" {
-  name         = "foobar"
-  plan         = 1000 
-  vip_failover = false
-
+  name           = "foobar"
+  plan           = 1000 
+  vip_failover   = false
+  sticky_session = false
+  timeout        = 10
+  
   health_check {
     protocol    = "http"
     path        = "/"
@@ -66,9 +68,10 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the resource.  
 * `plan` - (Optional) The plan of the resource.
-Valid value is one of the following: [ 1000 (default) / 5000 / 10000 / 50000 / 100000 ]  
+Valid value is one of the following: [ 1000 (default) / 5000 / 10000 / 50000 / 100000 / 400000]  
 * `vip_failover` - (Optional) The flag of enable VIP Fail-Over.  
 * `sticky_session` - (Optional) The flag of enable Sticky-Session.  
+* `timeout` - (Optional) Timeout seconds.  
 * `bind_ports` - (Required) The external listen ports. It contains some attributes to [Bind Ports](#bind-ports).
 * `health_check` - (Required) The health check rules. It contains some attributes to [Health Check](#health-check).
 * `sorry_server` - (Optional) The pair of IPAddress and port number of sorry-server.


### PR DESCRIPTION
fixes #487 

- 実サーバ通信タイムアウト設定を追加
- 400,000cpsプランを追加