### PR TITLE
依存リソースの削除待機

### DIFF
--- a/sakuracloud/resource_sakuracloud_bridge.go
+++ b/sakuracloud/resource_sakuracloud_bridge.go
@@ -115,6 +115,10 @@ func resourceSakuraCloudBridgeDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("could not read SakuraCloud Bridge[%s]: %s", d.Id(), err)
 	}
 
+	if err := waitForDeletionByBridgeID(ctx, client, bridge.ID); err != nil {
+		return fmt.Errorf("waiting deletion is failed: Bridge[%s] still used by Switches: %s", bridge.ID, err)
+	}
+
 	if err := bridgeOp.Delete(ctx, zone, bridge.ID); err != nil {
 		return fmt.Errorf("deleting SakuraCloud Bridge[%s] is failed: %s", d.Id(), err)
 	}

--- a/sakuracloud/resource_sakuracloud_cdrom.go
+++ b/sakuracloud/resource_sakuracloud_cdrom.go
@@ -200,9 +200,8 @@ func resourceSakuraCloudCDROMDelete(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("could not read SakuraCloud CDROM[%s]: %s", d.Id(), err)
 	}
 
-	// eject
-	if _, err := ejectCDROMFromAllServers(ctx, d, client, cdrom.ID); err != nil {
-		return fmt.Errorf("could not eject CDROM[%s] from Servers: %s", cdrom.ID, err)
+	if err := waitForDeletionByCDROMID(ctx, client, zone, cdrom.ID); err != nil {
+		return fmt.Errorf("waiting deletion is failed: CDROM[%s] still used by Servers: %s", cdrom.ID, err)
 	}
 
 	if err := cdromOp.Delete(ctx, zone, cdrom.ID); err != nil {

--- a/sakuracloud/resource_sakuracloud_disk.go
+++ b/sakuracloud/resource_sakuracloud_disk.go
@@ -192,6 +192,10 @@ func resourceSakuraCloudDiskDelete(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("could not read SakuraCloud Disk[%s]: %s", d.Id(), err)
 	}
 
+	if err := waitForDeletionByDiskID(ctx, client, zone, disk.ID); err != nil {
+		return fmt.Errorf("waiting deletion is failed: Disk[%s] still used by Servers: %s", disk.ID, err)
+	}
+
 	if err := diskOp.Delete(ctx, zone, disk.ID); err != nil {
 		return fmt.Errorf("deleting SakuraCloud Disk[%s] is failed: %s", d.Id(), err)
 	}


### PR DESCRIPTION
v2では依存リソースの削除はせず、自身への参照を持つリソースの存在確認を一定期間行ない、依存リソースがなくなったことを確認してから自身の削除を行う。

これまでいくつかのリソースでのみ待機処理を実装していたのをこのPRで全リソースを対象とする。