### PR TITLE
Fix build-time dockerfile: install bzr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12
 LABEL maintainer="Kazumichi Yamamoto <yamamoto.febc@gmail.com>"
 MAINTAINER Kazumichi Yamamoto <yamamoto.febc@gmail.com>
 
-RUN  apt-get update && apt-get -y install bash git make zip && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+RUN  apt-get update && apt-get -y install bash git make zip bzr && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 RUN go get -u golang.org/x/lint/golint
 RUN go get -u golang.org/x/tools/cmd/goimports
 


### PR DESCRIPTION
`golang:1.12`イメージに`bzr`コマンドが含まれなくなったためDockerでのリリースビルドがエラーとなる。このため`bzr`を明示的にインストールするように修正。

Note: v-nextにも適用する