### PR TITLE
os_typeに指定可能な値の追加

### DIFF
--- a/build_docs/docs/configuration/resources/data/archive.md
+++ b/build_docs/docs/configuration/resources/data/archive.md
@@ -36,10 +36,15 @@ data "sakuracloud_archive" "ubuntu" {
 |値|詳細                                          |
 |---------------------------|--------------------|
 | `centos`                  | CentOS(最新安定板)|
-| `centos7`                  | CentOS 7.7|
-| `centos6`                  | CentOS 6.10|
-| `ubuntu`                  | Ubuntu 18.04|
-| `debian`                  | Debian |
+| `centos8`                  | CentOS 8|
+| `centos7`                  | CentOS 7|
+| `centos6`                  | CentOS 6|
+| `ubuntu`                  | Ubuntu(最新安定板)|
+| `ubuntu1804`              | Ubuntu 18.04|
+| `ubuntu1604`              | Ubuntu 16.04|
+| `debian`                  | Debian(最新安定板) |
+| `debian10`                  | Debian10 |
+| `debian9`                  | Debian9 |
 | `coreos`                  | CoreOS|
 | `rancheros`               | RancherOS|
 | `k3os`                    | k3OS|

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud v1.30.0
+	github.com/sacloud/libsacloud v1.31.0
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud v1.30.0 h1:dWClUXd59zd+ncLTRh48ir3laTeHEULoQowcWQgi1a4=
-github.com/sacloud/libsacloud v1.30.0/go.mod h1:P7YAOVmnIn3DKHqCZcUKYUXmSwGBm3yS7IBEjKVSrjg=
+github.com/sacloud/libsacloud v1.31.0 h1:8pZMsqZzvYOGRAeOiVey427j01acVBd81kYe0yyfBXo=
+github.com/sacloud/libsacloud v1.31.0/go.mod h1:P7YAOVmnIn3DKHqCZcUKYUXmSwGBm3yS7IBEjKVSrjg=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=

--- a/vendor/github.com/sacloud/libsacloud/api/archive.go
+++ b/vendor/github.com/sacloud/libsacloud/api/archive.go
@@ -31,10 +31,15 @@ type ArchiveAPI struct {
 
 var (
 	archiveLatestStableCentOSTags                          = []string{"current-stable", "distro-centos"}
-	archiveLatestStableCentOS7Tags                         = []string{"distro-centos", "distro-ver-7.7"}
-	archiveLatestStableCentOS6Tags                         = []string{"distro-centos", "distro-ver-6.10"}
+	archiveLatestStableCentOS8Tags                         = []string{"centos-8-latest"}
+	archiveLatestStableCentOS7Tags                         = []string{"centos-7-latest"}
+	archiveLatestStableCentOS6Tags                         = []string{"centos-6-latest"}
 	archiveLatestStableUbuntuTags                          = []string{"current-stable", "distro-ubuntu"}
+	archiveLatestStableUbuntu1804Tags                      = []string{"ubuntu-18.04-latest"}
+	archiveLatestStableUbuntu1604Tags                      = []string{"ubuntu-16.04-latest"}
 	archiveLatestStableDebianTags                          = []string{"current-stable", "distro-debian"}
+	archiveLatestStableDebian10Tags                        = []string{"debian-10-latest"}
+	archiveLatestStableDebian9Tags                         = []string{"debian-9-latest"}
 	archiveLatestStableCoreOSTags                          = []string{"current-stable", "distro-coreos"}
 	archiveLatestStableRancherOSTags                       = []string{"current-stable", "distro-rancheros"}
 	archiveLatestStableK3OSTags                            = []string{"current-stable", "distro-k3os"}
@@ -67,10 +72,15 @@ func NewArchiveAPI(client *Client) *ArchiveAPI {
 
 	api.findFuncMapPerOSType = map[ostype.ArchiveOSTypes]func() (*sacloud.Archive, error){
 		ostype.CentOS:                              api.FindLatestStableCentOS,
+		ostype.CentOS8:                             api.FindLatestStableCentOS8,
 		ostype.CentOS7:                             api.FindLatestStableCentOS7,
 		ostype.CentOS6:                             api.FindLatestStableCentOS6,
 		ostype.Ubuntu:                              api.FindLatestStableUbuntu,
+		ostype.Ubuntu1804:                          api.FindLatestStableUbuntu1804,
+		ostype.Ubuntu1604:                          api.FindLatestStableUbuntu1604,
 		ostype.Debian:                              api.FindLatestStableDebian,
+		ostype.Debian10:                            api.FindLatestStableDebian10,
+		ostype.Debian9:                             api.FindLatestStableDebian9,
 		ostype.CoreOS:                              api.FindLatestStableCoreOS,
 		ostype.RancherOS:                           api.FindLatestStableRancherOS,
 		ostype.K3OS:                                api.FindLatestStableK3OS,
@@ -240,6 +250,11 @@ func (api *ArchiveAPI) FindLatestStableCentOS() (*sacloud.Archive, error) {
 	return api.findByOSTags(archiveLatestStableCentOSTags)
 }
 
+// FindLatestStableCentOS8 安定版最新のCentOS8パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableCentOS8() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableCentOS8Tags)
+}
+
 // FindLatestStableCentOS7 安定版最新のCentOS7パブリックアーカイブを取得
 func (api *ArchiveAPI) FindLatestStableCentOS7() (*sacloud.Archive, error) {
 	return api.findByOSTags(archiveLatestStableCentOS7Tags)
@@ -255,9 +270,29 @@ func (api *ArchiveAPI) FindLatestStableDebian() (*sacloud.Archive, error) {
 	return api.findByOSTags(archiveLatestStableDebianTags)
 }
 
+// FindLatestStableDebian10 安定版最新のDebian10パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableDebian10() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableDebian10Tags)
+}
+
+// FindLatestStableDebian9 安定版最新のDebian9パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableDebian9() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableDebian9Tags)
+}
+
 // FindLatestStableUbuntu 安定版最新のUbuntuパブリックアーカイブを取得
 func (api *ArchiveAPI) FindLatestStableUbuntu() (*sacloud.Archive, error) {
 	return api.findByOSTags(archiveLatestStableUbuntuTags)
+}
+
+// FindLatestStableUbuntu1804 安定版最新のUbuntu1804パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableUbuntu1804() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableUbuntu1804Tags)
+}
+
+// FindLatestStableUbuntu1604 安定版最新のUbuntu1604パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableUbuntu1604() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableUbuntu1604Tags)
 }
 
 // FindLatestStableCoreOS 安定版最新のCoreOSパブリックアーカイブを取得

--- a/vendor/github.com/sacloud/libsacloud/libsacloud.go
+++ b/vendor/github.com/sacloud/libsacloud/libsacloud.go
@@ -16,4 +16,4 @@
 package libsacloud
 
 // Version バージョン
-const Version = "1.30.0"
+const Version = "1.31.0"

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archive_ostype.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archive_ostype.go
@@ -23,14 +23,24 @@ type ArchiveOSTypes int
 const (
 	// CentOS OS種別:CentOS
 	CentOS ArchiveOSTypes = iota
+	// CentOS8 OS種別:CentOS8
+	CentOS8
 	// CentOS7 OS種別:CentOS7
 	CentOS7
 	// CentOS6 OS種別:CentOS6
 	CentOS6
 	// Ubuntu OS種別:Ubuntu
 	Ubuntu
+	// Ubuntu1804 OS種別:Ubuntu(Bionic)
+	Ubuntu1804
+	// Ubuntu1604 OS種別:Ubuntu(Xenial)
+	Ubuntu1604
 	// Debian OS種別:Debian
 	Debian
+	// Debian10 OS種別:Debian10
+	Debian10
+	// Debian9 OS種別:Debian9
+	Debian9
 	// CoreOS OS種別:CoreOS
 	CoreOS
 	// RancherOS OS種別:RancherOS
@@ -71,8 +81,10 @@ const (
 
 // OSTypeShortNames OSTypeとして利用できる文字列のリスト
 var OSTypeShortNames = []string{
-	"centos", "centos7", "centos6", "ubuntu", "debian", "coreos",
-	"rancheros", "k3os", "kusanagi", "sophos-utm", "freebsd",
+	"centos", "centos8", "centos7", "centos6",
+	"ubuntu", "ubuntu1804", "ubuntu1604",
+	"debian", "debian10", "debian9",
+	"coreos", "rancheros", "k3os", "kusanagi", "sophos-utm", "freebsd",
 	"netwiser", "opnsense",
 	"windows2016", "windows2016-rds", "windows2016-rds-office",
 	"windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all",
@@ -96,7 +108,10 @@ func (o ArchiveOSTypes) IsWindows() bool {
 // IsSupportDiskEdit ディスクの修正機能をフルサポートしているか(Windowsは一部サポートのためfalseを返す)
 func (o ArchiveOSTypes) IsSupportDiskEdit() bool {
 	switch o {
-	case CentOS, CentOS7, CentOS6, Ubuntu, Debian, CoreOS, RancherOS, K3OS, Kusanagi, FreeBSD:
+	case CentOS, CentOS8, CentOS7, CentOS6,
+		Ubuntu, Ubuntu1804, Ubuntu1604,
+		Debian, Debian10, Debian9,
+		CoreOS, RancherOS, K3OS, Kusanagi, FreeBSD:
 		return true
 	default:
 		return false
@@ -108,14 +123,24 @@ func StrToOSType(osType string) ArchiveOSTypes {
 	switch osType {
 	case "centos":
 		return CentOS
+	case "centos8":
+		return CentOS8
 	case "centos7":
 		return CentOS7
 	case "centos6":
 		return CentOS6
 	case "ubuntu":
 		return Ubuntu
+	case "ubuntu1804":
+		return Ubuntu1804
+	case "ubuntu1604":
+		return Ubuntu1604
 	case "debian":
 		return Debian
+	case "debian10":
+		return Debian10
+	case "debian9":
+		return Debian9
 	case "coreos":
 		return CoreOS
 	case "rancheros":

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archiveostypes_string.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archiveostypes_string.go
@@ -23,33 +23,38 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[CentOS-0]
-	_ = x[CentOS7-1]
-	_ = x[CentOS6-2]
-	_ = x[Ubuntu-3]
-	_ = x[Debian-4]
-	_ = x[CoreOS-5]
-	_ = x[RancherOS-6]
-	_ = x[K3OS-7]
-	_ = x[Kusanagi-8]
-	_ = x[SophosUTM-9]
-	_ = x[FreeBSD-10]
-	_ = x[Netwiser-11]
-	_ = x[OPNsense-12]
-	_ = x[Windows2016-13]
-	_ = x[Windows2016RDS-14]
-	_ = x[Windows2016RDSOffice-15]
-	_ = x[Windows2016SQLServerWeb-16]
-	_ = x[Windows2016SQLServerStandard-17]
-	_ = x[Windows2016SQLServer2017Standard-18]
-	_ = x[Windows2016SQLServerStandardAll-19]
-	_ = x[Windows2016SQLServer2017StandardAll-20]
-	_ = x[Windows2019-21]
-	_ = x[Custom-22]
+	_ = x[CentOS8-1]
+	_ = x[CentOS7-2]
+	_ = x[CentOS6-3]
+	_ = x[Ubuntu-4]
+	_ = x[Ubuntu1804-5]
+	_ = x[Ubuntu1604-6]
+	_ = x[Debian-7]
+	_ = x[Debian10-8]
+	_ = x[Debian9-9]
+	_ = x[CoreOS-10]
+	_ = x[RancherOS-11]
+	_ = x[K3OS-12]
+	_ = x[Kusanagi-13]
+	_ = x[SophosUTM-14]
+	_ = x[FreeBSD-15]
+	_ = x[Netwiser-16]
+	_ = x[OPNsense-17]
+	_ = x[Windows2016-18]
+	_ = x[Windows2016RDS-19]
+	_ = x[Windows2016RDSOffice-20]
+	_ = x[Windows2016SQLServerWeb-21]
+	_ = x[Windows2016SQLServerStandard-22]
+	_ = x[Windows2016SQLServer2017Standard-23]
+	_ = x[Windows2016SQLServerStandardAll-24]
+	_ = x[Windows2016SQLServer2017StandardAll-25]
+	_ = x[Windows2019-26]
+	_ = x[Custom-27]
 }
 
-const _ArchiveOSTypes_name = "CentOSCentOS7CentOS6UbuntuDebianCoreOSRancherOSK3OSKusanagiSophosUTMFreeBSDNetwiserOPNsenseWindows2016Windows2016RDSWindows2016RDSOfficeWindows2016SQLServerWebWindows2016SQLServerStandardWindows2016SQLServer2017StandardWindows2016SQLServerStandardAllWindows2016SQLServer2017StandardAllWindows2019Custom"
+const _ArchiveOSTypes_name = "CentOSCentOS8CentOS7CentOS6UbuntuUbuntu1804Ubuntu1604DebianDebian10Debian9CoreOSRancherOSK3OSKusanagiSophosUTMFreeBSDNetwiserOPNsenseWindows2016Windows2016RDSWindows2016RDSOfficeWindows2016SQLServerWebWindows2016SQLServerStandardWindows2016SQLServer2017StandardWindows2016SQLServerStandardAllWindows2016SQLServer2017StandardAllWindows2019Custom"
 
-var _ArchiveOSTypes_index = [...]uint16{0, 6, 13, 20, 26, 32, 38, 47, 51, 59, 68, 75, 83, 91, 102, 116, 136, 159, 187, 219, 250, 285, 296, 302}
+var _ArchiveOSTypes_index = [...]uint16{0, 6, 13, 20, 27, 33, 43, 53, 59, 67, 74, 80, 89, 93, 101, 110, 117, 125, 133, 144, 158, 178, 201, 229, 261, 292, 327, 338, 344}
 
 func (i ArchiveOSTypes) String() string {
 	if i < 0 || i >= ArchiveOSTypes(len(_ArchiveOSTypes_index)-1) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -217,7 +217,7 @@ github.com/posener/complete/match
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud v1.30.0
+# github.com/sacloud/libsacloud v1.31.0
 github.com/sacloud/libsacloud
 github.com/sacloud/libsacloud/api
 github.com/sacloud/libsacloud/sacloud

--- a/website/docs/d/archive.html.markdown
+++ b/website/docs/d/archive.html.markdown
@@ -50,10 +50,15 @@ data "sakuracloud_archive" "ubuntu" {
 ## `os_type` Parameter Reference
 
 * `centos` - CentOS(latest) 
-* `centos7` - CentOS 7.7
-* `centos6` - CentOS 6.10
-* `ubuntu` - Ubuntu 
-* `debian` - Debian 
+* `centos8` - CentOS 8 
+* `centos7` - CentOS 7
+* `centos6` - CentOS 6
+* `ubuntu` - Ubuntu(latest)
+* `ubuntu1804` - Ubuntu 18.04
+* `ubuntu1604` - Ubuntu 16.04
+* `debian` - Debian(latest) 
+* `debian10` - Debian 10
+* `debian9` - Debian 9
 * `coreos` - CoreOS
 * `rancheros` - RancherOS
 * `k3os` - k3OS


### PR DESCRIPTION
related: #532 

ref: https://github.com/sacloud/libsacloud/pull/389

`os_type`に指定できる値を追加する。

### メジャーバージョンを問わず最新安定版を参照するもの

- `centos`
- `ubuntu`
- `debian`

### メジャーバージョンごとの最新版を参照するもの
 
- `centos8`
- `centos7`
- `centos6`
- `ubuntu1804`
- `ubuntu1604`
- `debian10`
- `debian9`
