### PR TITLE
DNSリソースでのStateセット時エラーチェックの厳格化

### DIFF
--- a/sakuracloud/data_source_sakuracloud_dns.go
+++ b/sakuracloud/data_source_sakuracloud_dns.go
@@ -66,6 +66,42 @@ func dataSourceSakuraCloudDNS() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ttl": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"priority": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"weight": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/sakuracloud/resource_sakuracloud_dns_test.go
+++ b/sakuracloud/resource_sakuracloud_dns_test.go
@@ -120,10 +120,13 @@ func TestAccImportSakuraCloudDNS(t *testing.T) {
 			return fmt.Errorf("expected 1 state: %#v", s)
 		}
 		expects := map[string]string{
-			"zone":        zone,
-			"description": "DNS from TerraForm for SAKURA CLOUD",
-			"tags.0":      "tag1",
-			"tags.1":      "tag2",
+			"zone":            zone,
+			"description":     "DNS from TerraForm for SAKURA CLOUD",
+			"tags.0":          "tag1",
+			"tags.1":          "tag2",
+			"records.0.name":  "test1",
+			"records.0.type":  "A",
+			"records.0.value": "192.168.11.1",
 		}
 
 		if err := compareStateMulti(s[0], expects); err != nil {
@@ -198,6 +201,11 @@ resource "sakuracloud_dns" "foobar" {
     zone = "%s"
     description = "DNS from TerraForm for SAKURA CLOUD"
     tags = ["tag1","tag2"]
+    records {
+      name = "test1"
+      type = "A"
+      value = "192.168.11.1"
+    }
 }
 `, zone)
 }


### PR DESCRIPTION
fixes #495 

DNSリソースで`d.Set`を呼ぶ際のエラーチェックを厳格化し、セットするデータ型をより厳密にハンドリングする。

#495 の対応のために #485 をv1に先行して取り入れたもの。

DNSデータソースについても値のセット部分の処理を共有しており今回の修正の影響を受けるため合わせて対応している。