### PR TITLE
Upgrade schema - sakuracloud_server

### DIFF
--- a/CHANGELOG.v-next-schema.md
+++ b/CHANGELOG.v-next-schema.md
@@ -61,23 +61,70 @@ data sakuracoud_server "example" {
   
 ## リソース
 
-- Bridge
+- ブリッジ
 
   - `switch_ids`属性の廃止
 
-- GSLBサーバ
+- GSLB 実サーバ
 
   - `sakuracloud_gslb_server`を廃止
   
-- LoadBalancer VIP/サーバ
+- ロードバランサ VIP/実サーバ
 
   - `sakuracloud_loadbalancer_vip`を廃止  
   - `sakuracloud_loadbalancer_server`を廃止  
 
-- PacketFilterルール
+- パケットフィルタ ルール
 
   - `sakuracloud_packet_filter_rule`を`sakuracloud_packet_filter_rules`に変更  
   これまでルールごとに1リソースだったものが複数のリソースを保持するようになった
+    
+- サーバ    
+
+  - VNC関連項目を除去
+  - 表示用IP(Interfaces.Switch.UserIPAddress)の設定を除去
+  - NIC/追加NICを統合
+    - `nic`に文字列を指定からオブジェクトを指定するように変更
+    - *`nic`*がオブジェクトになることでデフォルト値が設定できなくなる。`nics`を明示的に書く必要がある。
+    - パケットフィルタとMACアドレスを`nics`配下の各要素内に配置
+    
+#### 変更前
+
+```hcl
+resource sakuracloud_server "foobar" {
+  name = "foobar"
+  
+  # nic  = "shared"      # 共有セグメントに接続(デフォルト)
+  # nic = "disconnect"   # 切断状態
+  # nic = "100000000001" # スイッチに接続(スイッチIDを指定)
+  
+  # 追加NIC
+  additional_nics = ["100000000002", "100000000003"] #スイッチIDのリスト 
+  
+  # パケットフィルタ
+  packet_filter_id = ["200000000001", "200000000002", "200000000003"] 
+}
+```
+
+#### 変更後
+
+```hcl
+resource sakuracloud_server "foobar" {
+  name = "foobar"
+  nics {
+    upstream         = "shared"
+    packet_filter_id = "200000000001"
+  }
+  nics {
+    upstream         = "100000000002" # スイッチID
+    packet_filter_id = "200000000002" # パケットフィルタID
+  }
+  nics {
+    upstream         = "100000000003" # スイッチID
+    packet_filter_id = "200000000003" # パケットフィルタID
+  }
+}
+```
     
 - シンプル監視 
 

--- a/CHANGELOG.v-next-schema.md
+++ b/CHANGELOG.v-next-schema.md
@@ -83,10 +83,10 @@ data sakuracoud_server "example" {
 
   - VNC関連項目を除去
   - 表示用IP(Interfaces.Switch.UserIPAddress)の設定を除去
-  - NIC/追加NICを統合
+  - NIC/追加NICを統合し`interfaces`を新設
     - `nic`に文字列を指定からオブジェクトを指定するように変更
-    - *`nic`*がオブジェクトになることでデフォルト値が設定できなくなる。`nics`を明示的に書く必要がある。
-    - パケットフィルタとMACアドレスを`nics`配下の各要素内に配置
+    - *`nic`*がオブジェクトになることでデフォルト値が設定できなくなる。`interfaces`を明示的に書く必要がある。
+    - パケットフィルタとMACアドレスを`interfaces`配下の各要素内に配置
     
 #### 変更前
 
@@ -111,15 +111,15 @@ resource sakuracloud_server "foobar" {
 ```hcl
 resource sakuracloud_server "foobar" {
   name = "foobar"
-  nics {
+  interfaces {
     upstream         = "shared"
     packet_filter_id = "200000000001"
   }
-  nics {
+  interfaces {
     upstream         = "100000000002" # スイッチID
     packet_filter_id = "200000000002" # パケットフィルタID
   }
-  nics {
+  interfaces {
     upstream         = "100000000003" # スイッチID
     packet_filter_id = "200000000003" # パケットフィルタID
   }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210070433-e7ad7ecec6cd
+	github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210122856-9ae9cbfb5219
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210122856-9ae9cbfb5219
+	github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191211005330-ca7e43850bdf
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210070433-e7ad7ecec6cd h1:doZTltRBKbLfTa3kB9/p1WXbDNEAZgGBBOV9scU63E4=
-github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210070433-e7ad7ecec6cd/go.mod h1:pMzeuC8nezPoWXhQ1ZrawwdZOGDqe3xs4Fa3MddE1W0=
+github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210122856-9ae9cbfb5219 h1:Bw+kd3OzOwNIGbrZibdpVCauC6HSfhhDD398KuCk6HA=
+github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210122856-9ae9cbfb5219/go.mod h1:pMzeuC8nezPoWXhQ1ZrawwdZOGDqe3xs4Fa3MddE1W0=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210122856-9ae9cbfb5219 h1:Bw+kd3OzOwNIGbrZibdpVCauC6HSfhhDD398KuCk6HA=
-github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210122856-9ae9cbfb5219/go.mod h1:pMzeuC8nezPoWXhQ1ZrawwdZOGDqe3xs4Fa3MddE1W0=
+github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191211005330-ca7e43850bdf h1:O1WNqsoTc577256128ZlCF0pgyVa6ZSi0rUvQsQAn+w=
+github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191211005330-ca7e43850bdf/go.mod h1:pMzeuC8nezPoWXhQ1ZrawwdZOGDqe3xs4Fa3MddE1W0=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=

--- a/sakuracloud/data_source_sakuracloud_server.go
+++ b/sakuracloud/data_source_sakuracloud_server.go
@@ -52,7 +52,7 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"nics": {
+			"interfaces": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{

--- a/sakuracloud/data_source_sakuracloud_server.go
+++ b/sakuracloud/data_source_sakuracloud_server.go
@@ -52,13 +52,25 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"nic": {
-				Type:     schema.TypeString,
+			"nics": {
+				Type:     schema.TypeList,
 				Computed: true,
-			},
-			"display_ipaddress": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"upstream": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"packet_filter_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"macaddress": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"cdrom_id": {
 				Type:     schema.TypeString,
@@ -71,21 +83,6 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 			"private_host_name": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			"additional_nics": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"additional_display_ipaddresses": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"packet_filter_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"icon_id": {
 				Type:     schema.TypeString,
@@ -108,11 +105,6 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 				Description:  "target SakuraCloud zone",
 				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
-			"macaddresses": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
 			"ipaddress": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -133,19 +125,6 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 			"nw_mask_len": {
 				Type:     schema.TypeInt,
 				Computed: true,
-			},
-			"vnc_host": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"vnc_port": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"vnc_password": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
 			},
 		},
 	}

--- a/sakuracloud/data_source_sakuracloud_server_test.go
+++ b/sakuracloud/data_source_sakuracloud_server_test.go
@@ -52,8 +52,8 @@ func TestAccSakuraCloudDataSourceServer_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "core", "1"),
 					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "memory", "1"),
 					//resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "disks.#", "1"),
-					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "nics.0.upstream", "shared"),
-					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "nics.#", "1"),
+					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "interfaces.0.upstream", "shared"),
+					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "interfaces.#", "1"),
 				),
 			},
 			{
@@ -94,7 +94,7 @@ resource "sakuracloud_server" "foobar" {
   disks = ["${sakuracloud_disk.foobar.id}"]
   description = "description_test"
   tags = ["tag1","tag2","tag3"]
-  nics {
+  interfaces {
     upstream = "shared"
   }
 }`, name, name)

--- a/sakuracloud/data_source_sakuracloud_server_test.go
+++ b/sakuracloud/data_source_sakuracloud_server_test.go
@@ -52,9 +52,8 @@ func TestAccSakuraCloudDataSourceServer_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "core", "1"),
 					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "memory", "1"),
 					//resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "disks.#", "1"),
-					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "nic", "shared"),
-					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "additional_nics.#", "0"),
-					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "macaddresses.#", "1"),
+					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "nics.0.upstream", "shared"),
+					resource.TestCheckResourceAttr("data.sakuracloud_server.foobar", "nics.#", "1"),
 				),
 			},
 			{
@@ -95,6 +94,9 @@ resource "sakuracloud_server" "foobar" {
   disks = ["${sakuracloud_disk.foobar.id}"]
   description = "description_test"
   tags = ["tag1","tag2","tag3"]
+  nics {
+    upstream = "shared"
+  }
 }`, name, name)
 }
 

--- a/sakuracloud/deletion_waiter.go
+++ b/sakuracloud/deletion_waiter.go
@@ -27,16 +27,24 @@ import (
 
 type deletionWaiterFindFunc func(context.Context, *APIClient, string, types.ID) (bool, error)
 
+func waitForDeletionByPrivateHostID(ctx context.Context, client *APIClient, zone string, privateHostID types.ID) error {
+	return waitForDeletion(ctx, client, zone, privateHostID, []deletionWaiterFindFunc{
+		findServerByPrivateHostID,
+	})
+}
+
 func waitForDeletionBySwitchID(ctx context.Context, client *APIClient, zone string, switchID types.ID) error {
-	finder := []deletionWaiterFindFunc{
+	return waitForDeletion(ctx, client, zone, switchID, []deletionWaiterFindFunc{
 		findServerBySwitchID,
 		findLoadBalancerBySwitchID,
 		findVPCRouterBySwitchID,
 		findDatabaseBySwitchID,
 		findNFSBySwitchID,
 		findMobileGatewayBySwitchID,
-	}
+	})
+}
 
+func waitForDeletion(ctx context.Context, client *APIClient, zone string, id types.ID, finder []deletionWaiterFindFunc) error {
 	var wg sync.WaitGroup
 	wg.Add(len(finder))
 
@@ -45,7 +53,7 @@ func waitForDeletionBySwitchID(ctx context.Context, client *APIClient, zone stri
 
 	for _, f := range finder {
 		go func(f deletionWaiterFindFunc) {
-			if err := waitForDeletionByFunc(ctx, client, zone, switchID, f); err != nil {
+			if err := waitForDeletionByFunc(ctx, client, zone, id, f); err != nil {
 				errCh <- err
 			}
 			wg.Done()
@@ -98,6 +106,22 @@ func findServerBySwitchID(ctx context.Context, client *APIClient, zone string, i
 		return false, fmt.Errorf("finding server is failed: %s", err)
 	}
 	return searched.Count != 0, nil
+}
+
+func findServerByPrivateHostID(ctx context.Context, client *APIClient, zone string, id types.ID) (bool, error) {
+	serverOp := sacloud.NewServerOp(client)
+
+	searched, err := serverOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding Server is failed: %s", err)
+	}
+
+	for _, s := range searched.Servers {
+		if s.PrivateHostID == id {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func findVPCRouterBySwitchID(ctx context.Context, client *APIClient, zone string, id types.ID) (bool, error) {

--- a/sakuracloud/resource_sakuracloud_internet_test.go
+++ b/sakuracloud/resource_sakuracloud_internet_test.go
@@ -219,7 +219,9 @@ resource "sakuracloud_server" "foobar" {
   name        = "myserver"
   disks       = ["${sakuracloud_disk.foobar.id}"]
   description = "Server from TerraForm for SAKURA CLOUD"
-  nic         = "${sakuracloud_internet.foobar.switch_id}"
+  nics {
+    upstream = sakuracloud_internet.foobar.switch_id
+  }
   ipaddress   = "${sakuracloud_internet.foobar.ipaddresses[0]}"
   gateway     = "${sakuracloud_internet.foobar.gateway}"
   nw_mask_len = "${sakuracloud_internet.foobar.nw_mask_len}"
@@ -245,7 +247,9 @@ resource "sakuracloud_server" "foobar" {
   name        = "myserver"
   disks       = ["${sakuracloud_disk.foobar.id}"]
   description = "Server from TerraForm for SAKURA CLOUD"
-  nic         = "${sakuracloud_internet.foobar.switch_id}"
+  nics {
+    upstream = sakuracloud_internet.foobar.switch_id
+  }
   ipaddress   = "${sakuracloud_internet.foobar.ipaddresses[0]}"
   gateway     = "${sakuracloud_internet.foobar.gateway}"
   nw_mask_len = "${sakuracloud_internet.foobar.nw_mask_len}"

--- a/sakuracloud/resource_sakuracloud_internet_test.go
+++ b/sakuracloud/resource_sakuracloud_internet_test.go
@@ -219,7 +219,7 @@ resource "sakuracloud_server" "foobar" {
   name        = "myserver"
   disks       = ["${sakuracloud_disk.foobar.id}"]
   description = "Server from TerraForm for SAKURA CLOUD"
-  nics {
+  interfaces {
     upstream = sakuracloud_internet.foobar.switch_id
   }
   ipaddress   = "${sakuracloud_internet.foobar.ipaddresses[0]}"
@@ -247,7 +247,7 @@ resource "sakuracloud_server" "foobar" {
   name        = "myserver"
   disks       = ["${sakuracloud_disk.foobar.id}"]
   description = "Server from TerraForm for SAKURA CLOUD"
-  nics {
+  interfaces {
     upstream = sakuracloud_internet.foobar.switch_id
   }
   ipaddress   = "${sakuracloud_internet.foobar.ipaddresses[0]}"

--- a/sakuracloud/resource_sakuracloud_packet_filter.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter.go
@@ -161,6 +161,10 @@ func resourceSakuraCloudPacketFilterDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("could not read SakuraCloud PacketFilter[%s]: %s", d.Id(), err)
 	}
 
+	if err := waitForDeletionByPacketFilterID(ctx, client, zone, pf.ID); err != nil {
+		return fmt.Errorf("waiting deletion is failed: PacketFilter[%s] still used by Server: %s", pf.ID, err)
+	}
+
 	if err := pfOp.Delete(ctx, zone, pf.ID); err != nil {
 		return fmt.Errorf("deleting SakuraCloud PacketFilter[%s] is failed: %s", d.Id(), err)
 	}

--- a/sakuracloud/resource_sakuracloud_private_host.go
+++ b/sakuracloud/resource_sakuracloud_private_host.go
@@ -142,7 +142,6 @@ func resourceSakuraCloudPrivateHostUpdate(d *schema.ResourceData, meta interface
 func resourceSakuraCloudPrivateHostDelete(d *schema.ResourceData, meta interface{}) error {
 	client, ctx, zone := getSacloudClient(d, meta)
 	phOp := sacloud.NewPrivateHostOp(client)
-	serverOp := sacloud.NewServerOp(client)
 
 	ph, err := phOp.Read(ctx, zone, sakuraCloudID(d.Id()))
 	if err != nil {
@@ -153,62 +152,12 @@ func resourceSakuraCloudPrivateHostDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("could not read SakuraCloud PrivateHost[%s]: %s", d.Id(), err)
 	}
 
-	searched, err := serverOp.Find(ctx, zone, &sacloud.FindCondition{})
-	if err != nil {
-		return fmt.Errorf("detaching Server is failed: %s", err)
-	}
-	for _, server := range searched.Servers {
-		if server.PrivateHostID == ph.ID {
-			if err := detachServerFromPrivateHost(ctx, client, zone, server.ID); err != nil {
-				return fmt.Errorf("detaching Server is failed: %s", err)
-			}
-		}
+	if err := waitForDeletionByPrivateHostID(ctx, client, zone, ph.ID); err != nil {
+		return fmt.Errorf("waiting deletion is failed: PrivateHost[%s] still used by Server: %s", ph.ID, err)
 	}
 
 	if err := phOp.Delete(ctx, zone, ph.ID); err != nil {
 		return fmt.Errorf("deleting SakuraCloud PrivateHost[%s] is failed: %s", d.Id(), err)
-	}
-	return nil
-}
-
-func detachServerFromPrivateHost(ctx context.Context, client *APIClient, zone string, serverID types.ID) error {
-	serverOp := sacloud.NewServerOp(client)
-
-	sakuraMutexKV.Lock(serverID.String())
-	defer sakuraMutexKV.Unlock(serverID.String())
-
-	server, err := serverOp.Read(ctx, zone, serverID)
-	if err != nil {
-		if sacloud.IsNotFoundError(err) {
-			return nil
-		}
-		return fmt.Errorf("reading SakuraCloud Server[%s] is failed: %s", serverID, err)
-	}
-	if !server.PrivateHostID.IsEmpty() {
-		isNeedRestart := false
-		if server.InstanceStatus.IsUp() {
-			isNeedRestart = true
-			if err := shutdownServerSync(ctx, client, zone, server.ID); err != nil {
-				return fmt.Errorf("stopping SakuraCloud Server[%s] is failed: %s", serverID, err)
-			}
-		}
-
-		_, err := serverOp.Update(ctx, zone, serverID, &sacloud.ServerUpdateRequest{
-			Name:            server.Name,
-			Description:     server.Description,
-			Tags:            server.Tags,
-			IconID:          server.IconID,
-			InterfaceDriver: server.InterfaceDriver,
-		})
-		if err != nil {
-			return fmt.Errorf("detaching Server[%s] From PrivateHost[%s] is failed: %s", serverID, server.PrivateHostID, err)
-		}
-
-		if isNeedRestart {
-			if err := bootServerSync(ctx, client, zone, server.ID); err != nil {
-				return fmt.Errorf("booting SakuraCloud Server[%s] is failed: %s", serverID, err)
-			}
-		}
 	}
 	return nil
 }

--- a/sakuracloud/resource_sakuracloud_private_host_test.go
+++ b/sakuracloud/resource_sakuracloud_private_host_test.go
@@ -197,7 +197,7 @@ var testAccCheckSakuraCloudPrivateHostConfig_Destroy_Basic = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver"
   private_host_id = "${sakuracloud_private_host.foobar.id}"
-  nics {
+  interfaces {
     upstream = "shared"
   }
 
@@ -214,7 +214,7 @@ var testAccCheckSakuraCloudPrivateHostConfig_Destroy_Update = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver"
 
-  nics {
+  interfaces {
     upstream = "shared"
   }
 

--- a/sakuracloud/resource_sakuracloud_private_host_test.go
+++ b/sakuracloud/resource_sakuracloud_private_host_test.go
@@ -197,6 +197,11 @@ var testAccCheckSakuraCloudPrivateHostConfig_Destroy_Basic = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver"
   private_host_id = "${sakuracloud_private_host.foobar.id}"
+  nics {
+    upstream = "shared"
+  }
+
+  force_shutdown = true
 }
 resource "sakuracloud_private_host" "foobar" {
   name = "before"
@@ -208,5 +213,11 @@ resource "sakuracloud_private_host" "foobar" {
 var testAccCheckSakuraCloudPrivateHostConfig_Destroy_Update = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver"
+
+  nics {
+    upstream = "shared"
+  }
+
+  force_shutdown = true
 }
 `

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -80,7 +80,7 @@ func resourceSakuraCloudServer() *schema.Resource {
 					types.InterfaceDrivers.E1000.String(),
 				}, false),
 			},
-			"nics": {
+			"interfaces": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 10,
@@ -317,7 +317,7 @@ func setServerResourceData(ctx context.Context, d *schema.ResourceData, client *
 	d.Set("interface_driver", data.InterfaceDriver.String())
 	d.Set("private_host_id", data.PrivateHostID.String())
 	d.Set("private_host_name", data.PrivateHostName)
-	if err := d.Set("nics", flattenServerNICs(data)); err != nil {
+	if err := d.Set("interfaces", flattenServerNICs(data)); err != nil {
 		return err
 	}
 	d.Set("icon_id", data.IconID.String())
@@ -387,7 +387,7 @@ func expandServerDisks(d *schema.ResourceData, client *APIClient) []diskBuilder.
 }
 
 func expandServerNIC(d resourceValueGettable) serverBuilder.NICSettingHolder {
-	nics := d.Get("nics").([]interface{})
+	nics := d.Get("interfaces").([]interface{})
 	if len(nics) == 0 {
 		return nil
 	}
@@ -412,7 +412,7 @@ func expandServerNIC(d resourceValueGettable) serverBuilder.NICSettingHolder {
 func expandServerAdditionalNICs(d resourceValueGettable) []serverBuilder.AdditionalNICSettingHolder {
 	var results []serverBuilder.AdditionalNICSettingHolder
 
-	nics := d.Get("nics").([]interface{})
+	nics := d.Get("interfaces").([]interface{})
 	if len(nics) < 2 {
 		return results
 	}
@@ -482,7 +482,7 @@ func flattenServerNetworkInfo(server *sacloud.Server) (ip, gateway string, nwMas
 
 func isServerDiskConfigChanged(d *schema.ResourceData) bool {
 	return d.HasChange("disks") ||
-		d.HasChange("nics") ||
+		d.HasChange("interfaces") ||
 		d.HasChange("ipaddress") ||
 		d.HasChange("gateway") ||
 		d.HasChange("nw_mask_len") ||

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -20,13 +20,12 @@ import (
 	"log"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	diskBuilder "github.com/sacloud/libsacloud/v2/utils/builder/disk"
+	serverBuilder "github.com/sacloud/libsacloud/v2/utils/builder/server"
 	serverUtil "github.com/sacloud/libsacloud/v2/utils/server"
 )
 
@@ -41,20 +40,7 @@ func resourceSakuraCloudServer() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		CustomizeDiff: customdiff.All(
-			serverNetworkAttrsCustomizeDiff,
-			hasTagResourceCustomizeDiff,
-		),
-		SchemaVersion: 1,
-		MigrateState: func(version int, state *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
-			if version < 1 {
-				v, exists := state.Attributes["commitment"]
-				if !exists || v == "" {
-					state.Attributes["commitment"] = types.Commitments.Standard.String()
-				}
-			}
-			return state, nil
-		},
+		CustomizeDiff: hasTagResourceCustomizeDiff,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -94,10 +80,29 @@ func resourceSakuraCloudServer() *schema.Resource {
 					types.InterfaceDrivers.E1000.String(),
 				}, false),
 			},
-			"nic": {
-				Type:     schema.TypeString,
+			"nics": {
+				Type:     schema.TypeList,
 				Optional: true,
-				Default:  "shared",
+				MaxItems: 10,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"upstream": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateSakuraCloudServerNIC,
+							Description:  "Upstream Network Type: valid value is one of [shared/disconnect/<switch id>]",
+						},
+						"packet_filter_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateSakuracloudIDType,
+						},
+						"macaddress": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"cdrom_id": {
 				Type:         schema.TypeString,
@@ -113,18 +118,6 @@ func resourceSakuraCloudServer() *schema.Resource {
 			"private_host_name": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			"additional_nics": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 3,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"packet_filter_ids": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 4,
-				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"icon_id": {
 				Type:         schema.TypeString,
@@ -173,7 +166,7 @@ func resourceSakuraCloudServer() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"macaddresses": {
+			"dns_servers": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -182,11 +175,6 @@ func resourceSakuraCloudServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-			},
-			"dns_servers": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"gateway": {
 				Type:     schema.TypeString,
@@ -202,80 +190,28 @@ func resourceSakuraCloudServer() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"force_shutdown": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
 
 func resourceSakuraCloudServerCreate(d *schema.ResourceData, meta interface{}) error {
 	client, ctx, zone := getSacloudClient(d, meta)
-	serverOp := sacloud.NewServerOp(client)
-	diskOp := sacloud.NewDiskOp(client)
-	interfaceOp := sacloud.NewInterfaceOp(client)
+	builder := expandServerBuilder(d, client)
 
-	// validate
-	if err := validateServerPlan(ctx, client, d); err != nil {
-		return err
+	if err := builder.Validate(ctx, zone); err != nil {
+		return fmt.Errorf("validating SakuraCloud Server is failed: %s", err)
 	}
 
-	server, err := serverOp.Create(ctx, zone, &sacloud.ServerCreateRequest{
-		CPU:                  d.Get("core").(int),
-		MemoryMB:             d.Get("memory").(int) * 1024,
-		ServerPlanCommitment: types.ECommitment(d.Get("commitment").(string)),
-		ServerPlanGeneration: types.PlanGenerations.Default,
-		ConnectedSwitches:    expandConnectedSwitches(d),
-		InterfaceDriver:      types.EInterfaceDriver(d.Get("interface_driver").(string)),
-		Name:                 d.Get("name").(string),
-		Description:          d.Get("description").(string),
-		Tags:                 expandTags(d),
-		IconID:               expandSakuraCloudID(d, "icon_id"),
-		WaitDiskMigration:    false,
-		PrivateHostID:        expandSakuraCloudID(d, "private_host_id"),
-	})
+	result, err := builder.Build(ctx, zone)
 	if err != nil {
 		return fmt.Errorf("creating SakuraCloud Server is failed: %s", err)
 	}
 
-	//connect disk to server
-	diskIDs := expandSakuraCloudIDs(d, "disks")
-	for _, diskID := range diskIDs {
-		if err := diskOp.ConnectToServer(ctx, zone, diskID, server.ID); err != nil {
-			return fmt.Errorf("connecting Disk[%s] to Server[%s] is failed: %s", diskID, server.ID, err)
-		}
-	}
-
-	// edit disk
-	editReq := expandDiskEditRequest(d)
-	if editReq != nil && len(diskIDs) > 0 {
-		if err := configDiskSync(ctx, client, zone, diskIDs[0], editReq); err != nil {
-			return fmt.Errorf("editting Disk[%s] is failed: %s", diskIDs[0], err)
-		}
-	}
-
-	// packet filters
-	packetFilterIDs := expandSakuraCloudIDs(d, "packet_filter_ids")
-	for i, pfID := range packetFilterIDs {
-		if !pfID.IsEmpty() && len(server.Interfaces) > i {
-			ifID := server.Interfaces[i].ID
-			if err := interfaceOp.ConnectToPacketFilter(ctx, zone, ifID, pfID); err != nil {
-				return fmt.Errorf("connecting PacketFilter[%d] to Interface[%d] is failed: %s", pfID, ifID, err)
-			}
-		}
-	}
-
-	// cdrom
-	cdromID := expandSakuraCloudID(d, "cdrom_id")
-	if !cdromID.IsEmpty() {
-		if err := serverOp.InsertCDROM(ctx, zone, server.ID, &sacloud.InsertCDROMRequest{ID: cdromID}); err != nil {
-			return fmt.Errorf("inserting CD-ROM[%s] to Server[%s] is failed: %s", cdromID, server.ID, err)
-		}
-	}
-
-	//boot
-	if err := bootServerSync(ctx, client, zone, server.ID); err != nil {
-		return fmt.Errorf("booting SakuraCloud Server[%s] is failed: %s", server.ID, err)
-	}
-
-	d.SetId(server.ID.String())
+	d.SetId(result.ServerID.String())
 	return resourceSakuraCloudServerRead(d, meta)
 }
 
@@ -307,113 +243,18 @@ func resourceSakuraCloudServerUpdate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("could not read SakuraCloud Server[%s]: %s", d.Id(), err)
 	}
 
-	isNeedRestart := false
-	isRunning := server.InstanceStatus.IsUp()
-	isPlanChanged := isServerPlanChanged(d)
+	builder := expandServerBuilder(d, client)
 
-	if isPlanChanged {
-		// validate
-		if err := validateServerPlan(ctx, client, d); err != nil {
-			return err
-		}
-		isNeedRestart = true
+	if err := builder.Validate(ctx, zone); err != nil {
+		return fmt.Errorf("validating SakuraCloud Server[%s] is failed: %s", server.ID, err)
 	}
 
-	isDiskConfigChanged := isServerDiskConfigChanged(d)
-
-	if isDiskConfigChanged || d.HasChange("additional_nics") || d.HasChange("interface_driver") || d.HasChange("private_host_id") {
-		isNeedRestart = true
-	}
-
-	if isNeedRestart && isRunning {
-		if err := shutdownServerSync(ctx, client, zone, server.ID); err != nil {
-			return fmt.Errorf("stopping SakuraCloud Server[%s] is failed: %s", server.ID, err)
-		}
-	}
-
-	if d.HasChange("disks") {
-		if err := reconcileServerDisks(ctx, client, d, server); err != nil {
-			return fmt.Errorf("reconciling Disks is failed: %s", err)
-		}
-	}
-
-	// NIC
-	if d.HasChange("nic") || d.HasChange("additional_nics") {
-		if err := reconcileServerNICs(ctx, client, d, server); err != nil {
-			return fmt.Errorf("reconciling NICs is failed: %s", err)
-		}
-	}
-
-	//refresh server(need refresh after disk and nic edit)
-	updatedServer, err := serverOp.Read(ctx, zone, server.ID)
-	if err != nil {
-		return fmt.Errorf("could not read Server[%s]: %s", server.ID, err)
-	}
-	server = updatedServer
-
-	// edit disk
-	if isDiskConfigChanged && len(updatedServer.Disks) > 0 {
-		editReq := expandDiskEditRequest(d)
-		if editReq != nil {
-			if err := configDiskSync(ctx, client, zone, updatedServer.Disks[0].ID, editReq); err != nil {
-				return fmt.Errorf("editting Disk[%s] is failed: %s", updatedServer.Disks[0].ID, err)
-			}
-		}
-	}
-
-	// change Plan
-	if isPlanChanged {
-		s, err := serverOp.ChangePlan(ctx, zone, server.ID, &sacloud.ServerChangePlanRequest{
-			CPU:                  d.Get("core").(int),
-			MemoryMB:             d.Get("memory").(int) * 1024,
-			ServerPlanCommitment: types.ECommitment(d.Get("commitment").(string)),
-			ServerPlanGeneration: types.PlanGenerations.Default,
-		})
-		if err != nil {
-			return fmt.Errorf("changing ServerPlan is failed: %s", err)
-		}
-		server = s
-		d.SetId(server.ID.String())
-	}
-
-	server, err = serverOp.Update(ctx, zone, server.ID, &sacloud.ServerUpdateRequest{
-		Name:            d.Get("name").(string),
-		Description:     d.Get("description").(string),
-		Tags:            expandTags(d),
-		IconID:          expandSakuraCloudID(d, "icon_id"),
-		PrivateHostID:   expandSakuraCloudID(d, "private_host_id"),
-		InterfaceDriver: types.EInterfaceDriver(d.Get("interface_driver").(string)),
-	})
+	result, err := builder.Update(ctx, zone)
 	if err != nil {
 		return fmt.Errorf("updating SakuraCloud Server[%s] is failed: %s", server.ID, err)
 	}
 
-	if d.HasChange("packet_filter_ids") {
-		if err := reconcileServerPacketFilters(ctx, client, d, server); err != nil {
-			return fmt.Errorf("reconciling PacketFilters is failed: %s", err)
-		}
-	}
-
-	if d.HasChange("cdrom_id") {
-		if !server.CDROMID.IsEmpty() {
-			if err := serverOp.EjectCDROM(ctx, zone, server.ID, &sacloud.EjectCDROMRequest{ID: server.CDROMID}); err != nil {
-				return fmt.Errorf("ejecting CD-ROM[%s] is failed: %s", server.CDROMID, err)
-			}
-		}
-		cdromID := expandSakuraCloudID(d, "cdrom_id")
-		if !cdromID.IsEmpty() {
-			if err := serverOp.InsertCDROM(ctx, zone, server.ID, &sacloud.InsertCDROMRequest{ID: cdromID}); err != nil {
-				return fmt.Errorf("inserting CD-ROM[%s] is failed: %s", cdromID, err)
-			}
-		}
-	}
-
-	if isNeedRestart && isRunning {
-		if err := bootServerSync(ctx, client, zone, server.ID); err != nil {
-			return fmt.Errorf("booting SakuraCloud Server[%s] is failed: %s", server.ID, err)
-		}
-	}
-
+	d.SetId(result.ServerID.String())
 	return resourceSakuraCloudServerRead(d, meta)
 }
 
@@ -476,19 +317,12 @@ func setServerResourceData(ctx context.Context, d *schema.ResourceData, client *
 	d.Set("interface_driver", data.InterfaceDriver.String())
 	d.Set("private_host_id", data.PrivateHostID.String())
 	d.Set("private_host_name", data.PrivateHostName)
-	d.Set("nic", flattenServerNIC(data))
-	if err := d.Set("additional_nics", flattenServerAdditionalNICs(data)); err != nil {
+	if err := d.Set("nics", flattenServerNICs(data)); err != nil {
 		return err
 	}
 	d.Set("icon_id", data.IconID.String())
 	d.Set("description", data.Description)
 	if err := d.Set("tags", data.Tags); err != nil {
-		return err
-	}
-	if err := d.Set("packet_filter_ids", flattenServerConnectedPacketFilterIDs(data)); err != nil {
-		return err
-	}
-	if err := d.Set("macaddresses", flattenServerMACAddresses(data)); err != nil {
 		return err
 	}
 	d.Set("ipaddress", ip)
@@ -502,105 +336,125 @@ func setServerResourceData(ctx context.Context, d *schema.ResourceData, client *
 	return nil
 }
 
-func configDiskSync(ctx context.Context, client *APIClient, zone string, id types.ID, editReq *sacloud.DiskEditRequest) error {
-	diskOp := sacloud.NewDiskOp(client)
-	if err := diskOp.Config(ctx, zone, id, editReq); err != nil {
-		return err
+func expandServerBuilder(d *schema.ResourceData, client *APIClient) *serverBuilder.Builder {
+	return &serverBuilder.Builder{
+		ServerID:        sakuraCloudID(d.Id()),
+		Name:            d.Get("name").(string),
+		CPU:             d.Get("core").(int),
+		MemoryGB:        d.Get("memory").(int),
+		Commitment:      types.ECommitment(d.Get("commitment").(string)),
+		Generation:      types.PlanGenerations.Default,
+		InterfaceDriver: types.EInterfaceDriver(d.Get("interface_driver").(string)),
+		Description:     d.Get("description").(string),
+		IconID:          expandSakuraCloudID(d, "icon_id"),
+		Tags:            expandTags(d),
+		CDROMID:         expandSakuraCloudID(d, "cdrom_id"),
+		PrivateHostID:   expandSakuraCloudID(d, "private_host_id"),
+		NIC:             expandServerNIC(d),
+		AdditionalNICs:  expandServerAdditionalNICs(d),
+		DiskBuilders:    expandServerDisks(d, client),
+		Client:          serverBuilder.NewBuildersAPIClient(client),
+		ForceShutdown:   d.Get("force_shutdown").(bool),
+		BootAfterCreate: true,
 	}
-	waiter := sacloud.WaiterForReady(func() (interface{}, error) {
-		return diskOp.Read(ctx, zone, id)
-	})
-	if _, err := waiter.WaitForState(ctx); err != nil {
-		return err
-	}
-	return nil
 }
 
-func serverNetworkAttrsCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
-	nic := ""
-	if d.HasChange("nic") {
-		_, v := d.GetChange("nic")
-		if v != nil {
-			nic = v.(string)
+func expandServerDisks(d *schema.ResourceData, client *APIClient) []diskBuilder.Builder {
+	var builders []diskBuilder.Builder
+	diskIDs := expandSakuraCloudIDs(d, "disks")
+	for i, diskID := range diskIDs {
+		b := &diskBuilder.ConnectedDiskBuilder{
+			ID:     diskID,
+			Client: diskBuilder.NewBuildersAPIClient(client),
 		}
-	} else {
-		v := d.Get("nic")
-		if v != nil {
-			nic = v.(string)
-		}
-	}
-
-	if nic == "shared" {
-		targets := []string{"ipaddress", "gateway"}
-		for _, t := range targets {
-			o, n := d.GetChange(t)
-			if o != nil && o.(string) != "" && n != nil {
-				d.Clear(t)
+		if i == 0 && isServerDiskConfigChanged(d) {
+			b.EditParameter = &diskBuilder.UnixEditRequest{
+				HostName:            d.Get("hostname").(string),
+				Password:            d.Get("password").(string),
+				DisablePWAuth:       d.Get("disable_pw_auth").(bool),
+				EnableDHCP:          false, // 項目追加
+				ChangePartitionUUID: false, // 項目追加
+				IPAddress:           d.Get("ipaddress").(string),
+				NetworkMaskLen:      d.Get("nw_mask_len").(int),
+				DefaultRoute:        d.Get("gateway").(string),
+				SSHKeyIDs:           expandSakuraCloudIDs(d, "ssh_key_ids"),
+				NoteIDs:             expandSakuraCloudIDs(d, "note_ids"),
 			}
 		}
-		o, n := d.GetChange("nw_mask_len")
-		if o != nil && o.(int) != 0 && n != nil {
-			d.Clear("nw_mask_len")
-		}
+		builders = append(builders, b)
 	}
-	return nil
+	return builders
 }
 
-func expandConnectedSwitches(d resourceValueGettable) []*sacloud.ConnectedSwitch {
-	var switches []*sacloud.ConnectedSwitch
+func expandServerNIC(d resourceValueGettable) serverBuilder.NICSettingHolder {
+	nics := d.Get("nics").([]interface{})
+	if len(nics) == 0 {
+		return nil
+	}
 
-	var primary *sacloud.ConnectedSwitch
-	nic := d.Get("nic").(string)
-	switch nic {
+	d = mapToResourceData(nics[0].(map[string]interface{}))
+	upstream := d.Get("upstream").(string)
+	switch upstream {
 	case "", "shared":
-		primary = &sacloud.ConnectedSwitch{
-			Scope: types.Scopes.Shared,
+		return &serverBuilder.SharedNICSetting{
+			PacketFilterID: expandSakuraCloudID(d, "packet_filter_id"),
 		}
 	case "disconnect":
-		primary = nil
+		return &serverBuilder.DisconnectedNICSetting{}
 	default:
-		primary = &sacloud.ConnectedSwitch{
-			ID: sakuraCloudID(nic),
+		return &serverBuilder.ConnectedNICSetting{
+			SwitchID:       sakuraCloudID(upstream),
+			PacketFilterID: expandSakuraCloudID(d, "packet_filter_id"),
 		}
 	}
-	switches = append(switches, primary)
-
-	additionalNICs := expandSakuraCloudIDs(d, "additional_nics")
-	for _, id := range additionalNICs {
-		var cs *sacloud.ConnectedSwitch
-		if !id.IsEmpty() {
-			cs = &sacloud.ConnectedSwitch{ID: id}
-		}
-		switches = append(switches, cs)
-	}
-
-	return switches
 }
 
-func flattenServerNIC(server *sacloud.Server) string {
-	hasFirstInterface := len(server.Interfaces) > 0
-	if hasFirstInterface {
-		nic := server.Interfaces[0]
-		if nic.SwitchID.IsEmpty() {
-			return "disconnect"
-		}
-		if nic.SwitchScope == types.Scopes.Shared {
-			return "shared"
-		}
-		return nic.SwitchID.String()
-	}
-	return ""
-}
+func expandServerAdditionalNICs(d resourceValueGettable) []serverBuilder.AdditionalNICSettingHolder {
+	var results []serverBuilder.AdditionalNICSettingHolder
 
-func flattenServerAdditionalNICs(server *sacloud.Server) []string {
-	var additionalNICs []string
-	for i, iface := range server.Interfaces {
+	nics := d.Get("nics").([]interface{})
+	if len(nics) < 2 {
+		return results
+	}
+
+	for i, nic := range nics {
 		if i == 0 {
 			continue
 		}
-		additionalNICs = append(additionalNICs, iface.SwitchID.String())
+		d = mapToResourceData(nic.(map[string]interface{}))
+		upstream := d.Get("upstream").(string)
+		switch upstream {
+		case "disconnect":
+			results = append(results, &serverBuilder.DisconnectedNICSetting{})
+		default:
+			results = append(results, &serverBuilder.ConnectedNICSetting{
+				SwitchID:       sakuraCloudID(upstream),
+				PacketFilterID: expandSakuraCloudID(d, "packet_filter_id"),
+			})
+		}
 	}
-	return additionalNICs
+	return results
+}
+
+func flattenServerNICs(server *sacloud.Server) []interface{} {
+	var results []interface{}
+	for _, nic := range server.Interfaces {
+		var upstream string
+		switch {
+		case nic.SwitchID.IsEmpty():
+			upstream = "disconnect"
+		case nic.SwitchScope == types.Scopes.Shared:
+			upstream = "shared"
+		default:
+			upstream = nic.SwitchID.String()
+		}
+		results = append(results, map[string]interface{}{
+			"upstream":         upstream,
+			"packet_filter_id": nic.PacketFilterID.String(),
+			"macaddress":       strings.ToLower(nic.MACAddress),
+		})
+	}
+	return results
 }
 
 func flattenServerConnectedDiskIDs(server *sacloud.Server) []string {
@@ -611,26 +465,8 @@ func flattenServerConnectedDiskIDs(server *sacloud.Server) []string {
 	return ids
 }
 
-func flattenServerConnectedPacketFilterIDs(server *sacloud.Server) []string {
-	var ids []string
-	for _, nic := range server.Interfaces {
-		if !nic.PacketFilterID.IsEmpty() {
-			ids = append(ids, nic.PacketFilterID.String())
-		}
-	}
-	return ids
-}
-
-func flattenServerMACAddresses(server *sacloud.Server) []string {
-	var macs []string
-	for _, nic := range server.Interfaces {
-		macs = append(macs, strings.ToLower(nic.MACAddress))
-	}
-	return macs
-}
-
 func flattenServerNetworkInfo(server *sacloud.Server) (ip, gateway string, nwMaskLen int, nwAddress string) {
-	if !server.Interfaces[0].SwitchID.IsEmpty() {
+	if len(server.Interfaces) > 0 && !server.Interfaces[0].SwitchID.IsEmpty() {
 		nic := server.Interfaces[0]
 		if nic.SwitchScope == types.Scopes.Shared {
 			ip = nic.IPAddress
@@ -644,76 +480,9 @@ func flattenServerNetworkInfo(server *sacloud.Server) (ip, gateway string, nwMas
 	return
 }
 
-func expandDiskEditSSHKeys(d resourceValueGettable) []*sacloud.DiskEditSSHKey {
-	var keys []*sacloud.DiskEditSSHKey
-	ids := expandSakuraCloudIDs(d, "ssh_key_ids")
-	for _, id := range ids {
-		keys = append(keys, &sacloud.DiskEditSSHKey{ID: id})
-	}
-	return keys
-}
-
-func expandDiskEditNotes(d resourceValueGettable) []*sacloud.DiskEditNote {
-	var notes []*sacloud.DiskEditNote
-	ids := expandSakuraCloudIDs(d, "note_ids")
-	for _, id := range ids {
-		notes = append(notes, &sacloud.DiskEditNote{ID: id})
-	}
-	return notes
-}
-
-func expandDiskEditUserSubnet(d resourceValueGettable) *sacloud.DiskEditUserSubnet {
-	maskLen := d.Get("nw_mask_len").(int)
-	gateway := d.Get("gateway").(string)
-	if maskLen != 0 && gateway != "" {
-		return &sacloud.DiskEditUserSubnet{
-			DefaultRoute:   gateway,
-			NetworkMaskLen: maskLen,
-		}
-	}
-	return nil
-}
-
-func expandDiskEditRequest(d resourceValueGettable) *sacloud.DiskEditRequest {
-
-	editReq := &sacloud.DiskEditRequest{
-		Background:          true,
-		Password:            d.Get("password").(string),
-		SSHKeys:             expandDiskEditSSHKeys(d),
-		DisablePWAuth:       d.Get("disable_pw_auth").(bool),
-		EnableDHCP:          false, // TODO 項目追加
-		ChangePartitionUUID: false, // TODO 項目追加
-		HostName:            d.Get("hostname").(string),
-		Notes:               expandDiskEditNotes(d),
-		UserIPAddress:       d.Get("ipaddress").(string),
-		UserSubnet:          expandDiskEditUserSubnet(d),
-	}
-
-	if isNeedDiskEdit(editReq) {
-		return editReq
-	}
-	return nil
-}
-
-func isNeedDiskEdit(req *sacloud.DiskEditRequest) bool {
-	return req.Password != "" ||
-		len(req.SSHKeys) > 0 ||
-		req.DisablePWAuth ||
-		req.EnableDHCP ||
-		req.ChangePartitionUUID ||
-		req.HostName != "" ||
-		len(req.Notes) > 0 ||
-		req.UserIPAddress != "" ||
-		req.UserSubnet != nil
-}
-
-func isServerPlanChanged(d *schema.ResourceData) bool {
-	return d.HasChange("core") || d.HasChange("memory") || d.HasChange("commitment")
-}
-
 func isServerDiskConfigChanged(d *schema.ResourceData) bool {
 	return d.HasChange("disks") ||
-		d.HasChange("nic") ||
+		d.HasChange("nics") ||
 		d.HasChange("ipaddress") ||
 		d.HasChange("gateway") ||
 		d.HasChange("nw_mask_len") ||
@@ -722,159 +491,4 @@ func isServerDiskConfigChanged(d *schema.ResourceData) bool {
 		d.HasChange("ssh_key_ids") ||
 		d.HasChange("disable_pw_auth") ||
 		d.HasChange("note_ids")
-}
-
-func validateServerPlan(ctx context.Context, client *APIClient, d resourceValueGettable) error {
-	zone := getZone(d, client)
-	_, err := serverUtil.FindPlan(ctx, sacloud.NewServerPlanOp(client), zone, &serverUtil.FindPlanRequest{
-		CPU:        d.Get("core").(int),
-		MemoryGB:   d.Get("memory").(int),
-		Commitment: types.ECommitment(d.Get("commitment").(string)),
-		Generation: types.PlanGenerations.Default,
-	})
-	if err != nil {
-		return fmt.Errorf("server plan is not found. Please change 'core' or 'memory' or 'commitment': %s", err)
-	}
-	return nil
-}
-
-func reconcileServerDisks(ctx context.Context, client *APIClient, d resourceValueGettable, server *sacloud.Server) error {
-	diskOp := sacloud.NewDiskOp(client)
-	zone := getZone(d, client)
-
-	//disconnect all old disks
-	for _, disk := range server.Disks {
-		if err := diskOp.DisconnectFromServer(ctx, zone, disk.ID); err != nil {
-			return fmt.Errorf("disconnecting Disk[%s] from Server[%s] is failed: %s", disk.ID, server.ID, err)
-		}
-	}
-
-	diskIDs := expandSakuraCloudIDs(d, "disks")
-	for _, diskID := range diskIDs {
-		if err := diskOp.ConnectToServer(ctx, zone, diskID, server.ID); err != nil {
-			return fmt.Errorf("connecting Disk[%s] to Server[%s] is failed: %s", diskID, server.ID, err)
-		}
-	}
-	return nil
-}
-
-func reconcileServerPacketFilters(ctx context.Context, client *APIClient, d resourceValueGettable, server *sacloud.Server) error {
-	interfaceOp := sacloud.NewInterfaceOp(client)
-	zone := getZone(d, client)
-	pfIDs := expandSakuraCloudIDs(d, "packet_filter_ids")
-
-	//disconnect
-	for i, nic := range server.Interfaces {
-		if !nic.PacketFilterID.IsEmpty() {
-			if err := interfaceOp.DisconnectFromPacketFilter(ctx, zone, nic.ID); err != nil {
-				return fmt.Errorf("disconnecting PacketFilter[%s] is failed: %s", nic.PacketFilterID, err)
-			}
-		}
-		if len(pfIDs) > i {
-			pfID := pfIDs[i]
-			if err := interfaceOp.ConnectToPacketFilter(ctx, zone, nic.ID, pfID); err != nil {
-				return fmt.Errorf("connecting PacketFilter[%s] is failed: %s", pfID, err)
-			}
-		}
-	}
-	return nil
-}
-
-func reconcileServerNICs(ctx context.Context, client *APIClient, d *schema.ResourceData, server *sacloud.Server) error {
-	interfaceOp := sacloud.NewInterfaceOp(client)
-	zone := getZone(d, client)
-
-	nicConf := []string{d.Get("nic").(string)}
-	additionalIDs := expandSakuraCloudIDs(d, "additional_nics")
-	for _, id := range additionalIDs {
-		nicConf = append(nicConf, id.String())
-	}
-
-	// disconnect&delete unnecessary interfaces
-	for i, nic := range server.Interfaces {
-		if i < len(nicConf) {
-			continue
-		}
-		if !nic.SwitchID.IsEmpty() {
-			if err := interfaceOp.DisconnectFromSwitch(ctx, zone, nic.ID); err != nil {
-				return fmt.Errorf("disconnecting Interface[%s] from Switch[%s] is failed: %s", nic.ID, nic.SwitchID, err)
-			}
-		}
-		if err := interfaceOp.Delete(ctx, zone, nic.ID); err != nil {
-			return fmt.Errorf("deleting Interface[%s] is failed: %s", nic.ID, err)
-		}
-	}
-
-	if len(nicConf) == 0 {
-		return nil
-	}
-
-	for i, nic := range nicConf {
-		if err := reconcileServerInterfaceConnection(ctx, client, zone, nic, i, server); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type serverConnectedNIC interface {
-	GetID() types.ID
-	GetSwitchID() types.ID
-	GetSwitchScope() types.EScope
-}
-
-func reconcileServerInterfaceConnection(ctx context.Context, client *APIClient, zone, nicConf string, nicIndex int, server *sacloud.Server) error {
-	interfaceOp := sacloud.NewInterfaceOp(client)
-
-	var nic serverConnectedNIC
-	if len(server.Interfaces) <= nicIndex {
-		newNIC, err := interfaceOp.Create(ctx, zone, &sacloud.InterfaceCreateRequest{ServerID: server.ID})
-		if err != nil {
-			return err
-		}
-		nic = newNIC
-	} else {
-		nic = server.Interfaces[nicIndex]
-	}
-
-	switch nicConf {
-	case "shared":
-		if nic.GetSwitchScope() != types.Scopes.Shared {
-			// disconnect if already connected
-			if !nic.GetSwitchID().IsEmpty() {
-				if err := interfaceOp.DisconnectFromSwitch(ctx, zone, nic.GetID()); err != nil {
-					return fmt.Errorf("disconnecting Interface[%s] from Switch[%s] is failed: %s", nic.GetID(), nic.GetSwitchID(), err)
-				}
-			}
-			// connect to shared segment
-			if err := interfaceOp.ConnectToSharedSegment(ctx, zone, nic.GetID()); err != nil {
-				return fmt.Errorf("connecting Interface[%s] to SharedSegment is failed: %s", nic.GetID(), err)
-			}
-		}
-	case "disconnect":
-		// disconnect if already connected
-		if !nic.GetSwitchID().IsEmpty() {
-			if err := interfaceOp.DisconnectFromSwitch(ctx, zone, nic.GetID()); err != nil {
-				return fmt.Errorf("disconnecting Interface[%s] from Switch[%s] is failed: %s", nic.GetID(), nic.GetSwitchID(), err)
-			}
-		}
-	default:
-		switchID := sakuraCloudID(nicConf)
-		if !nic.GetSwitchID().IsEmpty() && nic.GetSwitchID() != switchID {
-			if err := interfaceOp.DisconnectFromSwitch(ctx, zone, nic.GetID()); err != nil {
-				return fmt.Errorf("disconnecting Interface[%s] from Switch[%s] is failed: %s", nic.GetID(), nic.GetSwitchID(), err)
-			}
-		}
-
-		if nic.GetSwitchID() != switchID {
-			// connect to switch
-			if !switchID.IsEmpty() {
-				if err := interfaceOp.ConnectToSwitch(ctx, zone, nic.GetID(), switchID); err != nil {
-					return fmt.Errorf("connecting Interface[%s] to Switch[%s] is failed: %s", nic.GetID(), switchID, err)
-				}
-			}
-		}
-
-	}
-	return nil
 }

--- a/sakuracloud/resource_sakuracloud_server_test.go
+++ b/sakuracloud/resource_sakuracloud_server_test.go
@@ -65,11 +65,12 @@ func TestAccResourceSakuraCloudServer(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_server.foobar", "note_ids.0", "100000000000"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nic", "shared"),
+						"sakuracloud_server.foobar", "nics.#", "1"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "additional_nics.#", "0"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "macaddresses.#", "1"),
+						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
+					resource.TestMatchResourceAttr("sakuracloud_server.foobar",
+						"nics.0.macaddress",
+						regexp.MustCompile(".+")), // should be not empty
 					resource.TestMatchResourceAttr("sakuracloud_server.foobar",
 						"ipaddress",
 						regexp.MustCompile(".+")), // should be not empty
@@ -95,11 +96,7 @@ func TestAccResourceSakuraCloudServer(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_server.foobar", "tags.0", "tag2"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nic", "shared"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "additional_nics.#", "0"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "macaddresses.#", "1"),
+						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
 					resource.TestMatchResourceAttr("sakuracloud_server.foobar",
 						"nw_address",
 						regexp.MustCompile(".+")), // should be not empty
@@ -123,11 +120,9 @@ func TestAccSakuraCloudServer_EditConnections(t *testing.T) {
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					testAccCheckSakuraCloudServerAttributes(&server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nic", "shared"),
-					resource.TestCheckNoResourceAttr(
-						"sakuracloud_server.foobar", "additional_nics"),
+						"sakuracloud_server.foobar", "nics.#", "1"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "macaddresses.#", "1"),
+						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
 				),
 			},
 			{
@@ -136,11 +131,9 @@ func TestAccSakuraCloudServer_EditConnections(t *testing.T) {
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					testAccCheckSakuraCloudServerAttributes(&server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nic", "shared"),
+						"sakuracloud_server.foobar", "nics.#", "2"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "additional_nics.#", "1"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "macaddresses.#", "2"),
+						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
 				),
 			},
 			{
@@ -149,11 +142,9 @@ func TestAccSakuraCloudServer_EditConnections(t *testing.T) {
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					testAccCheckSakuraCloudServerAttributes(&server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nic", "shared"),
+						"sakuracloud_server.foobar", "nics.#", "4"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "additional_nics.#", "3"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "macaddresses.#", "4"),
+						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
 				),
 			},
 			{
@@ -162,11 +153,9 @@ func TestAccSakuraCloudServer_EditConnections(t *testing.T) {
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					testAccCheckSakuraCloudServerAttributesWithoutSharedInterface(&server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nic", "disconnect"),
+						"sakuracloud_server.foobar", "nics.#", "2"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "additional_nics.#", "1"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "macaddresses.#", "2"),
+						"sakuracloud_server.foobar", "nics.0.upstream", "disconnect"),
 				),
 			},
 		},
@@ -183,21 +172,35 @@ func TestAccSakuraCloudServer_ConnectPacketFilters(t *testing.T) {
 				Config: testAccCheckSakuraCloudServerConfig_with_packet_filter,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "packet_filter_ids.#", "2"),
+						"sakuracloud_server.foobar", "nics.#", "2"),
+					resource.TestCheckResourceAttrPair(
+						"sakuracloud_server.foobar", "nics.0.packet_filter_id",
+						"sakuracloud_packet_filter.foobar", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"sakuracloud_server.foobar", "nics.1.packet_filter_id",
+						"sakuracloud_packet_filter.foobar", "id",
+					),
 				),
 			},
 			{
 				Config: testAccCheckSakuraCloudServerConfig_with_packet_filter_upd,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "packet_filter_ids.#", "1"),
+						"sakuracloud_server.foobar", "nics.#", "1"),
+					resource.TestCheckResourceAttrPair(
+						"sakuracloud_server.foobar", "nics.0.packet_filter_id",
+						"sakuracloud_packet_filter.foobar", "id",
+					),
 				),
 			},
 			{
 				Config: testAccCheckSakuraCloudServerConfig_with_packet_filter_del,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "packet_filter_ids.#", "0"),
+						"sakuracloud_server.foobar", "nics.#", "1"),
+					resource.TestCheckResourceAttr(
+						"sakuracloud_server.foobar", "nics.0.packet_filter_id", ""),
 				),
 			},
 		},
@@ -205,6 +208,7 @@ func TestAccSakuraCloudServer_ConnectPacketFilters(t *testing.T) {
 }
 
 func TestAccSakuraCloudServer_With_PrivateHost(t *testing.T) {
+	skipIfFakeModeEnabled(t)
 
 	privateHostID, ok := os.LookupEnv("SAKURACLOUD_PRIVATE_HOST_ID")
 	if !ok {
@@ -263,9 +267,13 @@ func TestAccSakuraCloudServer_EditConnect_With_Same_Switch(t *testing.T) {
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					testAccCheckSakuraCloudServerAttributes(&server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nic", "shared"),
+						"sakuracloud_server.foobar", "nics.#", "2"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "additional_nics.#", "1"),
+						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
+					resource.TestCheckResourceAttrPair(
+						"sakuracloud_server.foobar", "nics.1.upstream",
+						"sakuracloud_switch.foobar", "id",
+					),
 					func(s *terraform.State) error {
 						if server.Interfaces[1].SwitchID.IsEmpty() {
 							return errors.New("Server.Interfaces[1].Switch is nil")
@@ -279,37 +287,18 @@ func TestAccSakuraCloudServer_EditConnect_With_Same_Switch(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "additional_nics.#", "1"),
+						"sakuracloud_server.foobar", "nics.#", "2"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "additional_nics.0", ""),
+						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
 					func(s *terraform.State) error {
-						if server.Interfaces[0].SwitchID.IsEmpty() {
-							return errors.New("Server.Interfaces[0].Switch is nil")
+						if !server.Interfaces[1].SwitchID.IsEmpty() {
+							return errors.New("Server.Interfaces[1].Switch is not empty")
 						}
-						if server.Interfaces[0].SwitchScope == types.Scopes.Shared {
-							return errors.New("Server.Interfaces[0].Switch is connecting to shared segment")
+						if server.Interfaces[1].SwitchScope == types.Scopes.Shared {
+							return errors.New("Server.Interfaces[1].Switch is connecting to shared segment")
 						}
 						return nil
 					},
-				),
-			},
-		},
-	})
-}
-
-func TestAccSakuraCloudServer_NIC_CustomDiff(t *testing.T) {
-	var server sacloud.Server
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSakuraCloudServerDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckSakuraCloudServerConfig_nic_custom_diff,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
-					testAccCheckSakuraCloudServerAttributes(&server),
-					resource.TestCheckResourceAttr("sakuracloud_server.foobar", "ipaddress", ""),
 				),
 			},
 		},
@@ -428,23 +417,25 @@ data "sakuracloud_archive" "ubuntu" {
   os_type = "ubuntu"
 }
 resource "sakuracloud_disk" "foobar" {
-    name = "mydisk"
-    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
+  name              = "mydisk"
+  source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 
 resource "sakuracloud_server" "foobar" {
-    name = "myserver"
-    disks = ["${sakuracloud_disk.foobar.id}"]
-    description = "Server from TerraForm for SAKURA CLOUD"
-    tags = ["tag1"]
-    icon_id = "${sakuracloud_icon.foobar.id}"
+  name = "myserver"
+  disks = ["${sakuracloud_disk.foobar.id}"]
+  description = "Server from TerraForm for SAKURA CLOUD"
+  tags = ["tag1"]
+  icon_id = "${sakuracloud_icon.foobar.id}"
+  nics {
+    upstream = "shared"
+  }
 
-    hostname = "myserver"
-    password = "p@ssw0rd"
-    ssh_key_ids = ["100000000000", "200000000000"]
-    disable_pw_auth = true
-    note_ids = ["100000000000", "200000000000"]
-
+  hostname = "myserver"
+  password = "p@ssw0rd"
+  ssh_key_ids = ["100000000000", "200000000000"]
+  disable_pw_auth = true
+  note_ids = ["100000000000", "200000000000"]
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -459,40 +450,55 @@ data "sakuracloud_archive" "ubuntu" {
 }
 
 resource "sakuracloud_disk" "foobar" {
-    name = "mydisk"
-    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
+  name = "mydisk"
+  source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 
 resource "sakuracloud_server" "foobar" {
-    name = "myserver_after"
-    disks = ["${sakuracloud_disk.foobar.id}"]
-    core = 2
-    memory = 2
-    description = "Server from TerraForm for SAKURA CLOUD"
-    tags = ["tag2"]
-    interface_driver = "e1000"
+  name = "myserver_after"
+  disks = ["${sakuracloud_disk.foobar.id}"]
+  core = 2
+  memory = 2
+  description = "Server from TerraForm for SAKURA CLOUD"
+  tags = ["tag2"]
+  interface_driver = "e1000"
+  nics {
+    upstream = "shared"
+  }
 }
 `
 
 const testAccCheckSakuraCloudServerConfig_swiched_NIC_basic = `
 resource "sakuracloud_server" "foobar" {
-    name = "myserver"
-    description = "Server from TerraForm for SAKURA CLOUD"
-    tags = ["tag1"]
+  name = "myserver"
+  description = "Server from TerraForm for SAKURA CLOUD"
+  tags = ["tag1"]
+  nics {
+    upstream = "shared"
+  }
 
-    hostname = "myserver"
-    password = "p@ssw0rd"
-    ssh_key_ids = ["100000000000", "200000000000"]
-    disable_pw_auth = true
-    note_ids = ["100000000000", "200000000000"]
+  hostname = "myserver"
+  password = "p@ssw0rd"
+  ssh_key_ids = ["100000000000", "200000000000"]
+  disable_pw_auth = true
+  note_ids = ["100000000000", "200000000000"]
+
+  force_shutdown = true
 }
 `
 
 const testAccCheckSakuraCloudServerConfig_swiched_NIC_added = `
 resource "sakuracloud_server" "foobar" {
-    name = "myserver"
-    description = "Server from TerraForm for SAKURA CLOUD"
-    additional_nics = [sakuracloud_switch.sw1.id]
+  name = "myserver"
+  description = "Server from TerraForm for SAKURA CLOUD"
+  nics {
+    upstream = "shared"
+  }
+  nics {
+    upstream = sakuracloud_switch.sw1.id
+  }
+
+  force_shutdown = true
 }
 resource "sakuracloud_switch" "sw1" {
   name = "terraform-test-switch1"
@@ -500,10 +506,24 @@ resource "sakuracloud_switch" "sw1" {
 `
 const testAccCheckSakuraCloudServerConfig_swiched_NIC_updated = `
 resource "sakuracloud_server" "foobar" {
-    name = "myserver"
-    description = "Server from TerraForm for SAKURA CLOUD"
-    additional_nics = [sakuracloud_switch.sw1.id, sakuracloud_switch.sw2.id, sakuracloud_switch.sw3.id]
+  name = "myserver"
+  description = "Server from TerraForm for SAKURA CLOUD"
+  nics {
+    upstream = "shared"
+  }
+  nics {
+    upstream = sakuracloud_switch.sw1.id
+  }
+  nics {
+    upstream = sakuracloud_switch.sw2.id
+  }
+  nics {
+    upstream = sakuracloud_switch.sw3.id
+  }
+
+  force_shutdown = true
 }
+
 resource "sakuracloud_switch" "sw1" {
   name = "terraform-test-switch1"
 }
@@ -517,10 +537,16 @@ resource "sakuracloud_switch" "sw3" {
 
 const testAccCheckSakuraCloudServerConfig_nw_nothing = `
 resource "sakuracloud_server" "foobar" {
-    name = "myserver"
-    description = "Server from TerraForm for SAKURA CLOUD"
-    nic = "disconnect"
-    additional_nics = [sakuracloud_switch.sw1.id]
+  name = "myserver"
+  description = "Server from TerraForm for SAKURA CLOUD"
+  nics {
+    upstream = "disconnect"
+  }
+  nics {
+    upstream = sakuracloud_switch.sw1.id
+  }
+
+  force_shutdown = true
 }
 resource "sakuracloud_switch" "sw1" {
   name = "terraform-test-switch1"
@@ -540,9 +566,16 @@ resource "sakuracloud_packet_filter" "foobar" {
 }
 resource "sakuracloud_server" "foobar" {
   name = "terraform-test-server"
-  nic = "shared"
-  additional_nics = [sakuracloud_switch.foobar.id]
-  packet_filter_ids = [sakuracloud_packet_filter.foobar.id , sakuracloud_packet_filter.foobar.id]
+  nics {
+    upstream = "shared"
+    packet_filter_id = sakuracloud_packet_filter.foobar.id
+  }
+  nics {
+    upstream = sakuracloud_switch.foobar.id
+    packet_filter_id = sakuracloud_packet_filter.foobar.id
+  }
+
+  force_shutdown = true
 }
 
 resource "sakuracloud_switch" "foobar" {
@@ -551,47 +584,45 @@ resource "sakuracloud_switch" "foobar" {
 `
 
 const testAccCheckSakuraCloudServerConfig_with_packet_filter_upd = `
-resource "sakuracloud_packet_filter" "foobar1" {
-    name = "mypacket_filter1"
-    description = "PacketFilter from TerraForm for SAKURA CLOUD"
-    expressions {
-    	protocol = "udp"
-    	source_network = "0.0.0.0"
-    	source_port = "0-65535"
-    	destination_port = "80"
-    	allow = true
-    }
-}
-resource "sakuracloud_packet_filter" "foobar2" {
-    name = "mypacket_filter2"
-    description = "PacketFilter from TerraForm for SAKURA CLOUD"
-    expressions {
-    	protocol = "udp"
-    	source_network = "0.0.0.0"
-    	source_port = "0-65535"
-    	destination_port = "80"
-    	allow = true
-    }
+resource "sakuracloud_packet_filter" "foobar" {
+  name = "mypacket_filter1"
+  description = "PacketFilter from TerraForm for SAKURA CLOUD"
+  expressions {
+  	protocol = "udp"
+  	source_network = "0.0.0.0"
+  	source_port = "0-65535"
+  	destination_port = "80"
+  	allow = true
+  }
 }
 resource "sakuracloud_server" "foobar" {
-    name = "myserver_upd"
-    nic = "shared"
-    packet_filter_ids = ["${sakuracloud_packet_filter.foobar1.id}"]
+  name = "myserver_upd"
+  nics {
+    upstream = "shared"
+    packet_filter_id = sakuracloud_packet_filter.foobar.id
+  }
+  force_shutdown = true
 }
 
 `
 
 const testAccCheckSakuraCloudServerConfig_with_packet_filter_del = `
 resource "sakuracloud_server" "foobar" {
-    name = "myserver_del"
-    nic = "shared"
+  name = "myserver_del"
+  nics {
+    upstream = "shared"
+  }
+  force_shutdown = true
 }`
 
 const testAccCheckSakuraCloudServerConfig_with_blank_disk = `
 resource "sakuracloud_server" "foobar" {
-    name = "myserver_with_blank"
-    nic = "shared"
-    disks = ["${sakuracloud_disk.foobar.id}"]
+  name = "myserver_with_blank"
+  disks = ["${sakuracloud_disk.foobar.id}"]
+  nics {
+    upstream = "shared"
+  }
+  force_shutdown = true
 }
 resource "sakuracloud_disk" "foobar" {
     name = "mydisk"
@@ -603,9 +634,14 @@ resource "sakuracloud_switch" "foobar" {
     name = "foobar"
 }
 resource "sakuracloud_server" "foobar" {
-    name = "foobar"
-    nic = "shared"
-    additional_nics = ["${sakuracloud_switch.foobar.id}"]
+  name = "foobar"
+  nics {
+    upstream = "shared"
+  }
+  nics {
+    upstream = sakuracloud_switch.foobar.id
+  }
+  force_shutdown = true
 }
 `
 
@@ -614,24 +650,24 @@ resource "sakuracloud_switch" "foobar" {
     name = "foobar"
 }
 resource "sakuracloud_server" "foobar" {
-    name = "foobar"
-    nic = "${sakuracloud_switch.foobar.id}"
-    additional_nics = [""]
+  name = "foobar"
+  nics {
+    upstream = "shared"
+  }
+  nics {
+    upstream = "disconnect"
+  }
+
+  force_shutdown = true
 }
 `
 
 const testAccCheckSakuraCloudServerConfig_with_private_host_template = `
 resource "sakuracloud_server" "foobar" {
-    name            = "myserver_with_private_host"
-    private_host_id = "%s"
-}
-`
+  name            = "myserver_with_private_host"
+  private_host_id = "%s"
 
-const testAccCheckSakuraCloudServerConfig_nic_custom_diff = `
-resource "sakuracloud_server" "foobar" {
-    name      = "foobar"
-    nic       = "shared"
-    ipaddress = ""
+  force_shutdown = true
 }
 `
 
@@ -640,48 +676,20 @@ data "sakuracloud_archive" "ubuntu" {
   os_type = "ubuntu"
 }
 resource "sakuracloud_disk" "foobar" {
-    name = "mydisk"
-    source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
+  name = "mydisk"
+  source_archive_id = "${data.sakuracloud_archive.ubuntu.id}"
 }
 resource "sakuracloud_switch" "foobar" {
-    name = "foobar"
+  name = "foobar"
 }
 resource "sakuracloud_server" "foobar" {
-    name        = "foobar"
-    disks       = ["${sakuracloud_disk.foobar.id}"]
-    nic         = "${sakuracloud_switch.foobar.id}"
-    ipaddress   = "192.168.0.2"
-    nw_mask_len = 24
-    gateway     = "192.168.0.1"
-}
-`
-
-const testAccCheckSakuraCloudServerConfig_display_ipaddress = `
-resource sakuracloud_switch "sw" {
-  count = 3
-  name = "sakuracloud_test_switch"
-}
-
-resource sakuracloud_server "switched" {
-  name              = "sakuracloud_test_connect_to_switched"
-  nic               = "${sakuracloud_switch.sw.0.id}"
-  display_ipaddress = "192.2.0.1"
-
-  additional_nics                = ["${sakuracloud_switch.sw.1.id}", "${sakuracloud_switch.sw.2.id}"]
-  additional_display_ipaddresses = ["192.2.1.1", "192.2.2.1"]
-}
-`
-const testAccCheckSakuraCloudServerConfig_display_ipaddress_upd = `
-resource sakuracloud_switch "sw" {
-  count = 3
-  name = "sakuracloud_test_switch"
-}
-
-resource sakuracloud_server "switched" {
-  name              = "sakuracloud_test_connect_to_switched"
-  nic               = "${sakuracloud_switch.sw.0.id}"
-  display_ipaddress = "192.2.0.2"
-  additional_nics   = ["${sakuracloud_switch.sw.1.id}", "${sakuracloud_switch.sw.2.id}"]
-  additional_display_ipaddresses = ["192.2.1.2", "192.2.2.2"]
+  name        = "foobar"
+  disks       = ["${sakuracloud_disk.foobar.id}"]
+  nics {
+    upstream = sakuracloud_switch.foobar.id
+  }
+  ipaddress   = "192.168.0.2"
+  nw_mask_len = 24
+  gateway     = "192.168.0.1"
 }
 `

--- a/sakuracloud/resource_sakuracloud_server_test.go
+++ b/sakuracloud/resource_sakuracloud_server_test.go
@@ -65,11 +65,11 @@ func TestAccResourceSakuraCloudServer(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_server.foobar", "note_ids.0", "100000000000"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.#", "1"),
+						"sakuracloud_server.foobar", "interfaces.#", "1"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
+						"sakuracloud_server.foobar", "interfaces.0.upstream", "shared"),
 					resource.TestMatchResourceAttr("sakuracloud_server.foobar",
-						"nics.0.macaddress",
+						"interfaces.0.macaddress",
 						regexp.MustCompile(".+")), // should be not empty
 					resource.TestMatchResourceAttr("sakuracloud_server.foobar",
 						"ipaddress",
@@ -96,7 +96,7 @@ func TestAccResourceSakuraCloudServer(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"sakuracloud_server.foobar", "tags.0", "tag2"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
+						"sakuracloud_server.foobar", "interfaces.0.upstream", "shared"),
 					resource.TestMatchResourceAttr("sakuracloud_server.foobar",
 						"nw_address",
 						regexp.MustCompile(".+")), // should be not empty
@@ -120,9 +120,9 @@ func TestAccSakuraCloudServer_EditConnections(t *testing.T) {
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					testAccCheckSakuraCloudServerAttributes(&server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.#", "1"),
+						"sakuracloud_server.foobar", "interfaces.#", "1"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
+						"sakuracloud_server.foobar", "interfaces.0.upstream", "shared"),
 				),
 			},
 			{
@@ -131,9 +131,9 @@ func TestAccSakuraCloudServer_EditConnections(t *testing.T) {
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					testAccCheckSakuraCloudServerAttributes(&server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.#", "2"),
+						"sakuracloud_server.foobar", "interfaces.#", "2"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
+						"sakuracloud_server.foobar", "interfaces.0.upstream", "shared"),
 				),
 			},
 			{
@@ -142,9 +142,9 @@ func TestAccSakuraCloudServer_EditConnections(t *testing.T) {
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					testAccCheckSakuraCloudServerAttributes(&server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.#", "4"),
+						"sakuracloud_server.foobar", "interfaces.#", "4"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
+						"sakuracloud_server.foobar", "interfaces.0.upstream", "shared"),
 				),
 			},
 			{
@@ -153,9 +153,9 @@ func TestAccSakuraCloudServer_EditConnections(t *testing.T) {
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					testAccCheckSakuraCloudServerAttributesWithoutSharedInterface(&server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.#", "2"),
+						"sakuracloud_server.foobar", "interfaces.#", "2"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.0.upstream", "disconnect"),
+						"sakuracloud_server.foobar", "interfaces.0.upstream", "disconnect"),
 				),
 			},
 		},
@@ -172,13 +172,13 @@ func TestAccSakuraCloudServer_ConnectPacketFilters(t *testing.T) {
 				Config: testAccCheckSakuraCloudServerConfig_with_packet_filter,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.#", "2"),
+						"sakuracloud_server.foobar", "interfaces.#", "2"),
 					resource.TestCheckResourceAttrPair(
-						"sakuracloud_server.foobar", "nics.0.packet_filter_id",
+						"sakuracloud_server.foobar", "interfaces.0.packet_filter_id",
 						"sakuracloud_packet_filter.foobar", "id",
 					),
 					resource.TestCheckResourceAttrPair(
-						"sakuracloud_server.foobar", "nics.1.packet_filter_id",
+						"sakuracloud_server.foobar", "interfaces.1.packet_filter_id",
 						"sakuracloud_packet_filter.foobar", "id",
 					),
 				),
@@ -187,9 +187,9 @@ func TestAccSakuraCloudServer_ConnectPacketFilters(t *testing.T) {
 				Config: testAccCheckSakuraCloudServerConfig_with_packet_filter_upd,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.#", "1"),
+						"sakuracloud_server.foobar", "interfaces.#", "1"),
 					resource.TestCheckResourceAttrPair(
-						"sakuracloud_server.foobar", "nics.0.packet_filter_id",
+						"sakuracloud_server.foobar", "interfaces.0.packet_filter_id",
 						"sakuracloud_packet_filter.foobar", "id",
 					),
 				),
@@ -198,9 +198,9 @@ func TestAccSakuraCloudServer_ConnectPacketFilters(t *testing.T) {
 				Config: testAccCheckSakuraCloudServerConfig_with_packet_filter_del,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.#", "1"),
+						"sakuracloud_server.foobar", "interfaces.#", "1"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.0.packet_filter_id", ""),
+						"sakuracloud_server.foobar", "interfaces.0.packet_filter_id", ""),
 				),
 			},
 		},
@@ -267,11 +267,11 @@ func TestAccSakuraCloudServer_EditConnect_With_Same_Switch(t *testing.T) {
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					testAccCheckSakuraCloudServerAttributes(&server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.#", "2"),
+						"sakuracloud_server.foobar", "interfaces.#", "2"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
+						"sakuracloud_server.foobar", "interfaces.0.upstream", "shared"),
 					resource.TestCheckResourceAttrPair(
-						"sakuracloud_server.foobar", "nics.1.upstream",
+						"sakuracloud_server.foobar", "interfaces.1.upstream",
 						"sakuracloud_switch.foobar", "id",
 					),
 					func(s *terraform.State) error {
@@ -287,9 +287,9 @@ func TestAccSakuraCloudServer_EditConnect_With_Same_Switch(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSakuraCloudServerExists("sakuracloud_server.foobar", &server),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.#", "2"),
+						"sakuracloud_server.foobar", "interfaces.#", "2"),
 					resource.TestCheckResourceAttr(
-						"sakuracloud_server.foobar", "nics.0.upstream", "shared"),
+						"sakuracloud_server.foobar", "interfaces.0.upstream", "shared"),
 					func(s *terraform.State) error {
 						if !server.Interfaces[1].SwitchID.IsEmpty() {
 							return errors.New("Server.Interfaces[1].Switch is not empty")
@@ -427,7 +427,7 @@ resource "sakuracloud_server" "foobar" {
   description = "Server from TerraForm for SAKURA CLOUD"
   tags = ["tag1"]
   icon_id = "${sakuracloud_icon.foobar.id}"
-  nics {
+  interfaces {
     upstream = "shared"
   }
 
@@ -462,7 +462,7 @@ resource "sakuracloud_server" "foobar" {
   description = "Server from TerraForm for SAKURA CLOUD"
   tags = ["tag2"]
   interface_driver = "e1000"
-  nics {
+  interfaces {
     upstream = "shared"
   }
 }
@@ -473,7 +473,7 @@ resource "sakuracloud_server" "foobar" {
   name = "myserver"
   description = "Server from TerraForm for SAKURA CLOUD"
   tags = ["tag1"]
-  nics {
+  interfaces {
     upstream = "shared"
   }
 
@@ -491,10 +491,10 @@ const testAccCheckSakuraCloudServerConfig_swiched_NIC_added = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver"
   description = "Server from TerraForm for SAKURA CLOUD"
-  nics {
+  interfaces {
     upstream = "shared"
   }
-  nics {
+  interfaces {
     upstream = sakuracloud_switch.sw1.id
   }
 
@@ -508,16 +508,16 @@ const testAccCheckSakuraCloudServerConfig_swiched_NIC_updated = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver"
   description = "Server from TerraForm for SAKURA CLOUD"
-  nics {
+  interfaces {
     upstream = "shared"
   }
-  nics {
+  interfaces {
     upstream = sakuracloud_switch.sw1.id
   }
-  nics {
+  interfaces {
     upstream = sakuracloud_switch.sw2.id
   }
-  nics {
+  interfaces {
     upstream = sakuracloud_switch.sw3.id
   }
 
@@ -539,10 +539,10 @@ const testAccCheckSakuraCloudServerConfig_nw_nothing = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver"
   description = "Server from TerraForm for SAKURA CLOUD"
-  nics {
+  interfaces {
     upstream = "disconnect"
   }
-  nics {
+  interfaces {
     upstream = sakuracloud_switch.sw1.id
   }
 
@@ -566,11 +566,11 @@ resource "sakuracloud_packet_filter" "foobar" {
 }
 resource "sakuracloud_server" "foobar" {
   name = "terraform-test-server"
-  nics {
+  interfaces {
     upstream = "shared"
     packet_filter_id = sakuracloud_packet_filter.foobar.id
   }
-  nics {
+  interfaces {
     upstream = sakuracloud_switch.foobar.id
     packet_filter_id = sakuracloud_packet_filter.foobar.id
   }
@@ -597,7 +597,7 @@ resource "sakuracloud_packet_filter" "foobar" {
 }
 resource "sakuracloud_server" "foobar" {
   name = "myserver_upd"
-  nics {
+  interfaces {
     upstream = "shared"
     packet_filter_id = sakuracloud_packet_filter.foobar.id
   }
@@ -609,7 +609,7 @@ resource "sakuracloud_server" "foobar" {
 const testAccCheckSakuraCloudServerConfig_with_packet_filter_del = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver_del"
-  nics {
+  interfaces {
     upstream = "shared"
   }
   force_shutdown = true
@@ -619,7 +619,7 @@ const testAccCheckSakuraCloudServerConfig_with_blank_disk = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver_with_blank"
   disks = ["${sakuracloud_disk.foobar.id}"]
-  nics {
+  interfaces {
     upstream = "shared"
   }
   force_shutdown = true
@@ -635,10 +635,10 @@ resource "sakuracloud_switch" "foobar" {
 }
 resource "sakuracloud_server" "foobar" {
   name = "foobar"
-  nics {
+  interfaces {
     upstream = "shared"
   }
-  nics {
+  interfaces {
     upstream = sakuracloud_switch.foobar.id
   }
   force_shutdown = true
@@ -651,10 +651,10 @@ resource "sakuracloud_switch" "foobar" {
 }
 resource "sakuracloud_server" "foobar" {
   name = "foobar"
-  nics {
+  interfaces {
     upstream = "shared"
   }
-  nics {
+  interfaces {
     upstream = "disconnect"
   }
 
@@ -685,7 +685,7 @@ resource "sakuracloud_switch" "foobar" {
 resource "sakuracloud_server" "foobar" {
   name        = "foobar"
   disks       = ["${sakuracloud_disk.foobar.id}"]
-  nics {
+  interfaces {
     upstream = sakuracloud_switch.foobar.id
   }
   ipaddress   = "192.168.0.2"

--- a/sakuracloud/resource_sakuracloud_switch_test.go
+++ b/sakuracloud/resource_sakuracloud_switch_test.go
@@ -134,7 +134,12 @@ var testAccCheckSakuraCloudSwitchConfig_update = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver"
   description = "Server from TerraForm for SAKURA CLOUD"
-  additional_nics = ["${sakuracloud_switch.foobar.id}"]
+  nics {
+    upstream = "shared"
+  }
+  nics {
+    upstream = sakuracloud_switch.foobar.id
+  }
 }
 resource "sakuracloud_switch" "foobar" {
   name = "myswitch_upd"

--- a/sakuracloud/resource_sakuracloud_switch_test.go
+++ b/sakuracloud/resource_sakuracloud_switch_test.go
@@ -134,10 +134,10 @@ var testAccCheckSakuraCloudSwitchConfig_update = `
 resource "sakuracloud_server" "foobar" {
   name = "myserver"
   description = "Server from TerraForm for SAKURA CLOUD"
-  nics {
+  interfaces {
     upstream = "shared"
   }
-  nics {
+  interfaces {
     upstream = sakuracloud_switch.foobar.id
   }
 }

--- a/sakuracloud/validators.go
+++ b/sakuracloud/validators.go
@@ -42,6 +42,22 @@ func validateSakuracloudIDType(v interface{}, k string) ([]string, []error) {
 	return ws, errors
 }
 
+func validateSakuraCloudServerNIC(v interface{}, k string) ([]string, []error) {
+	var ws []string
+	var errors []error
+
+	value := v.(string)
+	if value == "" || value == "shared" || value == "disconnect" {
+		return ws, errors
+	}
+	_, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q must be ID string(number only): %s", k, err))
+
+	}
+	return ws, errors
+}
+
 func validateBackupWeekdays(d resourceValueGettable, k string) error {
 	weekdays, ok := d.GetOk(k)
 	if !ok || len(weekdays.([]interface{})) == 0 {

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_server.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_server.go
@@ -280,6 +280,13 @@ func (o *ServerOp) ChangePlan(ctx context.Context, zone string, id types.ID, pla
 			putDisk(zone, disk)
 		}
 	}
+	for _, nic := range newServer.Interfaces {
+		iface, err := NewInterfaceOp().Read(ctx, zone, nic.ID)
+		if err == nil {
+			iface.ServerID = newServer.ID
+			putInterface(zone, iface)
+		}
+	}
 
 	return newServer, nil
 }

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/disk/api_client.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/disk/api_client.go
@@ -1,0 +1,84 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// APIClient builderが利用するAPIクライアント群
+type APIClient struct {
+	Archive  ArchiveFinder
+	Disk     CreateDiskHandler
+	DiskPlan PlanReader
+	Note     NoteHandler
+	SSHKey   SSHKeyHandler
+}
+
+// ArchiveFinder アーカイブ検索のためのインターフェース
+type ArchiveFinder interface {
+	Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ArchiveFindResult, error)
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.Archive, error)
+}
+
+// CreateDiskHandler ディスク操作のためのインターフェース
+type CreateDiskHandler interface {
+	Create(ctx context.Context, zone string, createParam *sacloud.DiskCreateRequest, distantFrom []types.ID) (*sacloud.Disk, error)
+	CreateWithConfig(
+		ctx context.Context,
+		zone string,
+		createParam *sacloud.DiskCreateRequest,
+		editParam *sacloud.DiskEditRequest,
+		bootAtAvailable bool,
+		distantFrom []types.ID,
+	) (*sacloud.Disk, error)
+	Update(ctx context.Context, zone string, id types.ID, updateParam *sacloud.DiskUpdateRequest) (*sacloud.Disk, error)
+	Config(ctx context.Context, zone string, id types.ID, editParam *sacloud.DiskEditRequest) error
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.Disk, error)
+	ConnectToServer(ctx context.Context, zone string, id types.ID, serverID types.ID) error
+}
+
+// PlanReader ディスクプラン取得のためのインターフェース
+type PlanReader interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.DiskPlan, error)
+}
+
+// NoteHandler スタートアップスクリプト参照のためのインターフェース
+type NoteHandler interface {
+	Read(ctx context.Context, id types.ID) (*sacloud.Note, error)
+	Create(ctx context.Context, param *sacloud.NoteCreateRequest) (*sacloud.Note, error)
+	Delete(ctx context.Context, id types.ID) error
+}
+
+// SSHKeyHandler SSHKey参照のためのインターフェース
+type SSHKeyHandler interface {
+	Read(ctx context.Context, id types.ID) (*sacloud.SSHKey, error)
+	Generate(ctx context.Context, param *sacloud.SSHKeyGenerateRequest) (*sacloud.SSHKeyGenerated, error)
+	Delete(ctx context.Context, id types.ID) error
+}
+
+// NewBuildersAPIClient APIクライアントの作成
+func NewBuildersAPIClient(caller sacloud.APICaller) *APIClient {
+	return &APIClient{
+		Archive:  sacloud.NewArchiveOp(caller),
+		Disk:     sacloud.NewDiskOp(caller),
+		DiskPlan: sacloud.NewDiskPlanOp(caller),
+		Note:     sacloud.NewNoteOp(caller),
+		SSHKey:   sacloud.NewSSHKeyOp(caller),
+	}
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/disk/builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/disk/builder.go
@@ -605,6 +605,12 @@ func (d *ConnectedDiskBuilder) Build(ctx context.Context, zone string, serverID 
 		if err := d.Client.Disk.Config(ctx, zone, d.ID, req); err != nil {
 			return nil, err
 		}
+		waiter := sacloud.WaiterForReady(func() (interface{}, error) {
+			return d.Client.Disk.Read(ctx, zone, d.ID)
+		})
+		if _, err := waiter.WaitForState(ctx); err != nil {
+			return nil, err
+		}
 	}
 	return res, nil
 }
@@ -622,6 +628,12 @@ func (d *ConnectedDiskBuilder) Update(ctx context.Context, zone string) (*Update
 			return nil, err
 		}
 		if err := d.Client.Disk.Config(ctx, zone, d.ID, req); err != nil {
+			return nil, err
+		}
+		waiter := sacloud.WaiterForReady(func() (interface{}, error) {
+			return d.Client.Disk.Read(ctx, zone, d.ID)
+		})
+		if _, err := waiter.WaitForState(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/disk/builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/disk/builder.go
@@ -1,0 +1,788 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/sacloud/libsacloud/v2/utils/builder"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	archiveUtil "github.com/sacloud/libsacloud/v2/utils/archive"
+)
+
+// Builder ディスクの構築インターフェース
+type Builder interface {
+	Validate(ctx context.Context, zone string) error
+	Build(ctx context.Context, zone string, serverID types.ID) (*BuildResult, error)
+	Update(ctx context.Context, zone string) (*UpdateResult, error)
+	DiskID() types.ID
+	UpdateLevel(ctx context.Context, zone string, disk *sacloud.Disk) builder.UpdateLevel
+}
+
+// BuildResult ディスク構築結果
+type BuildResult struct {
+	DiskID          types.ID
+	GeneratedSSHKey *sacloud.SSHKeyGenerated
+}
+
+// UpdateResult ディスク更新結果
+type UpdateResult struct {
+	Disk *sacloud.Disk
+}
+
+// FromUnixBuilder Unix系パブリックアーカイブからディスクを作成するリクエスト
+type FromUnixBuilder struct {
+	OSType ostype.ArchiveOSType
+
+	Name        string
+	SizeGB      int
+	DistantFrom []types.ID
+	PlanID      types.ID
+	Connection  types.EDiskConnection
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+
+	EditParameter *UnixEditRequest
+
+	Client *APIClient
+
+	ID types.ID
+
+	generatedSSHKey *sacloud.SSHKeyGenerated
+	generatedNotes  []*sacloud.Note
+}
+
+// Validate 設定値の検証
+func (d *FromUnixBuilder) Validate(ctx context.Context, zone string) error {
+	if !d.OSType.IsSupportDiskEdit() {
+		return fmt.Errorf("invalid OSType: %s", d.OSType.String())
+	}
+	if err := validateDiskPlan(ctx, d.Client, zone, d.PlanID, d.SizeGB); err != nil {
+		return err
+	}
+
+	if d.EditParameter != nil {
+		return d.EditParameter.Validate(ctx, d.Client)
+	}
+	return nil
+}
+
+// Build ディスクの構築
+func (d *FromUnixBuilder) Build(ctx context.Context, zone string, serverID types.ID) (*BuildResult, error) {
+	res, err := build(ctx, d.Client, zone, serverID, d.DistantFrom, d)
+	if err != nil {
+		return nil, err
+	}
+	d.ID = res.DiskID
+
+	if d.generatedSSHKey != nil {
+		res.GeneratedSSHKey = d.generatedSSHKey
+	}
+
+	if d.EditParameter != nil {
+		if d.EditParameter.IsSSHKeysEphemeral {
+			if err := d.Client.SSHKey.Delete(ctx, d.generatedSSHKey.ID); err != nil {
+				return nil, err
+			}
+		}
+		if d.EditParameter.IsNotesEphemeral {
+			for _, note := range d.generatedNotes {
+				if err := d.Client.Note.Delete(ctx, note.ID); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return res, nil
+}
+
+// Update ディスクの更新
+func (d *FromUnixBuilder) Update(ctx context.Context, zone string) (*UpdateResult, error) {
+	return update(ctx, d.Client, zone, d)
+}
+
+// DiskID ディスクID取得
+func (d *FromUnixBuilder) DiskID() types.ID {
+	return d.ID
+}
+
+// UpdateLevel Update時にどのレベルの変更が必要か
+func (d *FromUnixBuilder) UpdateLevel(ctx context.Context, zone string, disk *sacloud.Disk) builder.UpdateLevel {
+	return updateLevel(disk, d.EditParameter != nil, d)
+}
+
+func (d *FromUnixBuilder) updateDiskParameter() *sacloud.DiskUpdateRequest {
+	return &sacloud.DiskUpdateRequest{
+		Name:        d.Name,
+		Description: d.Description,
+		Tags:        d.Tags,
+		IconID:      d.IconID,
+		Connection:  d.Connection,
+	}
+}
+
+func (d *FromUnixBuilder) createDiskParameter(ctx context.Context, client *APIClient, zone string, serverID types.ID) (*sacloud.DiskCreateRequest, *sacloud.DiskEditRequest, error) {
+	archive, err := archiveUtil.FindByOSType(ctx, client.Archive, zone, d.OSType)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	createReq := &sacloud.DiskCreateRequest{
+		DiskPlanID:      d.PlanID,
+		SizeMB:          d.SizeGB * 1024,
+		Connection:      d.Connection,
+		SourceArchiveID: archive.ID,
+		ServerID:        serverID,
+		Name:            d.Name,
+		Description:     d.Description,
+		Tags:            d.Tags,
+		IconID:          d.IconID,
+	}
+
+	var editReq *sacloud.DiskEditRequest
+	if d.EditParameter != nil {
+		req, sshKey, notes, err := d.EditParameter.prepareDiskEditParameter(ctx, client)
+		if err != nil {
+			return nil, nil, err
+		}
+		editReq = req
+		if sshKey != nil {
+			d.generatedSSHKey = sshKey
+		}
+		if len(notes) > 0 {
+			d.generatedNotes = notes
+		}
+	}
+
+	return createReq, editReq, nil
+}
+
+// FromFixedArchiveBuilder ディスクの修正をサポートしないパブリックアーカイブからディスクを作成するリクエスト
+type FromFixedArchiveBuilder struct {
+	OSType ostype.ArchiveOSType
+
+	Name        string
+	SizeGB      int
+	DistantFrom []types.ID
+	PlanID      types.ID
+	Connection  types.EDiskConnection
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+
+	Client *APIClient
+
+	ID types.ID
+
+	generatedSSHKey *sacloud.SSHKeyGenerated
+	generatedNotes  []*sacloud.Note
+}
+
+// Validate 設定値の検証
+func (d *FromFixedArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	if d.OSType.IsSupportDiskEdit() || d.OSType.IsWindows() {
+		return fmt.Errorf("invalid OSType: %s", d.OSType.String())
+	}
+	if err := validateDiskPlan(ctx, d.Client, zone, d.PlanID, d.SizeGB); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Build ディスクの構築
+func (d *FromFixedArchiveBuilder) Build(ctx context.Context, zone string, serverID types.ID) (*BuildResult, error) {
+	res, err := build(ctx, d.Client, zone, serverID, d.DistantFrom, d)
+	if err != nil {
+		return nil, err
+	}
+	d.ID = res.DiskID
+	if d.generatedSSHKey != nil {
+		res.GeneratedSSHKey = d.generatedSSHKey
+	}
+	return res, nil
+}
+
+// Update ディスクの更新
+func (d *FromFixedArchiveBuilder) Update(ctx context.Context, zone string) (*UpdateResult, error) {
+	return update(ctx, d.Client, zone, d)
+}
+
+// DiskID ディスクID取得
+func (d *FromFixedArchiveBuilder) DiskID() types.ID {
+	return d.ID
+}
+
+// UpdateLevel Update時にどのレベルの変更が必要か
+func (d *FromFixedArchiveBuilder) UpdateLevel(ctx context.Context, zone string, disk *sacloud.Disk) builder.UpdateLevel {
+	return updateLevel(disk, false, d)
+}
+
+func (d *FromFixedArchiveBuilder) updateDiskParameter() *sacloud.DiskUpdateRequest {
+	return &sacloud.DiskUpdateRequest{
+		Name:        d.Name,
+		Description: d.Description,
+		Tags:        d.Tags,
+		IconID:      d.IconID,
+		Connection:  d.Connection,
+	}
+}
+
+func (d *FromFixedArchiveBuilder) createDiskParameter(ctx context.Context, client *APIClient, zone string, serverID types.ID) (*sacloud.DiskCreateRequest, *sacloud.DiskEditRequest, error) {
+	archive, err := archiveUtil.FindByOSType(ctx, client.Archive, zone, d.OSType)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	createReq := &sacloud.DiskCreateRequest{
+		DiskPlanID:      d.PlanID,
+		SizeMB:          d.SizeGB * 1024,
+		Connection:      d.Connection,
+		SourceArchiveID: archive.ID,
+		ServerID:        serverID,
+		Name:            d.Name,
+		Description:     d.Description,
+		Tags:            d.Tags,
+		IconID:          d.IconID,
+	}
+	return createReq, nil, nil
+}
+
+// FromWindowsBuilder Windows系パブリックアーカイブからディスクを作成するリクエスト
+type FromWindowsBuilder struct {
+	OSType ostype.ArchiveOSType
+
+	Name        string
+	SizeGB      int
+	DistantFrom []types.ID
+	PlanID      types.ID
+	Connection  types.EDiskConnection
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+
+	EditParameter *WindowsEditRequest
+
+	Client *APIClient
+
+	ID types.ID
+}
+
+// Validate 設定値の検証
+func (d *FromWindowsBuilder) Validate(ctx context.Context, zone string) error {
+	if !d.OSType.IsWindows() {
+		return fmt.Errorf("invalid OSType: %s", d.OSType.String())
+	}
+	if err := validateDiskPlan(ctx, d.Client, zone, d.PlanID, d.SizeGB); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Build ディスクの構築
+func (d *FromWindowsBuilder) Build(ctx context.Context, zone string, serverID types.ID) (*BuildResult, error) {
+	res, err := build(ctx, d.Client, zone, serverID, d.DistantFrom, d)
+	if err != nil {
+		return nil, err
+	}
+	d.ID = res.DiskID
+	return res, nil
+}
+
+// Update ディスクの更新
+func (d *FromWindowsBuilder) Update(ctx context.Context, zone string) (*UpdateResult, error) {
+	return update(ctx, d.Client, zone, d)
+}
+
+// DiskID ディスクID取得
+func (d *FromWindowsBuilder) DiskID() types.ID {
+	return d.ID
+}
+
+// UpdateLevel Update時にどのレベルの変更が必要か
+func (d *FromWindowsBuilder) UpdateLevel(ctx context.Context, zone string, disk *sacloud.Disk) builder.UpdateLevel {
+	return updateLevel(disk, d.EditParameter != nil, d)
+}
+
+func (d *FromWindowsBuilder) updateDiskParameter() *sacloud.DiskUpdateRequest {
+	return &sacloud.DiskUpdateRequest{
+		Name:        d.Name,
+		Description: d.Description,
+		Tags:        d.Tags,
+		IconID:      d.IconID,
+		Connection:  d.Connection,
+	}
+}
+
+func (d *FromWindowsBuilder) createDiskParameter(ctx context.Context, client *APIClient, zone string, serverID types.ID) (*sacloud.DiskCreateRequest, *sacloud.DiskEditRequest, error) {
+	archive, err := archiveUtil.FindByOSType(ctx, client.Archive, zone, d.OSType)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	createReq := &sacloud.DiskCreateRequest{
+		DiskPlanID:      d.PlanID,
+		SizeMB:          d.SizeGB * 1024,
+		Connection:      d.Connection,
+		SourceArchiveID: archive.ID,
+		ServerID:        serverID,
+		Name:            d.Name,
+		Description:     d.Description,
+		Tags:            d.Tags,
+		IconID:          d.IconID,
+	}
+
+	var editReq *sacloud.DiskEditRequest
+	if d.EditParameter != nil {
+		editReq = d.EditParameter.prepareDiskEditParameter()
+	}
+
+	return createReq, editReq, nil
+}
+
+// FromDiskOrArchiveBuilder ディスクorアーカイブからディスクを作成するリクエスト
+//
+// ディスクの修正が可能かは実行時にさくらのクラウドAPI側にて判定される
+type FromDiskOrArchiveBuilder struct {
+	SourceDiskID    types.ID
+	SourceArchiveID types.ID
+
+	Name        string
+	SizeGB      int
+	DistantFrom []types.ID
+	PlanID      types.ID
+	Connection  types.EDiskConnection
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+
+	EditParameter *UnixEditRequest
+
+	Client *APIClient
+
+	ID types.ID
+
+	generatedSSHKey *sacloud.SSHKeyGenerated
+	generatedNotes  []*sacloud.Note
+}
+
+// Validate 設定値の検証
+func (d *FromDiskOrArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	if d.SourceArchiveID.IsEmpty() && d.SourceDiskID.IsEmpty() {
+		return errors.New("SourceArchiveID or SourceDiskID is required")
+	}
+	if err := validateDiskPlan(ctx, d.Client, zone, d.PlanID, d.SizeGB); err != nil {
+		return err
+	}
+
+	if !d.SourceArchiveID.IsEmpty() {
+		if _, err := d.Client.Archive.Read(ctx, zone, d.SourceArchiveID); err != nil {
+			return err
+		}
+	}
+	if !d.SourceDiskID.IsEmpty() {
+		if _, err := d.Client.Disk.Read(ctx, zone, d.SourceDiskID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Build ディスクの構築
+func (d *FromDiskOrArchiveBuilder) Build(ctx context.Context, zone string, serverID types.ID) (*BuildResult, error) {
+	res, err := build(ctx, d.Client, zone, serverID, d.DistantFrom, d)
+	if err != nil {
+		return nil, err
+	}
+	d.ID = res.DiskID
+	if d.generatedSSHKey != nil {
+		res.GeneratedSSHKey = d.generatedSSHKey
+	}
+
+	if d.EditParameter != nil {
+		if d.EditParameter.IsSSHKeysEphemeral {
+			if err := d.Client.SSHKey.Delete(ctx, d.generatedSSHKey.ID); err != nil {
+				return nil, err
+			}
+		}
+		if d.EditParameter.IsNotesEphemeral {
+			for _, note := range d.generatedNotes {
+				if err := d.Client.Note.Delete(ctx, note.ID); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return res, nil
+}
+
+// Update ディスクの更新
+func (d *FromDiskOrArchiveBuilder) Update(ctx context.Context, zone string) (*UpdateResult, error) {
+	return update(ctx, d.Client, zone, d)
+}
+
+// DiskID ディスクID取得
+func (d *FromDiskOrArchiveBuilder) DiskID() types.ID {
+	return d.ID
+}
+
+// UpdateLevel Update時にどのレベルの変更が必要か
+func (d *FromDiskOrArchiveBuilder) UpdateLevel(ctx context.Context, zone string, disk *sacloud.Disk) builder.UpdateLevel {
+	return updateLevel(disk, d.EditParameter != nil, d)
+}
+
+func (d *FromDiskOrArchiveBuilder) updateDiskParameter() *sacloud.DiskUpdateRequest {
+	return &sacloud.DiskUpdateRequest{
+		Name:        d.Name,
+		Description: d.Description,
+		Tags:        d.Tags,
+		IconID:      d.IconID,
+		Connection:  d.Connection,
+	}
+}
+
+func (d *FromDiskOrArchiveBuilder) createDiskParameter(ctx context.Context, client *APIClient, zone string, serverID types.ID) (*sacloud.DiskCreateRequest, *sacloud.DiskEditRequest, error) {
+	createReq := &sacloud.DiskCreateRequest{
+		DiskPlanID:      d.PlanID,
+		SizeMB:          d.SizeGB * 1024,
+		Connection:      d.Connection,
+		SourceArchiveID: d.SourceArchiveID,
+		SourceDiskID:    d.SourceDiskID,
+		ServerID:        serverID,
+		Name:            d.Name,
+		Description:     d.Description,
+		Tags:            d.Tags,
+		IconID:          d.IconID,
+	}
+
+	var editReq *sacloud.DiskEditRequest
+	if d.EditParameter != nil {
+		req, sshKey, notes, err := d.EditParameter.prepareDiskEditParameter(ctx, client)
+		if err != nil {
+			return nil, nil, err
+		}
+		editReq = req
+		if sshKey != nil {
+			d.generatedSSHKey = sshKey
+		}
+		if len(notes) > 0 {
+			d.generatedNotes = notes
+		}
+	}
+
+	return createReq, editReq, nil
+}
+
+// BlankBuilder ブランクディスクを作成する場合のリクエスト
+type BlankBuilder struct {
+	Name        string
+	SizeGB      int
+	DistantFrom []types.ID
+	PlanID      types.ID
+	Connection  types.EDiskConnection
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+
+	Client *APIClient
+
+	ID types.ID
+}
+
+// Validate 設定値の検証
+func (d *BlankBuilder) Validate(ctx context.Context, zone string) error {
+	if err := validateDiskPlan(ctx, d.Client, zone, d.PlanID, d.SizeGB); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Build ディスクの構築
+func (d *BlankBuilder) Build(ctx context.Context, zone string, serverID types.ID) (*BuildResult, error) {
+	res, err := build(ctx, d.Client, zone, serverID, d.DistantFrom, d)
+	if err != nil {
+		return nil, err
+	}
+	d.ID = res.DiskID
+	return res, err
+}
+
+// Update ディスクの更新
+func (d *BlankBuilder) Update(ctx context.Context, zone string) (*UpdateResult, error) {
+	return update(ctx, d.Client, zone, d)
+}
+
+// DiskID ディスクID取得
+func (d *BlankBuilder) DiskID() types.ID {
+	return d.ID
+}
+
+// UpdateLevel Update時にどのレベルの変更が必要か
+func (d *BlankBuilder) UpdateLevel(ctx context.Context, zone string, disk *sacloud.Disk) builder.UpdateLevel {
+	return updateLevel(disk, false, d)
+}
+
+func (d *BlankBuilder) updateDiskParameter() *sacloud.DiskUpdateRequest {
+	return &sacloud.DiskUpdateRequest{
+		Name:        d.Name,
+		Description: d.Description,
+		Tags:        d.Tags,
+		IconID:      d.IconID,
+		Connection:  d.Connection,
+	}
+}
+
+func (d *BlankBuilder) createDiskParameter(ctx context.Context, client *APIClient, zone string, serverID types.ID) (*sacloud.DiskCreateRequest, *sacloud.DiskEditRequest, error) {
+	createReq := &sacloud.DiskCreateRequest{
+		DiskPlanID:  d.PlanID,
+		SizeMB:      d.SizeGB * 1024,
+		Connection:  d.Connection,
+		ServerID:    serverID,
+		Name:        d.Name,
+		Description: d.Description,
+		Tags:        d.Tags,
+		IconID:      d.IconID,
+	}
+	return createReq, nil, nil
+}
+
+// ConnectedDiskBuilder 既存ディスクを接続する場合のリクエスト
+type ConnectedDiskBuilder struct {
+	ID            types.ID
+	EditParameter *UnixEditRequest
+
+	Client *APIClient
+}
+
+// Validate 設定値の検証
+func (d *ConnectedDiskBuilder) Validate(ctx context.Context, zone string) error {
+	if d.ID.IsEmpty() {
+		return errors.New("DiskID is required")
+	}
+
+	if _, err := d.Client.Disk.Read(ctx, zone, d.ID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Build ディスクの構築
+func (d *ConnectedDiskBuilder) Build(ctx context.Context, zone string, serverID types.ID) (*BuildResult, error) {
+	res := &BuildResult{
+		DiskID: d.ID,
+	}
+	if !serverID.IsEmpty() {
+		if err := d.Client.Disk.ConnectToServer(ctx, zone, d.ID, serverID); err != nil {
+			return nil, err
+		}
+	}
+
+	if d.EditParameter != nil {
+		req, sshKey, _, err := d.EditParameter.prepareDiskEditParameter(ctx, d.Client)
+		if err != nil {
+			return nil, err
+		}
+		res.GeneratedSSHKey = sshKey
+		if err := d.Client.Disk.Config(ctx, zone, d.ID, req); err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+// Update ディスクの更新
+func (d *ConnectedDiskBuilder) Update(ctx context.Context, zone string) (*UpdateResult, error) {
+	disk, err := d.Client.Disk.Read(ctx, zone, d.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if d.EditParameter != nil {
+		req, _, _, err := d.EditParameter.prepareDiskEditParameter(ctx, d.Client)
+		if err != nil {
+			return nil, err
+		}
+		if err := d.Client.Disk.Config(ctx, zone, d.ID, req); err != nil {
+			return nil, err
+		}
+	}
+
+	return &UpdateResult{Disk: disk}, nil
+}
+
+// DiskID ディスクID取得
+func (d *ConnectedDiskBuilder) DiskID() types.ID {
+	return d.ID
+}
+
+// UpdateLevel Update時にどのレベルの変更が必要か
+func (d *ConnectedDiskBuilder) UpdateLevel(ctx context.Context, zone string, disk *sacloud.Disk) builder.UpdateLevel {
+	return updateLevel(disk, d.EditParameter != nil, d)
+}
+
+func (d *ConnectedDiskBuilder) updateDiskParameter() *sacloud.DiskUpdateRequest {
+	return nil
+}
+
+func (d *ConnectedDiskBuilder) createDiskParameter(
+	ctx context.Context,
+	client *APIClient,
+	zone string,
+	serverID types.ID,
+) (*sacloud.DiskCreateRequest, *sacloud.DiskEditRequest, error) {
+	// noop
+	return nil, nil, nil
+}
+
+type diskBuilder interface {
+	createDiskParameter(
+		ctx context.Context,
+		client *APIClient,
+		zone string,
+		serverID types.ID,
+	) (*sacloud.DiskCreateRequest, *sacloud.DiskEditRequest, error)
+	updateDiskParameter() *sacloud.DiskUpdateRequest
+	DiskID() types.ID
+}
+
+func build(ctx context.Context, client *APIClient, zone string, serverID types.ID, distantFrom []types.ID, builder diskBuilder) (*BuildResult, error) {
+	var err error
+
+	diskReq, editReq, err := builder.createDiskParameter(ctx, client, zone, serverID)
+	if err != nil {
+		return nil, err
+	}
+	if diskReq == nil {
+		return nil, fmt.Errorf("disk create request is nil")
+	}
+	diskReq.ServerID = serverID
+
+	var disk *sacloud.Disk
+
+	if editReq == nil {
+		disk, err = client.Disk.Create(ctx, zone, diskReq, distantFrom)
+	} else {
+		disk, err = client.Disk.CreateWithConfig(ctx, zone, diskReq, editReq, false, distantFrom)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	waiter := sacloud.WaiterForReady(func() (interface{}, error) {
+		return client.Disk.Read(ctx, zone, disk.ID)
+	})
+	lastState, err := waiter.WaitForState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	disk = lastState.(*sacloud.Disk)
+
+	return &BuildResult{DiskID: disk.ID}, nil
+}
+
+func update(ctx context.Context, client *APIClient, zone string, builder diskBuilder) (*UpdateResult, error) {
+	var err error
+
+	diskID := builder.DiskID()
+	if diskID.IsEmpty() {
+		return nil, fmt.Errorf("disk id required")
+	}
+
+	diskReq, editReq, err := builder.createDiskParameter(ctx, client, zone, types.ID(0))
+	if err != nil {
+		return nil, err
+	}
+	if diskReq == nil {
+		return nil, fmt.Errorf("disk update request is nil")
+	}
+
+	disk, err := client.Disk.Update(ctx, zone, diskID, &sacloud.DiskUpdateRequest{
+		Name:        diskReq.Name,
+		Description: diskReq.Description,
+		Tags:        diskReq.Tags,
+		IconID:      diskReq.IconID,
+		Connection:  diskReq.Connection,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if editReq != nil {
+		if err := client.Disk.Config(ctx, zone, disk.ID, editReq); err != nil {
+			return nil, err
+		}
+	}
+
+	waiter := sacloud.WaiterForReady(func() (interface{}, error) {
+		return client.Disk.Read(ctx, zone, disk.ID)
+	})
+	lastState, err := waiter.WaitForState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	disk = lastState.(*sacloud.Disk)
+
+	return &UpdateResult{Disk: disk}, nil
+}
+
+func validateDiskPlan(ctx context.Context, client *APIClient, zone string, diskPlanID types.ID, sizeGB int) error {
+	plan, err := client.DiskPlan.Read(ctx, zone, diskPlanID)
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, size := range plan.Size {
+		if size.Availability.IsAvailable() && size.GetSizeGB() == sizeGB {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("disk plan[%s:%dGB] is not found", plan.Name, sizeGB)
+	}
+	return nil
+}
+
+func updateLevel(disk *sacloud.Disk, hasEditReq bool, b diskBuilder) builder.UpdateLevel {
+	if disk.ID != b.DiskID() || hasEditReq {
+		return builder.UpdateLevelNeedShutdown
+	}
+
+	current := &sacloud.DiskUpdateRequest{
+		Name:        disk.Name,
+		Description: disk.Description,
+		Tags:        disk.Tags,
+		IconID:      disk.IconID,
+		Connection:  disk.Connection,
+	}
+	desired := b.updateDiskParameter()
+	if desired == nil {
+		return builder.UpdateLevelNone
+	}
+	if reflect.DeepEqual(current, desired) {
+		if current.Connection != desired.Connection {
+			return builder.UpdateLevelNeedShutdown
+		}
+		return builder.UpdateLevelSimple
+	}
+	return builder.UpdateLevelNone
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/disk/director.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/disk/director.go
@@ -1,0 +1,125 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// Director パラメータに応じて適切なDiskBuilderを構築する
+type Director struct {
+	OSType ostype.ArchiveOSType
+
+	Name        string
+	SizeGB      int
+	DistantFrom []types.ID
+	PlanID      types.ID
+	Connection  types.EDiskConnection
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+
+	DiskID          types.ID
+	SourceDiskID    types.ID
+	SourceArchiveID types.ID
+
+	EditParameter *EditRequest
+	Client        *APIClient
+}
+
+// Builder パラメータに応じて適切なDiskBuilderを返す
+func (d *Director) Builder() Builder {
+	switch {
+	case d.OSType == ostype.Custom:
+		switch {
+		case !d.DiskID.IsEmpty():
+			return &ConnectedDiskBuilder{
+				ID:            d.DiskID,
+				EditParameter: d.EditParameter.ToUnixDiskEditRequest(),
+				Client:        d.Client,
+			}
+		case !d.SourceDiskID.IsEmpty(), !d.SourceArchiveID.IsEmpty():
+			return &FromDiskOrArchiveBuilder{
+				SourceDiskID:    d.SourceDiskID,
+				SourceArchiveID: d.SourceArchiveID,
+				Name:            d.Name,
+				SizeGB:          d.SizeGB,
+				DistantFrom:     d.DistantFrom,
+				PlanID:          d.PlanID,
+				Connection:      d.Connection,
+				Description:     d.Description,
+				Tags:            d.Tags,
+				IconID:          d.IconID,
+				EditParameter:   d.EditParameter.ToUnixDiskEditRequest(),
+				Client:          d.Client,
+			}
+		default:
+			return &BlankBuilder{
+				Name:        d.Name,
+				SizeGB:      d.SizeGB,
+				DistantFrom: d.DistantFrom,
+				PlanID:      d.PlanID,
+				Connection:  d.Connection,
+				Description: d.Description,
+				Tags:        d.Tags,
+				IconID:      d.IconID,
+				Client:      d.Client,
+			}
+		}
+	case d.OSType.IsSupportDiskEdit():
+		return &FromUnixBuilder{
+			OSType:        d.OSType,
+			Name:          d.Name,
+			SizeGB:        d.SizeGB,
+			DistantFrom:   d.DistantFrom,
+			PlanID:        d.PlanID,
+			Connection:    d.Connection,
+			Description:   d.Description,
+			Tags:          d.Tags,
+			IconID:        d.IconID,
+			EditParameter: d.EditParameter.ToUnixDiskEditRequest(),
+			Client:        d.Client,
+		}
+	case d.OSType.IsWindows():
+		return &FromWindowsBuilder{
+			OSType:        d.OSType,
+			Name:          d.Name,
+			SizeGB:        d.SizeGB,
+			DistantFrom:   d.DistantFrom,
+			PlanID:        d.PlanID,
+			Connection:    d.Connection,
+			Description:   d.Description,
+			Tags:          d.Tags,
+			IconID:        d.IconID,
+			EditParameter: d.EditParameter.ToWindowsDiskEditRequest(),
+			Client:        d.Client,
+		}
+	default:
+		// ディスクの修正をサポートしないものが指定された場合
+		return &FromFixedArchiveBuilder{
+			OSType:      d.OSType,
+			Name:        d.Name,
+			SizeGB:      d.SizeGB,
+			DistantFrom: d.DistantFrom,
+			PlanID:      d.PlanID,
+			Connection:  d.Connection,
+			Description: d.Description,
+			Tags:        d.Tags,
+			IconID:      d.IconID,
+			Client:      d.Client,
+		}
+	}
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/disk/edit_request.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/disk/edit_request.go
@@ -1,0 +1,192 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// EditRequest 汎用ディスクの修正リクエストパラメータ DiskDirectorが利用する
+type EditRequest UnixEditRequest
+
+// ToUnixDiskEditRequest Unix系パラメータへの変換
+func (d *EditRequest) ToUnixDiskEditRequest() *UnixEditRequest {
+	if d == nil {
+		return nil
+	}
+	req := UnixEditRequest(*d)
+	return &req
+}
+
+// ToWindowsDiskEditRequest Windows系パラメータへの変換
+func (d *EditRequest) ToWindowsDiskEditRequest() *WindowsEditRequest {
+	if d == nil {
+		return nil
+	}
+	return &WindowsEditRequest{
+		IPAddress:      d.IPAddress,
+		NetworkMaskLen: d.NetworkMaskLen,
+		DefaultRoute:   d.DefaultRoute,
+	}
+}
+
+// UnixEditRequest Unix系の場合のディスクの修正リクエスト
+type UnixEditRequest struct {
+	HostName string
+	Password string
+
+	DisablePWAuth       bool
+	EnableDHCP          bool
+	ChangePartitionUUID bool
+
+	IPAddress      string
+	NetworkMaskLen int
+	DefaultRoute   string
+
+	SSHKeys   []string
+	SSHKeyIDs []types.ID
+
+	// IsSSHKeysEphemeral trueの場合、SSHキーを生成する場合に生成したSSHキーリソースをサーバ作成後に削除する
+	IsSSHKeysEphemeral bool
+	// GenerateSSHKeyName 設定されていた場合、クラウドAPIを用いてキーペアを生成する。
+	GenerateSSHKeyName        string
+	GenerateSSHKeyPassPhrase  string
+	GenerateSSHKeyDescription string
+
+	IsNotesEphemeral bool
+	Notes            []string
+	NoteIDs          []types.ID
+}
+
+// Validate 設定値の検証
+func (u *UnixEditRequest) Validate(ctx context.Context, client *APIClient) error {
+	for _, id := range u.SSHKeyIDs {
+		if _, err := client.SSHKey.Read(ctx, id); err != nil {
+			return err
+		}
+	}
+	for _, id := range u.NoteIDs {
+		if _, err := client.Note.Read(ctx, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (u *UnixEditRequest) prepareDiskEditParameter(ctx context.Context, client *APIClient) (*sacloud.DiskEditRequest, *sacloud.SSHKeyGenerated, []*sacloud.Note, error) {
+
+	editReq := &sacloud.DiskEditRequest{
+		Background:          true,
+		Password:            u.Password,
+		DisablePWAuth:       u.DisablePWAuth,
+		EnableDHCP:          u.EnableDHCP,
+		ChangePartitionUUID: u.ChangePartitionUUID,
+		HostName:            u.HostName,
+	}
+
+	if u.IPAddress != "" {
+		editReq.UserIPAddress = u.IPAddress
+	}
+	if u.NetworkMaskLen > 0 || u.DefaultRoute != "" {
+		editReq.UserSubnet = &sacloud.DiskEditUserSubnet{
+			NetworkMaskLen: u.NetworkMaskLen,
+			DefaultRoute:   u.DefaultRoute,
+		}
+	}
+
+	// ssh key
+	var sshKeys []*sacloud.DiskEditSSHKey
+	for _, key := range u.SSHKeys {
+		sshKeys = append(sshKeys, &sacloud.DiskEditSSHKey{
+			PublicKey: key,
+		})
+	}
+	for _, id := range u.SSHKeyIDs {
+		sshKeys = append(sshKeys, &sacloud.DiskEditSSHKey{
+			ID: id,
+		})
+	}
+
+	var generatedSSHKey *sacloud.SSHKeyGenerated
+	if u.GenerateSSHKeyName != "" {
+		generated, err := client.SSHKey.Generate(ctx, &sacloud.SSHKeyGenerateRequest{
+			Name:        u.GenerateSSHKeyName,
+			PassPhrase:  u.GenerateSSHKeyPassPhrase,
+			Description: u.GenerateSSHKeyDescription,
+		})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		generatedSSHKey = generated
+		sshKeys = append(sshKeys, &sacloud.DiskEditSSHKey{
+			ID: generated.ID,
+		})
+	}
+	editReq.SSHKeys = sshKeys
+
+	// startup script
+	var notes []*sacloud.DiskEditNote
+	var generatedNotes []*sacloud.Note
+
+	for _, note := range u.Notes {
+		created, err := client.Note.Create(ctx, &sacloud.NoteCreateRequest{
+			Name:    fmt.Sprintf("note-%s", time.Now().Format(time.RFC3339)),
+			Class:   "shell",
+			Content: note,
+		})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		notes = append(notes, &sacloud.DiskEditNote{
+			ID: created.ID,
+		})
+		generatedNotes = append(generatedNotes, created)
+	}
+	for _, id := range u.NoteIDs {
+		notes = append(notes, &sacloud.DiskEditNote{
+			ID: id,
+		})
+	}
+	editReq.Notes = notes
+
+	return editReq, generatedSSHKey, generatedNotes, nil
+}
+
+// WindowsEditRequest Windows系の場合のディスクの修正リクエスト
+type WindowsEditRequest struct {
+	IPAddress      string
+	NetworkMaskLen int
+	DefaultRoute   string
+}
+
+func (w *WindowsEditRequest) prepareDiskEditParameter() *sacloud.DiskEditRequest {
+	editReq := &sacloud.DiskEditRequest{Background: true}
+
+	if w.IPAddress != "" {
+		editReq.UserIPAddress = w.IPAddress
+	}
+	if w.NetworkMaskLen > 0 || w.DefaultRoute != "" {
+		editReq.UserSubnet = &sacloud.DiskEditUserSubnet{
+			NetworkMaskLen: w.NetworkMaskLen,
+			DefaultRoute:   w.DefaultRoute,
+		}
+	}
+	return editReq
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/api_client.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/api_client.go
@@ -1,0 +1,86 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/utils/server"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// APIClient builderが利用するAPIクライアント群
+type APIClient struct {
+	Disk         DiskHandler
+	Interface    InterfaceHandler
+	PacketFilter PacketFilterReader
+	Server       CreateServerHandler
+	ServerPlan   server.PlanFinder
+	Switch       SwitchReader
+}
+
+// DiskHandler ディスクの接続/切断のためのインターフェース
+type DiskHandler interface {
+	ConnectToServer(ctx context.Context, zone string, id types.ID, serverID types.ID) error
+	DisconnectFromServer(ctx context.Context, zone string, id types.ID) error
+}
+
+// SwitchReader スイッチ参照のためのインターフェース
+type SwitchReader interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.Switch, error)
+}
+
+// InterfaceHandler NIC操作のためのインターフェース
+type InterfaceHandler interface {
+	Create(ctx context.Context, zone string, param *sacloud.InterfaceCreateRequest) (*sacloud.Interface, error)
+	Update(ctx context.Context, zone string, id types.ID, param *sacloud.InterfaceUpdateRequest) (*sacloud.Interface, error)
+	Delete(ctx context.Context, zone string, id types.ID) error
+	ConnectToSharedSegment(ctx context.Context, zone string, id types.ID) error
+	ConnectToSwitch(ctx context.Context, zone string, id types.ID, switchID types.ID) error
+	DisconnectFromSwitch(ctx context.Context, zone string, id types.ID) error
+	ConnectToPacketFilter(ctx context.Context, zone string, id types.ID, packetFilterID types.ID) error
+	DisconnectFromPacketFilter(ctx context.Context, zone string, id types.ID) error
+}
+
+// PacketFilterReader パケットフィルタ参照のためのインターフェース
+type PacketFilterReader interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.PacketFilter, error)
+}
+
+// CreateServerHandler サーバ操作のためのインターフェース
+type CreateServerHandler interface {
+	Create(ctx context.Context, zone string, param *sacloud.ServerCreateRequest) (*sacloud.Server, error)
+	Update(ctx context.Context, zone string, id types.ID, param *sacloud.ServerUpdateRequest) (*sacloud.Server, error)
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.Server, error)
+	InsertCDROM(ctx context.Context, zone string, id types.ID, insertParam *sacloud.InsertCDROMRequest) error
+	EjectCDROM(ctx context.Context, zone string, id types.ID, ejectParam *sacloud.EjectCDROMRequest) error
+	Boot(ctx context.Context, zone string, id types.ID) error
+	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error
+	ChangePlan(ctx context.Context, zone string, id types.ID, plan *sacloud.ServerChangePlanRequest) (*sacloud.Server, error)
+}
+
+// NewBuildersAPIClient APIクライアントの作成
+func NewBuildersAPIClient(caller sacloud.APICaller) *APIClient {
+	return &APIClient{
+		Disk:         sacloud.NewDiskOp(caller),
+		Interface:    sacloud.NewInterfaceOp(caller),
+		PacketFilter: sacloud.NewPacketFilterOp(caller),
+		Server:       sacloud.NewServerOp(caller),
+		ServerPlan:   sacloud.NewServerPlanOp(caller),
+		Switch:       sacloud.NewSwitchOp(caller),
+	}
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/builder.go
@@ -638,8 +638,10 @@ func (b *Builder) reconcileInterfaces(ctx context.Context, zone string, server *
 					return err
 				}
 			}
-			if err := b.Client.Interface.ConnectToPacketFilter(ctx, zone, nic.ID, desired.packetFilterID); err != nil {
-				return err
+			if !desired.packetFilterID.IsEmpty() {
+				if err := b.Client.Interface.ConnectToPacketFilter(ctx, zone, nic.ID, desired.packetFilterID); err != nil {
+					return err
+				}
 			}
 		}
 		if desired.displayIP != nic.UserIPAddress {

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/builder.go
@@ -1,0 +1,661 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/sacloud/libsacloud/v2/utils/builder"
+	"github.com/sacloud/libsacloud/v2/utils/builder/disk"
+
+	"github.com/sacloud/libsacloud/v2/utils/server"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// Builder サーバ作成時のパラメータ
+type Builder struct {
+	Name            string
+	CPU             int
+	MemoryGB        int
+	Commitment      types.ECommitment
+	Generation      types.EPlanGeneration
+	InterfaceDriver types.EInterfaceDriver
+	Description     string
+	IconID          types.ID
+	Tags            types.Tags
+	BootAfterCreate bool
+	CDROMID         types.ID
+	PrivateHostID   types.ID
+	NIC             NICSettingHolder
+	AdditionalNICs  []AdditionalNICSettingHolder
+	DiskBuilders    []disk.Builder
+
+	Client *APIClient
+
+	ServerID      types.ID
+	ForceShutdown bool
+}
+
+// BuildResult サーバ構築結果
+type BuildResult struct {
+	ServerID               types.ID
+	GeneratedSSHPrivateKey string
+}
+
+var (
+	defaultCPU             = 1
+	defaultMemoryGB        = 1
+	defaultCommitment      = types.Commitments.Standard
+	defaultGeneration      = types.PlanGenerations.Default
+	defaultInterfaceDriver = types.InterfaceDrivers.VirtIO
+)
+
+// Validate 入力値の検証
+//
+// 各種IDの存在確認のためにAPIリクエストが行われます。
+func (b *Builder) Validate(ctx context.Context, zone string) error {
+	b.setDefaults()
+
+	// Fields
+	if b.Client == nil {
+		return errors.New("client is empty")
+	}
+
+	if b.NIC == nil && len(b.AdditionalNICs) > 0 {
+		return errors.New("NIC is required when AdditionalNICs is specified")
+	}
+
+	if len(b.AdditionalNICs) > 9 {
+		return errors.New("AdditionalNICs must be less than 9")
+	}
+
+	if b.InterfaceDriver != types.InterfaceDrivers.E1000 && b.InterfaceDriver != types.InterfaceDrivers.VirtIO {
+		return fmt.Errorf("invalid InterfaceDriver: %s", b.InterfaceDriver)
+	}
+
+	// Field values
+	_, err := server.FindPlan(ctx, b.Client.ServerPlan, zone, &server.FindPlanRequest{
+		CPU:        b.CPU,
+		MemoryGB:   b.MemoryGB,
+		Commitment: b.Commitment,
+		Generation: b.Generation,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, diskBuilder := range b.DiskBuilders {
+		if err := diskBuilder.Validate(ctx, zone); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Build サーバ構築を行う
+func (b *Builder) Build(ctx context.Context, zone string) (*BuildResult, error) {
+	// validate
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	// create server
+	server, err := b.createServer(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+	result := &BuildResult{
+		ServerID: server.ID,
+	}
+
+	// create&connect disk(s)
+	for _, diskReq := range b.DiskBuilders {
+		builtDisk, err := diskReq.Build(ctx, zone, server.ID)
+		if err != nil {
+			return nil, err
+		}
+		if builtDisk.GeneratedSSHKey != nil {
+			result.GeneratedSSHPrivateKey = builtDisk.GeneratedSSHKey.PrivateKey
+		}
+	}
+
+	// connect packet filter
+	if err := b.updateInterfaces(ctx, zone, server); err != nil {
+		return nil, err
+	}
+
+	// insert CD-ROM
+	if !b.CDROMID.IsEmpty() {
+		req := &sacloud.InsertCDROMRequest{ID: b.CDROMID}
+		if err := b.Client.Server.InsertCDROM(ctx, zone, server.ID, req); err != nil {
+			return nil, err
+		}
+	}
+
+	// bool
+	if b.BootAfterCreate {
+		if err := b.Client.Server.Boot(ctx, zone, server.ID); err != nil {
+			return nil, err
+		}
+		// wait
+		waiter := sacloud.WaiterForUp(func() (interface{}, error) {
+			return b.Client.Server.Read(ctx, zone, server.ID)
+		})
+
+		lastState, err := waiter.WaitForState(ctx)
+		if err != nil {
+			return nil, err
+		}
+		server = lastState.(*sacloud.Server)
+	}
+
+	b.ServerID = result.ServerID
+	return result, nil
+}
+
+// IsNeedShutdown Update時にシャットダウンが必要か
+func (b *Builder) IsNeedShutdown(ctx context.Context, zone string) (bool, error) {
+	if b.ServerID.IsEmpty() {
+		return false, fmt.Errorf("server id required")
+	}
+
+	server, err := b.Client.Server.Read(ctx, zone, b.ServerID)
+	if err != nil {
+		return false, err
+	}
+
+	if !reflect.DeepEqual(b.currentState(server), b.desiredState()) {
+		return true, nil
+	}
+
+	// ここに到達するときはserver.Disksとb.DiskBuildersは同数となっている
+	for i, disk := range server.Disks {
+		level := b.DiskBuilders[i].UpdateLevel(ctx, zone, &sacloud.Disk{
+			ID:              disk.ID,
+			Name:            disk.Name,
+			Availability:    disk.Availability,
+			Connection:      disk.Connection,
+			ConnectionOrder: disk.ConnectionOrder,
+			ReinstallCount:  disk.ReinstallCount,
+			SizeMB:          disk.SizeMB,
+			DiskPlanID:      disk.DiskPlanID,
+			Storage:         disk.Storage,
+		})
+
+		if level == builder.UpdateLevelNeedShutdown {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Update サーバの更新
+func (b *Builder) Update(ctx context.Context, zone string) (*BuildResult, error) {
+	// validate
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+	if b.ServerID.IsEmpty() {
+		return nil, fmt.Errorf("server id required")
+	}
+
+	result := &BuildResult{ServerID: b.ServerID}
+
+	server, err := b.Client.Server.Read(ctx, zone, b.ServerID)
+	if err != nil {
+		return nil, err
+	}
+
+	isNeedShutdown, err := b.IsNeedShutdown(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	// shutdown
+	if isNeedShutdown && server.InstanceStatus.IsUp() {
+		if err := b.Client.Server.Shutdown(ctx, zone, server.ID, &sacloud.ShutdownOption{Force: b.ForceShutdown}); err != nil {
+			return nil, err
+		}
+		waiter := sacloud.WaiterForDown(func() (interface{}, error) {
+			return b.Client.Server.Read(ctx, zone, server.ID)
+		})
+		if _, err := waiter.WaitForState(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	// reconcile disks
+	if err := b.reconcileDisks(ctx, zone, server, result); err != nil {
+		return nil, err
+	}
+
+	// reconcile interface
+	if err := b.reconcileInterfaces(ctx, zone, server); err != nil {
+		return nil, err
+	}
+
+	// plan
+	if b.isPlanChanged(server) {
+		updated, err := b.Client.Server.ChangePlan(ctx, zone, server.ID, &sacloud.ServerChangePlanRequest{
+			CPU:                  b.CPU,
+			MemoryMB:             b.MemoryGB * 1024,
+			ServerPlanGeneration: b.Generation,
+			ServerPlanCommitment: b.Commitment,
+		})
+		if err != nil {
+			return nil, err
+		}
+		server = updated
+	}
+
+	// update
+	updated, err := b.Client.Server.Update(ctx, zone, server.ID, &sacloud.ServerUpdateRequest{
+		Name:            b.Name,
+		Description:     b.Description,
+		Tags:            b.Tags,
+		IconID:          b.IconID,
+		PrivateHostID:   b.PrivateHostID,
+		InterfaceDriver: b.InterfaceDriver,
+	})
+	if err != nil {
+		return nil, err
+	}
+	server = updated
+
+	// insert CD-ROM
+	if !b.CDROMID.IsEmpty() && b.CDROMID != server.CDROMID {
+		if !server.CDROMID.IsEmpty() {
+			if err := b.Client.Server.EjectCDROM(ctx, zone, server.ID, &sacloud.EjectCDROMRequest{ID: server.CDROMID}); err != nil {
+				return nil, err
+			}
+		}
+		if err := b.Client.Server.InsertCDROM(ctx, zone, server.ID, &sacloud.InsertCDROMRequest{ID: b.CDROMID}); err != nil {
+			return nil, err
+		}
+	}
+
+	// bool
+	if isNeedShutdown && server.InstanceStatus.IsDown() {
+		if err := b.Client.Server.Boot(ctx, zone, server.ID); err != nil {
+			return nil, err
+		}
+		// wait
+		waiter := sacloud.WaiterForUp(func() (interface{}, error) {
+			return b.Client.Server.Read(ctx, zone, server.ID)
+		})
+		_, err := waiter.WaitForState(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	result.ServerID = server.ID
+	return result, nil
+}
+
+func (b *Builder) setDefaults() {
+	if b.CPU == 0 {
+		b.CPU = defaultCPU
+	}
+	if b.MemoryGB == 0 {
+		b.MemoryGB = defaultMemoryGB
+	}
+	if b.Commitment == types.ECommitment("") {
+		b.Commitment = defaultCommitment
+	}
+	if b.Generation == types.EPlanGeneration(0) {
+		b.Generation = defaultGeneration
+	}
+	if b.InterfaceDriver == types.EInterfaceDriver("") {
+		b.InterfaceDriver = defaultInterfaceDriver
+	}
+}
+
+type serverState struct {
+	privateHostID   types.ID
+	interfaceDriver types.EInterfaceDriver
+	memoryGB        int
+	cpu             int
+	nic             *nicState   // hash
+	additionalNICs  []*nicState // hash
+	diskCount       int
+}
+
+func (b *Builder) desiredState() *serverState {
+	var nic *nicState
+	if b.NIC != nil {
+		nic = b.NIC.state()
+	}
+	var additionalNICs []*nicState
+	for _, n := range b.AdditionalNICs {
+		additionalNICs = append(additionalNICs, n.state())
+	}
+
+	return &serverState{
+		privateHostID:   b.PrivateHostID,
+		interfaceDriver: b.InterfaceDriver,
+		memoryGB:        b.MemoryGB,
+		cpu:             b.CPU,
+		nic:             nic,
+		additionalNICs:  additionalNICs,
+		diskCount:       len(b.DiskBuilders),
+	}
+}
+
+func (b *Builder) currentNICState(nic *sacloud.InterfaceView) *nicState {
+	var state *nicState
+
+	switch {
+	case nic.SwitchScope == types.Scopes.Shared:
+		state = &nicState{
+			upstreamType:   types.UpstreamNetworkTypes.Shared,
+			switchID:       types.ID(0),
+			packetFilterID: nic.PacketFilterID,
+			displayIP:      "",
+		}
+	case nic.SwitchID.IsEmpty():
+		state = &nicState{
+			upstreamType:   types.UpstreamNetworkTypes.None,
+			switchID:       types.ID(0),
+			packetFilterID: types.ID(0),
+			displayIP:      "",
+		}
+	default:
+		state = &nicState{
+			upstreamType:   types.UpstreamNetworkTypes.Switch,
+			switchID:       nic.SwitchID,
+			packetFilterID: nic.PacketFilterID,
+			displayIP:      nic.UserIPAddress,
+		}
+	}
+	return state
+}
+
+func (b *Builder) currentState(server *sacloud.Server) *serverState {
+	var nic *nicState
+	var additionalNICs []*nicState
+	for i, n := range server.Interfaces {
+		state := b.currentNICState(n)
+		if i == 0 {
+			nic = state
+		} else {
+			additionalNICs = append(additionalNICs, state)
+		}
+	}
+
+	return &serverState{
+		privateHostID:   server.PrivateHostID,
+		interfaceDriver: server.InterfaceDriver,
+		memoryGB:        server.GetMemoryGB(),
+		cpu:             server.CPU,
+		nic:             nic,
+		additionalNICs:  additionalNICs,
+		diskCount:       len(server.Disks),
+	}
+}
+
+// createServer サーバ作成
+func (b *Builder) createServer(ctx context.Context, zone string) (*sacloud.Server, error) {
+	param := &sacloud.ServerCreateRequest{
+		CPU:                  b.CPU,
+		MemoryMB:             b.MemoryGB * 1024,
+		ServerPlanCommitment: b.Commitment,
+		ServerPlanGeneration: b.Generation,
+		InterfaceDriver:      b.InterfaceDriver,
+		Name:                 b.Name,
+		Description:          b.Description,
+		Tags:                 b.Tags,
+		IconID:               b.IconID,
+		WaitDiskMigration:    false,
+		PrivateHostID:        b.PrivateHostID,
+		ConnectedSwitches:    []*sacloud.ConnectedSwitch{},
+	}
+	if b.NIC != nil {
+		cs := b.NIC.GetConnectedSwitchParam()
+		if cs == nil {
+			param.ConnectedSwitches = append(param.ConnectedSwitches, nil)
+		} else {
+			param.ConnectedSwitches = append(param.ConnectedSwitches, cs)
+		}
+	}
+	if len(b.AdditionalNICs) > 0 {
+		for _, nic := range b.AdditionalNICs {
+			switchID := nic.GetSwitchID()
+			if switchID.IsEmpty() {
+				param.ConnectedSwitches = append(param.ConnectedSwitches, nil)
+			} else {
+				param.ConnectedSwitches = append(param.ConnectedSwitches, &sacloud.ConnectedSwitch{ID: switchID})
+			}
+		}
+	}
+	return b.Client.Server.Create(ctx, zone, param)
+}
+
+type updateInterfaceRequest struct {
+	index          int
+	packetFilterID types.ID
+	displayIP      string
+}
+
+func (b *Builder) collectInterfaceParameters() []*updateInterfaceRequest {
+	var reqs []*updateInterfaceRequest
+	if b.NIC != nil {
+		reqs = append(reqs, &updateInterfaceRequest{
+			index:          0,
+			packetFilterID: b.NIC.GetPacketFilterID(),
+		})
+	}
+	for i, nic := range b.AdditionalNICs {
+		reqs = append(reqs, &updateInterfaceRequest{
+			index:          i + 1,
+			packetFilterID: nic.GetPacketFilterID(),
+		})
+	}
+	return reqs
+}
+
+func (b *Builder) updateInterfaces(ctx context.Context, zone string, server *sacloud.Server) error {
+	requests := b.collectInterfaceParameters()
+	for _, req := range requests {
+		if req.index < len(server.Interfaces) {
+			iface := server.Interfaces[req.index]
+
+			if !req.packetFilterID.IsEmpty() {
+				if err := b.Client.Interface.ConnectToPacketFilter(ctx, zone, iface.ID, req.packetFilterID); err != nil {
+					return err
+				}
+			}
+
+			if req.displayIP != "" {
+				if _, err := b.Client.Interface.Update(ctx, zone, iface.ID, &sacloud.InterfaceUpdateRequest{
+					UserIPAddress: req.displayIP,
+				}); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (b *Builder) reconcileDisks(ctx context.Context, zone string, server *sacloud.Server, result *BuildResult) error {
+	// reconcile disks
+	isDiskUpdated := len(server.Disks) != len(b.DiskBuilders) // isDiskUpdateがtrueの場合、後でディスクの取外&接続を行う
+	for i, diskReq := range b.DiskBuilders {
+		if diskReq.DiskID().IsEmpty() {
+			res, err := diskReq.Build(ctx, zone, server.ID)
+			if err != nil {
+				return err
+			}
+			if res.GeneratedSSHKey != nil {
+				result.GeneratedSSHPrivateKey = res.GeneratedSSHKey.PrivateKey
+			}
+			isDiskUpdated = true
+		}
+		if len(server.Disks) > i {
+			disk := server.Disks[i]
+			level := diskReq.UpdateLevel(ctx, zone, &sacloud.Disk{
+				ID:              disk.ID,
+				Name:            disk.Name,
+				Availability:    disk.Availability,
+				Connection:      disk.Connection,
+				ConnectionOrder: disk.ConnectionOrder,
+				ReinstallCount:  disk.ReinstallCount,
+				SizeMB:          disk.SizeMB,
+				DiskPlanID:      disk.DiskPlanID,
+				Storage:         disk.Storage,
+			})
+			if level != builder.UpdateLevelNone {
+				_, err := diskReq.Update(ctx, zone)
+				if err != nil {
+					return err
+				}
+			}
+			if disk.ID != diskReq.DiskID() {
+				isDiskUpdated = true
+			}
+		}
+	}
+	if isDiskUpdated {
+		refreshed, err := b.Client.Server.Read(ctx, zone, server.ID)
+		if err != nil {
+			return err
+		}
+		server = refreshed
+
+		// disconnect all
+		for i := range server.Disks {
+			// disconnect
+			if err := b.Client.Disk.DisconnectFromServer(ctx, zone, server.Disks[i].ID); err != nil {
+				return err
+			}
+		}
+		// reconnect all
+		for _, diskReq := range b.DiskBuilders {
+			if err := b.Client.Disk.ConnectToServer(ctx, zone, diskReq.DiskID(), server.ID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (b *Builder) reconcileInterfaces(ctx context.Context, zone string, server *sacloud.Server) error {
+	desiredState := b.desiredState()
+	for i, nic := range server.Interfaces {
+		current := b.currentNICState(nic)
+		var desired *nicState
+		if i == 0 {
+			desired = desiredState.nic
+		} else {
+			if len(desiredState.additionalNICs) > i-1 {
+				desired = desiredState.additionalNICs[i-1]
+			}
+		}
+		if desired == nil && !nic.SwitchID.IsEmpty() {
+			// disconnect and delete
+			if err := b.Client.Interface.DisconnectFromSwitch(ctx, zone, nic.ID); err != nil {
+				return err
+			}
+			if err := b.Client.Interface.Delete(ctx, zone, nic.ID); err != nil {
+				return err
+			}
+			continue
+		}
+		if current.upstreamType != desired.upstreamType ||
+			current.switchID != desired.switchID {
+			if !nic.SwitchID.IsEmpty() {
+				if err := b.Client.Interface.DisconnectFromSwitch(ctx, zone, nic.ID); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	desiredNICs := []*nicState{desiredState.nic}
+	desiredNICs = append(desiredNICs, desiredState.additionalNICs...)
+
+	for i, desired := range desiredNICs {
+		var nic *sacloud.InterfaceView
+		if len(server.Interfaces) > i {
+			nic = server.Interfaces[i]
+		}
+		if nic == nil {
+			created, err := b.Client.Interface.Create(ctx, zone, &sacloud.InterfaceCreateRequest{
+				ServerID: server.ID,
+			})
+			if err != nil {
+				return err
+			}
+			nic = &sacloud.InterfaceView{
+				ID:             created.ID,
+				MACAddress:     created.MACAddress,
+				IPAddress:      created.IPAddress,
+				UserIPAddress:  created.UserIPAddress,
+				HostName:       created.HostName,
+				SwitchID:       created.SwitchID,
+				SwitchScope:    created.SwitchScope,
+				PacketFilterID: created.PacketFilterID,
+			}
+		}
+		switch desired.upstreamType {
+		case types.UpstreamNetworkTypes.None:
+			// noop
+		case types.UpstreamNetworkTypes.Shared:
+			if nic.SwitchScope != types.Scopes.Shared {
+				if err := b.Client.Interface.ConnectToSharedSegment(ctx, zone, nic.ID); err != nil {
+					return err
+				}
+			}
+		default:
+			if nic.SwitchID != desired.switchID {
+				if err := b.Client.Interface.ConnectToSwitch(ctx, zone, nic.ID, desired.switchID); err != nil {
+					return err
+				}
+			}
+		}
+		if desired.packetFilterID != nic.PacketFilterID {
+			if !nic.PacketFilterID.IsEmpty() {
+				if err := b.Client.Interface.DisconnectFromPacketFilter(ctx, zone, nic.ID); err != nil {
+					return err
+				}
+			}
+			if err := b.Client.Interface.ConnectToPacketFilter(ctx, zone, nic.ID, desired.packetFilterID); err != nil {
+				return err
+			}
+		}
+		if desired.displayIP != nic.UserIPAddress {
+			if _, err := b.Client.Interface.Update(ctx, zone, nic.ID, &sacloud.InterfaceUpdateRequest{
+				UserIPAddress: desired.displayIP,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (b *Builder) isPlanChanged(server *sacloud.Server) bool {
+	return b.CPU != server.CPU ||
+		b.MemoryGB != server.GetMemoryGB() ||
+		b.Commitment != server.ServerPlanCommitment ||
+		b.Generation != server.ServerPlanGeneration
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/nic.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/nic.go
@@ -1,0 +1,182 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+type nicState struct {
+	upstreamType   types.EUpstreamNetworkType
+	switchID       types.ID
+	packetFilterID types.ID
+	displayIP      string
+}
+
+// NICSettingHolder NIC設定を保持するためのインターフェース
+type NICSettingHolder interface {
+	GetConnectedSwitchParam() *sacloud.ConnectedSwitch
+
+	GetPacketFilterID() types.ID
+	Validate(ctx context.Context, client *APIClient, zone string) error
+	state() *nicState
+}
+
+// AdditionalNICSettingHolder 追加NIC設定を保持するためのインターフェース
+type AdditionalNICSettingHolder interface {
+	GetSwitchID() types.ID
+
+	GetDisplayIPAddress() string
+	GetPacketFilterID() types.ID
+	Validate(ctx context.Context, client *APIClient, zone string) error
+	state() *nicState
+}
+
+// SharedNICSetting サーバ作成時に共有セグメントに接続するためのパラメータ
+//
+// NICSettingHolderを実装し、Builder.NICに利用できる。
+type SharedNICSetting struct {
+	PacketFilterID types.ID
+}
+
+// GetConnectedSwitchParam サーバ作成時の接続先指定パラメータを作成して返す
+func (c *SharedNICSetting) GetConnectedSwitchParam() *sacloud.ConnectedSwitch {
+	return &sacloud.ConnectedSwitch{Scope: types.Scopes.Shared}
+}
+
+// GetPacketFilterID このNICに接続するパケットフィルタのIDを返す
+func (c *SharedNICSetting) GetPacketFilterID() types.ID {
+	return c.PacketFilterID
+}
+
+// Validate 設定値の検証
+func (c *SharedNICSetting) Validate(ctx context.Context, client *APIClient, zone string) error {
+	if !c.PacketFilterID.IsEmpty() {
+		if _, err := client.PacketFilter.Read(ctx, zone, c.PacketFilterID); err != nil {
+			return fmt.Errorf("reading packet filter info(id:%d) is failed: %s", c.PacketFilterID, err)
+		}
+	}
+	return nil
+}
+
+func (c *SharedNICSetting) state() *nicState {
+	return &nicState{
+		upstreamType:   types.UpstreamNetworkTypes.Shared,
+		switchID:       types.ID(0),
+		packetFilterID: c.PacketFilterID,
+		displayIP:      "",
+	}
+}
+
+// ConnectedNICSetting サーバ作成時にスイッチに接続するためのパラメータ
+//
+// NICSettingHolderとAdditionalNICSettingHolderを実装し、Builder.NIC/Builder.AdditionalNICsに利用できる。
+type ConnectedNICSetting struct {
+	SwitchID         types.ID
+	DisplayIPAddress string
+	PacketFilterID   types.ID
+}
+
+// GetConnectedSwitchParam サーバ作成時の接続先指定パラメータを作成して返す
+func (c *ConnectedNICSetting) GetConnectedSwitchParam() *sacloud.ConnectedSwitch {
+	return &sacloud.ConnectedSwitch{ID: c.SwitchID}
+}
+
+// GetSwitchID このNICが接続するスイッチのIDを返す
+func (c *ConnectedNICSetting) GetSwitchID() types.ID {
+	return c.SwitchID
+}
+
+// GetDisplayIPAddress 表示用IPアドレスを返す
+func (c *ConnectedNICSetting) GetDisplayIPAddress() string {
+	return c.DisplayIPAddress
+}
+
+// GetPacketFilterID このNICに接続するパケットフィルタのIDを返す
+func (c *ConnectedNICSetting) GetPacketFilterID() types.ID {
+	return c.PacketFilterID
+}
+
+// Validate 設定値の検証
+func (c *ConnectedNICSetting) Validate(ctx context.Context, client *APIClient, zone string) error {
+	if c.SwitchID.IsEmpty() {
+		return errors.New("ConnectedNICSetting: SwitchID is required")
+	}
+
+	if _, err := client.Switch.Read(ctx, zone, c.SwitchID); err != nil {
+		return fmt.Errorf("reading switch info(id:%d) is failed: %s", c.SwitchID, err)
+	}
+
+	if !c.PacketFilterID.IsEmpty() {
+		if _, err := client.PacketFilter.Read(ctx, zone, c.PacketFilterID); err != nil {
+			return fmt.Errorf("reading packet filter info(id:%d) is failed: %s", c.PacketFilterID, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *ConnectedNICSetting) state() *nicState {
+	return &nicState{
+		upstreamType:   types.UpstreamNetworkTypes.Switch,
+		switchID:       c.SwitchID,
+		packetFilterID: c.PacketFilterID,
+		displayIP:      c.DisplayIPAddress,
+	}
+}
+
+// DisconnectedNICSetting 切断状態のNICを作成するためのパラメータ
+//
+// NICSettingHolderとAdditionalNICSettingHolderを実装し、Builder.NIC/Builder.AdditionalNICsに利用できる。
+type DisconnectedNICSetting struct{}
+
+// GetConnectedSwitchParam サーバ作成時の接続先指定パラメータを作成して返す
+func (d *DisconnectedNICSetting) GetConnectedSwitchParam() *sacloud.ConnectedSwitch {
+	return nil
+}
+
+// GetSwitchID このNICが接続するスイッチのIDを返す
+func (d *DisconnectedNICSetting) GetSwitchID() types.ID {
+	return types.ID(0)
+}
+
+// GetDisplayIPAddress 表示用IPアドレスを返す
+func (d *DisconnectedNICSetting) GetDisplayIPAddress() string {
+	return ""
+}
+
+// GetPacketFilterID このNICに接続するパケットフィルタのIDを返す
+func (d *DisconnectedNICSetting) GetPacketFilterID() types.ID {
+	return types.ID(0)
+}
+
+// Validate 設定値の検証
+func (d *DisconnectedNICSetting) Validate(ctx context.Context, client *APIClient, zone string) error {
+	return nil
+}
+
+func (d *DisconnectedNICSetting) state() *nicState {
+	return &nicState{
+		upstreamType:   types.UpstreamNetworkTypes.None,
+		switchID:       types.ID(0),
+		packetFilterID: types.ID(0),
+		displayIP:      "",
+	}
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/update_level.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/update_level.go
@@ -1,0 +1,27 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+// UpdateLevel Update時にどのレベルの変更が必要か
+type UpdateLevel int
+
+const (
+	// UpdateLevelNone 変更なし
+	UpdateLevelNone UpdateLevel = iota
+	// UpdateLevelSimple 単純な更新のみ(再起動不要)
+	UpdateLevelSimple
+	// UpdateLevelNeedShutdown シャットダウンが必要な変更
+	UpdateLevelNeedShutdown
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/posener/complete/match
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210122856-9ae9cbfb5219
+# github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191211005330-ca7e43850bdf
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/pkg/cidr
 github.com/sacloud/libsacloud/v2/pkg/mapconv

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/posener/complete/match
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210070433-e7ad7ecec6cd
+# github.com/sacloud/libsacloud/v2 v2.0.0-beta6.0.20191210122856-9ae9cbfb5219
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/pkg/cidr
 github.com/sacloud/libsacloud/v2/pkg/mapconv
@@ -242,6 +242,9 @@ github.com/sacloud/libsacloud/v2/sacloud/search/keys
 github.com/sacloud/libsacloud/v2/sacloud/trace
 github.com/sacloud/libsacloud/v2/sacloud/types
 github.com/sacloud/libsacloud/v2/utils/archive
+github.com/sacloud/libsacloud/v2/utils/builder
+github.com/sacloud/libsacloud/v2/utils/builder/disk
+github.com/sacloud/libsacloud/v2/utils/builder/server
 github.com/sacloud/libsacloud/v2/utils/builder/vpcrouter
 github.com/sacloud/libsacloud/v2/utils/nfs
 github.com/sacloud/libsacloud/v2/utils/server


### PR DESCRIPTION
- `sakuracloud_server`リソース/データソースのスキーマ変更
  - VNC関連項目を除去(別途データソースを新設予定)
  - 表示用IP(Interfaces.Switch.UserIPAddress)の設定を除去
  - NIC/追加NICを統合し`interfaces`を新設
    - `nic`に文字列を指定からオブジェクトを指定するように変更
    - *`nic`*がオブジェクトになることでデフォルト値が設定できなくなる。`interfaces`を明示的に書く必要がある。
    - パケットフィルタとMACアドレスを`interfaces`配下の各要素内に配置

```hcl
resource sakuracloud_server "foobar" {
  name = "foobar"
  
  # nic = "shared"       # 共有セグメントに接続(デフォルト)
  # nic = "disconnect"   # 切断状態
  # nic = "100000000001" # スイッチに接続(スイッチIDを指定)
  
  # 追加NIC
  additional_nics = ["100000000002", "100000000003"] #スイッチIDのリスト 
  
  # パケットフィルタ
  packet_filter_id = ["200000000001", "200000000002", "200000000003"] 
}
```

#### 変更後

```hcl
resource sakuracloud_server "foobar" {
  name = "foobar"
  interfaces {
    upstream         = "shared"
    packet_filter_id = "200000000001"
  }
  interfaces {
    upstream         = "100000000002" # スイッチID
    packet_filter_id = "200000000002" # パケットフィルタID
  }
  interfaces {
    upstream         = "100000000003" # スイッチID
    packet_filter_id = "200000000003" # パケットフィルタID
  }
}
```

- 実装に`libsacloud/utils/builder/server`を利用し、プロバイダー側でのリソース操作を最小限にする
- NIC関連のCustomizeDiffを除去
- スキーマバージョンの廃止
  - v2ではv1からのマイグレーションをサポートしない方針のため
- 専有ホスト削除時のサーバデタッチを廃止(ロックが緩くなることに起因)
- パケットフィルタ削除時の待機処理を実装
- その他テストケース修正