### PR TITLE
フィールド名変更: key => private_key

### DIFF
--- a/build_docs/docs/configuration/resources/webaccel_certificate.md
+++ b/build_docs/docs/configuration/resources/webaccel_certificate.md
@@ -14,7 +14,7 @@ data sakuracloud_webaccel "site" {
 resource sakuracloud_webaccel_certificate "example" {
   site_id           = data.sakuracloud_webaccel.site.id
   certificate_chain = file("crt")
-  key               = file("key")
+  private_key               = file("key")
 }
 ```
 
@@ -24,7 +24,7 @@ resource sakuracloud_webaccel_certificate "example" {
 |-- ----------------- | :---: | -------------------- | :--------: | ------------------------ | -------------------------------------------- --|
 | `site_id`           | ◯     | ウェブアクセラレータのサイトID                | -          | 文字列                      | -                                              |
 | `certificate_chain` | -     | 証明書               | -          | 文字列                      | 中間証明書がある場合はサーバ証明書、中間証明書の順番に連結したものを指定                                              |
-| `key`               | -     | 秘密鍵               | -          | 文字列                      | -                                              |
+| `private_key`               | -     | 秘密鍵               | -          | 文字列                      | -                                              |
 
 ### 属性
 

--- a/sakuracloud/resource_sakuracloud_webaccel_certificate.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_certificate.go
@@ -29,7 +29,7 @@ func resourceSakuraCloudWebAccelCertificate() *schema.Resource {
 				Required:  true,
 				Sensitive: true,
 			},
-			"key": {
+			"private_key": {
 				Type:      schema.TypeString,
 				Required:  true,
 				Sensitive: true,
@@ -74,7 +74,7 @@ func resourceSakuraCloudWebAccelCertificateCreate(d *schema.ResourceData, meta i
 
 	res, err := client.WebAccel.CreateCertificate(siteID, &sacloud.WebAccelCertRequest{
 		CertificateChain: d.Get("certificate_chain").(string),
-		Key:              d.Get("key").(string),
+		Key:              d.Get("private_key").(string),
 	})
 	if err != nil {
 		return err
@@ -109,10 +109,10 @@ func resourceSakuraCloudWebAccelCertificateUpdate(d *schema.ResourceData, meta i
 	client := meta.(*APIClient)
 	siteID := d.Id()
 
-	if d.HasChange("certificate_chain") || d.HasChange("key") {
+	if d.HasChange("certificate_chain") || d.HasChange("private_key") {
 		res, err := client.WebAccel.UpdateCertificate(siteID, &sacloud.WebAccelCertRequest{
 			CertificateChain: d.Get("certificate_chain").(string),
-			Key:              d.Get("key").(string),
+			Key:              d.Get("private_key").(string),
 		})
 		if err != nil {
 			return err

--- a/sakuracloud/resource_sakuracloud_webaccel_certificate_test.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_certificate_test.go
@@ -79,7 +79,7 @@ data sakuracloud_webaccel "site" {
 resource sakuracloud_webaccel_certificate "foobar" {
   site_id           = data.sakuracloud_webaccel.site.id
   certificate_chain = file("%s") 
-  key               = file("%s")
+  private_key       = file("%s")
 }
 `
 	return fmt.Sprintf(tmpl, siteName, crt, key)

--- a/website/docs/r/webaccel_certificate.html.markdown
+++ b/website/docs/r/webaccel_certificate.html.markdown
@@ -20,7 +20,7 @@ data sakuracloud_webaccel "site" {
 resource sakuracloud_webaccel_certificate "example" {
   site_id           = data.sakuracloud_webaccel.site.id
   certificate_chain = file("crt")
-  key               = file("key")
+  private_key               = file("key")
 }
 ```
 
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 * `site_id` - (Required) The id of the target site on WebAccel.
 * `certificate_chain` - (Required) The contents of certificate.
-* `key` - (Required) The content of private key.
+* `private_key` - (Required) The content of private key.
 
 ## Attributes Reference
 


### PR DESCRIPTION
ウェブアクセラレータ 証明書リソースのフィールド名を変更する。

breaking-changeのためv1.18.0を欠番とし、v1.18.1としてリリースする。
(このためアップグレードガイドには記載しない)