### PR TITLE
親子リソースでの同時変更処理の改善

### DIFF
--- a/sakuracloud/resource_sakuracloud_dns.go
+++ b/sakuracloud/resource_sakuracloud_dns.go
@@ -148,7 +148,7 @@ func resourceSakuraCloudDNSUpdate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("could not read SakuraCloud DNS[%s]: %s", d.Id(), err)
 	}
 
-	if _, err := dnsOp.Update(ctx, dns.ID, expandDNSUpdateRequest(d)); err != nil {
+	if _, err := dnsOp.Update(ctx, dns.ID, expandDNSUpdateRequest(d, dns)); err != nil {
 		return fmt.Errorf("updating SakuraCloud DNS[%s] is failed: %s", d.Id(), err)
 	}
 	return resourceSakuraCloudDNSRead(d, meta)
@@ -202,12 +202,16 @@ func expandDNSCreateRequest(d *schema.ResourceData) *sacloud.DNSCreateRequest {
 	}
 }
 
-func expandDNSUpdateRequest(d *schema.ResourceData) *sacloud.DNSUpdateRequest {
+func expandDNSUpdateRequest(d *schema.ResourceData, dns *sacloud.DNS) *sacloud.DNSUpdateRequest {
+	records := dns.Records
+	if d.HasChange("records") {
+		records = expandDNSRecords(d, "records")
+	}
 	return &sacloud.DNSUpdateRequest{
 		Description: d.Get("description").(string),
 		Tags:        expandTags(d),
 		IconID:      expandSakuraCloudID(d, "icon_id"),
-		Records:     expandDNSRecords(d, "records"),
+		Records:     records,
 	}
 }
 

--- a/sakuracloud/resource_sakuracloud_dns_record_test.go
+++ b/sakuracloud/resource_sakuracloud_dns_record_test.go
@@ -41,40 +41,26 @@ func TestAccResourceSakuraCloudDNSRecord_Basic(t *testing.T) {
 				Config: testAccCheckSakuraCloudDNSRecordConfig_basic(zone),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSakuraCloudDNSExists("sakuracloud_dns.foobar", &dns),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns.foobar", "zone", zone),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar", "name", "test1"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar", "type", "A"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar", "value", "192.168.0.1"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar1", "name", "_sip._tls"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar1", "type", "SRV"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar1", "value", "www.sakura.ne.jp."),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar1", "priority", "1"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar1", "weight", "2"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar1", "port", "3"),
+					resource.TestCheckResourceAttr("sakuracloud_dns.foobar", "zone", zone),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar", "name", "test1"),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar", "type", "A"),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar", "value", "192.168.0.1"),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar1", "name", "_sip._tls"),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar1", "type", "SRV"),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar1", "value", "www.sakura.ne.jp."),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar1", "priority", "1"),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar1", "weight", "2"),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar1", "port", "3"),
 				),
 			},
 			{
 				Config: testAccCheckSakuraCloudDNSRecordConfig_update(zone),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSakuraCloudDNSExists("sakuracloud_dns.foobar", &dns),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns.foobar", "zone", zone),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar", "name", "test2"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar", "type", "A"),
-					resource.TestCheckResourceAttr(
-						"sakuracloud_dns_record.foobar", "value", "192.168.0.2"),
+					resource.TestCheckResourceAttr("sakuracloud_dns.foobar", "zone", zone),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar", "name", "test2"),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar", "type", "A"),
+					resource.TestCheckResourceAttr("sakuracloud_dns_record.foobar", "value", "192.168.0.2"),
 				),
 			},
 		},
@@ -187,7 +173,7 @@ func testAccCheckSakuraCloudDNSRecordConfig_update(zone string) string {
 	return fmt.Sprintf(`
 resource "sakuracloud_dns" "foobar" {
   zone = "%s"
-  description = "DNS from TerraForm for SAKURA CLOUD"
+  description = "DNS from TerraForm for SAKURA CLOUD-upd"
   tags = ["hoge1"]
 }
 

--- a/sakuracloud/resource_sakuracloud_packet_filter.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter.go
@@ -136,11 +136,7 @@ func resourceSakuraCloudPacketFilterUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("could not read SakuraCloud PacketFilter[%s]: %s", d.Id(), err)
 	}
 
-	_, err = pfOp.Update(ctx, zone, pf.ID, &sacloud.PacketFilterUpdateRequest{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		Expression:  expandPacketFilterExpressions(d),
-	})
+	_, err = pfOp.Update(ctx, zone, pf.ID, expandPacketFilterUpdateRequest(d, pf))
 	if err != nil {
 		return fmt.Errorf("updating SakuraCloud PacketFilter[%s] is failed: %s", d.Id(), err)
 	}
@@ -179,6 +175,19 @@ func setPacketFilterResourceData(ctx context.Context, d *schema.ResourceData, cl
 	}
 	d.Set("zone", getZone(d, client))
 	return nil
+}
+
+func expandPacketFilterUpdateRequest(d *schema.ResourceData, pf *sacloud.PacketFilter) *sacloud.PacketFilterUpdateRequest {
+	expressions := pf.Expression
+	if d.HasChange("expressions") {
+		expressions = expandPacketFilterExpressions(d)
+	}
+
+	return &sacloud.PacketFilterUpdateRequest{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Expression:  expressions,
+	}
 }
 
 func flattenPacketFilterExpressions(pf *sacloud.PacketFilter) []interface{} {

--- a/sakuracloud/resource_sakuracloud_packet_filter_test.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter_test.go
@@ -155,7 +155,7 @@ resource "sakuracloud_packet_filter" "foobar" {
 var testAccCheckSakuraCloudPacketFilterConfig_update = `
 resource "sakuracloud_packet_filter" "foobar" {
   name        = "mypacket_filter_upd"
-  description = "PacketFilter from TerraForm for SAKURA CLOUD"
+  description = "PacketFilter from TerraForm for SAKURA CLOUD-upd"
   expressions {
     protocol         = "tcp"
     source_network   = "192.168.2.0"


### PR DESCRIPTION
親子両方とも変更する際、子リソースの変更を取りこぼすケースがあったのを修正。

#### 変更前

```hcl
resource sakuracloud_dns "example" {
  zone = "example.com"
  description = "foo"
}

resource sakuracloud_dns_record "record1" {
  dns_id = sakuracloud_dns.example.id
  name  = "www"
  value = "192.2.0.1"
}

resource sakuracloud_dns_record "record2" {
  dns_id = sakuracloud_dns.example.id
  name  = "www"
  value = "192.2.0.2"
}
```

#### 変更後

```hcl
resource sakuracloud_dns "example" {
  zone = "example.com"
  description = "bar" # 更新
}

resource sakuracloud_dns_record "record1" {
  dns_id = sakuracloud_dns.example.id
  name  = "www"
  value = "192.2.0.1"
}

# レコードを削除
```

#### 結果

レコード`record2`が削除されないことがある