### PR TITLE
v2.0: design doc

### DIFF
--- a/design/v2.md
+++ b/design/v2.md
@@ -1,0 +1,99 @@
+# terraform-provider-sakuracloud v2
+
+terraform-provider-sakuracloudの次期バージョンであるv2について記載する。
+
+## 背景 / Background
+
+主要コンポーネントである[Libsacloud](https://github.com/sacloud/libsacloud)のバージョンをv2にする。  
+Libsacloud v1ではGoらしくない部分があり、テストの記述が煩雑といった問題がある。  
+terraform-provider-sakuracloud v2ではLibsacloud v2を利用することでテストを容易にし、より効果的なテストの記述を促す。
+
+Libsacloud v1はsacloud配下の主要プロダクト(Terraform/[Usacloud](https://github.com/sacloud/usacloud))のv2対応以降はバグフィックスのみとなる。
+このためLibsacloudの利用者である当プロジェクトでもLibsacloudに合わせてバージョニングし、v1についてはバグフィックスを中心にしたい。
+
+また、Libsacloud v2対応の際に後方互換のない変更が入る可能性が高いため、このタイミングでスキーマ変更を伴う改善なども行いたい。
+
+## Goal/Non-Goal
+
+### 開発関連
+
+- [ ] Libsacloud v2の利用
+- [ ] Acceptance Testの改善
+  - [ ] Libsacloud v2などでfakeドライバーを利用し、オフラインでAccTest可能にする
+  - [ ] 作成するリソースの命名規則統一
+  - [ ] リソースのクリーンアップ処理
+- [ ] リリースプロセスの修正(現在のプロセスは複数のアクティブバージョンに対応していない)
+- [ ] terraform-providersでのコーディングスタイル/規約の踏襲
+
+### スキーマ関連
+
+- [ ] DataSourceでのFilter周りの整理
+- [ ] サーバリソースでのNIC周りの整理
+
+### やらないこと
+
+- 完全なstateアップグレード/マイグレーションのサポート
+
+## 設計 / How?
+
+v2では以下の実装方針を加える。
+
+### 子リソースの切断/削除はしない
+
+例としてブリッジの削除時の処理など。
+
+これまではブリッジに接続されたスイッチがあれば切断処理 -> ブリッジを削除という処理をしていたが、v-nextではブリッジの削除のみ行う。
+
+これは、Terraformが関知していないリソースについてはTerraformから操作しないことで意図しないリソースの削除などを抑制し、より安全な運用を目指すため。
+子リソースがTerraformで管理されていれば依存関係はTerraformが解決してくれる分だけで十分なはずという前提の方針となっている。
+
+これまでと比べると手作業で(Terraform外で)リソースを追加していた場合などにterraform destroy時のエラーが増えることになるが許容する。
+
+Note: ブリッジの例ではスイッチの側で自身がブリッジに接続されているか判定->切断を行う。
+
+### terraform-providersでのコーディングスタイル/規約の踏襲
+
+[Terraform Provider開発ベストプラクティス](https://www.terraform.io/docs/extend/best-practices/index.html)の踏襲に加え、以下のような点に注意する。
+
+```
+- resource filename matches convention resource_providername_resource_name.go
+- data source filename matches convention data_source_providername_resource_name.go
+- we always let d.Set() to dereference pointers safely to avoid crashes, i.e. there's nothing like d.Set(*variable)
+- flatteners and expanders are in structures.go + tests in structures_test.go
+- any validation functions longer than a few lines are in validators.go + tests in validators_test.go
+- Use structure.go and structure_test.go for all flattener and expander functions.
+- Each resource import function should be under their own, import_sakuracloud_<resource>.go
+- d.Set() is called in any C/R/U/D for all available fields unless they're Computed-only (i.e. there are no orphans)
+- we always let d.Set() to dereference pointers safely to avoid crashes, i.e. there's nothing like d.Set(*variable)
+- all of d.Set(), d.Get(), d.GetOk(), d.GetChange() etc. use real field names (i.e. no typos)
+- d.Set() is always error-checked if it’s set, list or map
+- d.Set() is never error-checked if it's primitive data type (string, int, float, bool)
+- Resource uses either Read or Exists function to remove resource from state if it's gone
+- d.Partial() & d.SetPartial() are used any time there's more than 1 API call used to create or update a resource.
+- schema.ForceNew is used for any field that is not updatable
+- all field names are lowercase_underscore
+- where possible data source fields match resource (e.g. when referencing aws_instance user shouldn't need to change anything - just add data. prefix)
+- Constants are used if there are available in the upstream SDK (e.g. for status codes)
+- [INFO] log message at least 2 per each C/R/U/D - e.g. creating (input), created (output)
+- The provider code does not panic, always returns errors
+- The acceptance tests should cover least 50% of the code base. 
+
+```
+
+## ユーザーへの影響
+
+### 影響
+
+- tfファイルの書き換えが発生する
+- stateのアップグレード、またはリソースの再作成の作業が発生する
+
+### 対応
+
+- v1を継続してメンテナンス(ただしバグフィックス中心で新機能の追加は行わない)
+- アップグレードガイドの提供
+
+## トラッキング
+
+- [v2関連のIssue](https://github.com/sacloud/terraform-provider-sakuracloud/issues?q=is%3Aissue+is%3Aopen+label%3Av2)
+- [v2関連のPullRequest](https://github.com/sacloud/terraform-provider-sakuracloud/pulls?utf8=✓&q=is%3Apr+label%3Av2+)
+ 


### PR DESCRIPTION
related: #480 

v2.0の開発にあたりdesign docを追加する。
これまで #480でトラッキングしてきたが追いにくくなってきたため独立したドキュメントとし、今後の変更はドキュメントに対するPRで行う。