### PR TITLE
ディスクの修正でのBackgroundパラメータの利用

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud v1.28.0
+	github.com/sacloud/libsacloud v1.28.1
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud v1.28.0 h1:xIsN0BTmN+lq0u22FiOoKoUIl4tqs7hPZECwwnx6x6A=
-github.com/sacloud/libsacloud v1.28.0/go.mod h1:P7YAOVmnIn3DKHqCZcUKYUXmSwGBm3yS7IBEjKVSrjg=
+github.com/sacloud/libsacloud v1.28.1 h1:laoicuTen5Ipe1Kmu6WOZE760FSkzywhWSvKS+qFYUs=
+github.com/sacloud/libsacloud v1.28.1/go.mod h1:P7YAOVmnIn3DKHqCZcUKYUXmSwGBm3yS7IBEjKVSrjg=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=

--- a/sakuracloud/resource_sakuracloud_disk_test.go
+++ b/sakuracloud/resource_sakuracloud_disk_test.go
@@ -50,7 +50,7 @@ func TestAccResourceSakuraCloudDisk(t *testing.T) {
 						"sakuracloud_disk.foobar", "connector", "virtio"),
 					resource.TestCheckResourceAttr(
 						"sakuracloud_disk.foobar", "size", "20"),
-					resource.TestCheckNoResourceAttr("sakuracloud_disk.foobar", "icon_id"),
+					resource.TestCheckResourceAttr("sakuracloud_disk.foobar", "icon_id", ""),
 				),
 			},
 		},

--- a/sakuracloud/resource_sakuracloud_private_host_test.go
+++ b/sakuracloud/resource_sakuracloud_private_host_test.go
@@ -77,8 +77,8 @@ func TestAccResourceSakuraCloudPrivateHost_DestroyWithRunningServers(t *testing.
 			{
 				Config: testAccCheckSakuraCloudPrivateHostConfig_Destroy_Update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr(
-						"sakuracloud_server.foobar", "private_host_id"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_server.foobar", "private_host_id", ""),
 				),
 			},
 		},

--- a/sakuracloud/resource_sakuracloud_server_test.go
+++ b/sakuracloud/resource_sakuracloud_server_test.go
@@ -87,7 +87,7 @@ func TestAccResourceSakuraCloudServer(t *testing.T) {
 					resource.TestMatchResourceAttr("sakuracloud_server.foobar",
 						"nw_address",
 						regexp.MustCompile(".+")), // should be not empty
-					resource.TestCheckNoResourceAttr("sakuracloud_server.foobar", "icon_id"),
+					resource.TestCheckResourceAttr("sakuracloud_server.foobar", "icon_id", ""),
 				),
 			},
 		},

--- a/vendor/github.com/sacloud/libsacloud/api/disk.go
+++ b/vendor/github.com/sacloud/libsacloud/api/disk.go
@@ -119,7 +119,16 @@ func (api *DiskAPI) Config(id int64, disk *sacloud.DiskEditValue) (bool, error) 
 		uri    = fmt.Sprintf("%s/%d/config", api.getResourceURL(), id)
 	)
 
-	return api.modify(method, uri, disk)
+	// HACK APIからの戻り値"Success"がboolではなく文字列となっているためapi.modifyを使わずに実装する。
+	res := &struct {
+		IsOk bool `json:"is_ok,omitempty"` // is_ok項目
+	}{}
+	err := api.baseAPI.request(method, uri, disk, res)
+	if err != nil {
+		return false, err
+	}
+	return res.IsOk, nil
+
 }
 
 func (api *DiskAPI) install(id int64, body *sacloud.Disk) (bool, error) {

--- a/vendor/github.com/sacloud/libsacloud/libsacloud.go
+++ b/vendor/github.com/sacloud/libsacloud/libsacloud.go
@@ -2,4 +2,4 @@
 package libsacloud
 
 // Version バージョン
-const Version = "1.28.0"
+const Version = "1.28.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -217,7 +217,7 @@ github.com/posener/complete/match
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud v1.28.0
+# github.com/sacloud/libsacloud v1.28.1
 github.com/sacloud/libsacloud
 github.com/sacloud/libsacloud/api
 github.com/sacloud/libsacloud/sacloud


### PR DESCRIPTION
( a part of #517 )

ディスクの修正API呼び出し時に`Background`パラメータを利用する。

参考: `Background`パラメータはパーティションリサイズAPIでも利用可能であるが、このプロジェクトからは利用していない。