### PR TITLE
サーバリソースでの予期せぬdiffの回避

### DIFF
--- a/sakuracloud/resource_sakuracloud_server_connector_test.go
+++ b/sakuracloud/resource_sakuracloud_server_connector_test.go
@@ -80,9 +80,6 @@ func TestAccResourceSakuraCloudServerConnector(t *testing.T) {
 					resource.TestCheckNoResourceAttr(
 						"sakuracloud_server.foobar", "packet_filter_ids",
 					),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "cdrom_id", "",
-					),
 				),
 			},
 		},
@@ -92,11 +89,12 @@ func TestAccResourceSakuraCloudServerConnector(t *testing.T) {
 const testAccCheckSakuraCloudServerConnectorConfig_basic = `
 resource sakuracloud_server "foobar" {
   name = "foobar"
-  additional_nics = [""]
+  graceful_shutdown_timeout = 5
 }
 resource sakuracloud_disk "foobar" {
   name = "foobar"
   count = 1
+  graceful_shutdown_timeout = 5
 }
 resource sakuracloud_packet_filter "foobar" {
   name = "foobar"
@@ -118,13 +116,18 @@ resource sakuracloud_server_connector "foobar" {
 `
 
 const testAccCheckSakuraCloudServerConnectorConfig_update = `
+resource sakuracloud_switch "foobar" {
+  name = "foobar"
+}
 resource sakuracloud_server "foobar" {
   name = "foobar"
-  additional_nics = [""]
+  additional_nics = ["${sakuracloud_switch.foobar.id}"]
+  graceful_shutdown_timeout = 5
 }
 resource sakuracloud_disk "foobar" {
   name = "foobar"
   count = 2
+  graceful_shutdown_timeout = 5
 }
 resource sakuracloud_packet_filter "foobar" {
   name = "foobar"
@@ -146,13 +149,17 @@ resource sakuracloud_server_connector "foobar" {
 `
 
 const testAccCheckSakuraCloudServerConnectorConfig_delete = `
+resource sakuracloud_switch "foobar" {
+  name = "foobar"
+}
 resource sakuracloud_server "foobar" {
   name = "foobar"
-  additional_nics = [""]
+  graceful_shutdown_timeout = 5
 }
 resource sakuracloud_disk "foobar" {
   name = "foobar"
   count = 2
+  graceful_shutdown_timeout = 5
 }
 resource sakuracloud_packet_filter "foobar" {
   name = "foobar"

--- a/sakuracloud/structure.go
+++ b/sakuracloud/structure.go
@@ -187,7 +187,17 @@ func flattenDisplayIPAddress(interfaces []sacloud.Interface) []interface{} {
 			}
 		}
 	}
-	return ret
+	exists := false
+	for _, v := range ret {
+		if v.(string) != "" {
+			exists = true
+			break
+		}
+	}
+	if exists {
+		return ret
+	}
+	return []interface{}{}
 }
 
 func flattenPacketFilters(interfaces []sacloud.Interface) []string {
@@ -200,7 +210,7 @@ func flattenPacketFilters(interfaces []sacloud.Interface) []string {
 		ret = append(ret, id)
 	}
 
-	if len(interfaces) <= 1 {
+	if len(interfaces) == 0 {
 		return ret
 	}
 


### PR DESCRIPTION
サーバリソース(sakuracloud_server)のimport後に`terraform plan`などを実行した場合に`packet_filter_ids`などで差分が出てしまう問題の修正。

