### PR TITLE
モバイルゲートウェイ削除時にSIMのIPをクリア

### DIFF
--- a/sakuracloud/resource_sakuracloud_mobile_gateway.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway.go
@@ -574,6 +574,16 @@ func resourceSakuraCloudMobileGatewayDelete(d *schema.ResourceData, meta interfa
 	}
 
 	for _, sim := range sims {
+		if sim.Activated {
+			_, err = client.SIM.Deactivate(toSakuraCloudID(sim.ResourceID))
+			if err != nil {
+				return fmt.Errorf("Failed to deactivate SakuraCloud SIM resource: %s", err)
+			}
+		}
+		_, err = client.SIM.ClearIP(toSakuraCloudID(sim.ResourceID))
+		if err != nil {
+			return fmt.Errorf("Failed to ClearIP SakuraCloud SIM resource: %s", err)
+		}
 		_, err = client.MobileGateway.DeleteSIM(mgw.ID, toSakuraCloudID(sim.ResourceID))
 		if err != nil {
 			return fmt.Errorf("Error deleting SakuraCloud MobileGateway resource: %s", err)


### PR DESCRIPTION
fixes #542 

モバイルゲートウェイ削除時に接続されているSIMをDeactivate/ClearIPを呼んでから切断するようにする。