### PR TITLE
シンプル監視での再通知間隔の設定

### DIFF
--- a/build_docs/docs/configuration/resources/data/simple_monitor.md
+++ b/build_docs/docs/configuration/resources/data/simple_monitor.md
@@ -32,5 +32,6 @@ data "sakuracloud_simple_monitor" "mymonitor" {
 | `notify_email_html`   | HTMLメール有効    | - | 
 | `notify_slack_enabled`| Slack通知有効     | - | 
 | `notify_slack_webhook`| Slack WebhookURL | - | 
+| `notify_interval`| 再通知間隔(秒) | - | 
 | `enabled`             | 有効              | - | 
 

--- a/build_docs/docs/configuration/resources/simple_monitor.md
+++ b/build_docs/docs/configuration/resources/simple_monitor.md
@@ -23,10 +23,12 @@ resource "sakuracloud_simple_monitor" "mymonitor" {
   # password   = "bar"
 
   notify_email_enabled = true
+  
 
   #notify_email_html    = false
   #notify_slack_enabled = false
   #notify_slack_webhook = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+  #notify_interval      = 7200
   #enabled              = true
 
   description = "Description"
@@ -68,6 +70,7 @@ resource "sakuracloud_simple_monitor" "my_sslcert_monitor" {
 | `notify_email_html`   | -   | HTMLメール有効    | `false`  | `true`<br />`false` | - |
 | `notify_slack_enabled`| -   | Slack通知有効     | `false` | `true`<br />`false` | - |
 | `notify_slack_webhook`| -   | Slack WebhookURL | -       | 文字列 | - |
+| `notify_interval`| -   | 再通知間隔(秒) | -       | 数値 | - |
 | `enabled`             | -   | 有効              | `true` | `true`<br />`false` | - |
 
 #### `health_check`

--- a/sakuracloud/data_source_sakuracloud_simple_monitor.go
+++ b/sakuracloud/data_source_sakuracloud_simple_monitor.go
@@ -144,7 +144,10 @@ func dataSourceSakuraCloudSimpleMonitor() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			"notify_interval": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"enabled": {
 				Type:     schema.TypeBool,
 				Computed: true,

--- a/sakuracloud/resource_sakuracloud_simple_monitor.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor.go
@@ -140,7 +140,11 @@ func resourceSakuraCloudSimpleMonitor() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
+			"notify_interval": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  60 * 60 * 2,
+			},
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -257,6 +261,11 @@ func resourceSakuraCloudSimpleMonitorCreate(d *schema.ResourceData, meta interfa
 	}
 	if notifySlack {
 		opts.EnableNofitySlack(d.Get("notify_slack_webhook").(string))
+	}
+
+	notifyInterval := d.Get("notify_interval").(int)
+	if notifyInterval > 0 {
+		opts.SetNotifyInterval(notifyInterval)
 	}
 
 	simpleMonitor, err := client.SimpleMonitor.Create(opts)
@@ -418,6 +427,11 @@ func resourceSakuraCloudSimpleMonitorUpdate(d *schema.ResourceData, meta interfa
 		simpleMonitor.DisableNotifySlack()
 	}
 
+	notifyInterval := d.Get("notify_interval").(int)
+	if notifyInterval > 0 {
+		simpleMonitor.SetNotifyInterval(notifyInterval)
+	}
+
 	simpleMonitor, err = client.SimpleMonitor.Update(simpleMonitor.ID, simpleMonitor)
 	if err != nil {
 		return fmt.Errorf("Failed to create SakuraCloud SimpleMonitor resource: %s", err)
@@ -510,6 +524,7 @@ func setSimpleMonitorResourceData(d *schema.ResourceData, client *APIClient, dat
 
 	d.Set("notify_email_enabled", strings.ToLower(data.Settings.SimpleMonitor.NotifyEmail.Enabled) == "true")
 	d.Set("notify_email_html", strings.ToLower(data.Settings.SimpleMonitor.NotifyEmail.HTML) == "true")
+	d.Set("notify_interval", data.Settings.SimpleMonitor.NotifyInterval)
 
 	enableSlack := strings.ToLower(data.Settings.SimpleMonitor.NotifySlack.Enabled) == "true"
 	d.Set("notify_slack_enabled", enableSlack)

--- a/sakuracloud/resource_sakuracloud_simple_monitor_test.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor_test.go
@@ -44,6 +44,8 @@ func TestAccResourceSakuraCloudSimpleMonitor(t *testing.T) {
 						"sakuracloud_simple_monitor.foobar", "notify_slack_enabled", "true"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "notify_slack_webhook", testAccSlackWebhook),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_simple_monitor.foobar", "notify_interval", "3600"),
 					resource.TestCheckResourceAttrPair(
 						"sakuracloud_simple_monitor.foobar", "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -69,8 +71,10 @@ func TestAccResourceSakuraCloudSimpleMonitor(t *testing.T) {
 						"sakuracloud_simple_monitor.foobar", "notify_email_html", "false"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_simple_monitor.foobar", "notify_email_enabled", "false"),
-					resource.TestCheckNoResourceAttr(
-						"sakuracloud_simple_monitor.foobar", "icon_id"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_simple_monitor.foobar", "notify_interval", "7200"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_simple_monitor.foobar", "icon_id", ""),
 				),
 			},
 		},
@@ -199,6 +203,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
     notify_email_html = true
     notify_slack_enabled = true
     notify_slack_webhook = "%s"
+    notify_interval = 3600
     icon_id = "${sakuracloud_icon.foobar.id}"
 }
 
@@ -223,6 +228,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
     notify_email_enabled = false
     notify_slack_enabled = true
     notify_slack_webhook = "%s"
+    notify_interval = 7200
 }`, testAccSlackWebhook)
 
 const testAccSlackWebhook = `https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX`

--- a/website/docs/d/simple_monitor.html.markdown
+++ b/website/docs/d/simple_monitor.html.markdown
@@ -33,6 +33,7 @@ data "sakuracloud_simple_monitor" "foobar" {
 * `notify_email_html` - The flag of enable/disable HTML format for E-mail.
 * `notify_slack_enabled` - The flag of enable/disable notification by slack.
 * `notify_slack_webhook` - The webhook URL of destination of slack notification.
+* `notify_interval` - The intervals of notify (unit:`second`).  
 * `enabled` - The flag of enable/disable monitoring.
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.

--- a/website/docs/r/simple_monitor.html.markdown
+++ b/website/docs/r/simple_monitor.html.markdown
@@ -33,6 +33,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
   notify_email_html    = true
   notify_slack_enabled = true
   notify_slack_webhook = "https://hooks.slack.com/services/XXX/XXX/XXXXXX"
+  notify_interval      = 7200
 
   description = "description"
   tags        = ["foo", "bar"]
@@ -59,6 +60,7 @@ The following arguments are supported:
 * `notify_email_html` - (Optional) The flag of enable/disable HTML format for E-mail.
 * `notify_slack_enabled` - (Optional) The flag of enable/disable notification by slack.
 * `notify_slack_webhook` - (Optional) The webhook URL of destination of slack notification.
+* `notify_interval` - The intervals of notify (unit:`second`).  
 * `enabled` - (Optional) The flag of enable/disable monitoring.
 * `description` - (Optional) The description of the resource.
 * `tags` - (Optional) The tag list of the resources.
@@ -94,6 +96,7 @@ Valid value is one of the following: [ "http" / "https" / "ping" / "tcp" / "dns"
 * `notify_email_html` - The flag of enable/disable HTML format for E-mail.
 * `notify_slack_enabled` - The flag of enable/disable notification by slack.
 * `notify_slack_webhook` - The webhook URL of destination of slack notification.
+* `notify_interval` - The intervals of notify (unit:`second`).  
 * `enabled` - The flag of enable/disable monitoring.
 * `description` - The description of the resource.
 * `tags` - The tag list of the resources.


### PR DESCRIPTION
( a part of #517 )

シンプル監視で再通知間隔を指定可能にする。