### PR TITLE
Adapt provider to the Terraform Plugin Best Practices - Naming

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -64,7 +64,7 @@ test:
 testacc:
 	TF_ACC=1 SAKURACLOUD_APPEND_USER_AGENT="(Acceptance Test)" go test -mod=vendor -v $(TESTARGS) -timeout 240m ./...
 
-testacc-fake:
+testfake:
 	FAKE_MODE=1 TF_ACC=1 SAKURACLOUD_APPEND_USER_AGENT="(Acceptance Test)" go test -mod=vendor -v $(TESTARGS) -timeout 240m ./...
 
 vet: golint

--- a/sakuracloud/data_source_sakuracloud_dns.go
+++ b/sakuracloud/data_source_sakuracloud_dns.go
@@ -50,7 +50,7 @@ func dataSourceSakuraCloudDNS() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"records": {
+			"record": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{

--- a/sakuracloud/data_source_sakuracloud_gslb.go
+++ b/sakuracloud/data_source_sakuracloud_gslb.go
@@ -88,7 +88,7 @@ func dataSourceSakuraCloudGSLB() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"servers": {
+			"server": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{

--- a/sakuracloud/data_source_sakuracloud_loadbalancer.go
+++ b/sakuracloud/data_source_sakuracloud_loadbalancer.go
@@ -81,7 +81,7 @@ func dataSourceSakuraCloudLoadBalancer() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"vips": {
+			"vip": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -106,7 +106,7 @@ func dataSourceSakuraCloudLoadBalancer() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"servers": {
+						"server": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{

--- a/sakuracloud/data_source_sakuracloud_packet_filter.go
+++ b/sakuracloud/data_source_sakuracloud_packet_filter.go
@@ -35,7 +35,7 @@ func dataSourceSakuraCloudPacketFilter() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"expressions": {
+			"expression": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{

--- a/sakuracloud/data_source_sakuracloud_packet_filter_test.go
+++ b/sakuracloud/data_source_sakuracloud_packet_filter_test.go
@@ -34,12 +34,12 @@ func TestAccSakuraCloudDataSourcePacketFilter_basic(t *testing.T) {
 					testCheckSakuraCloudDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.protocol", "tcp"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.source_network", "0.0.0.0/0"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.source_port", "0-65535"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.destination_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.allow", "true"),
+					resource.TestCheckResourceAttr(resourceName, "expression.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.source_network", "0.0.0.0/0"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.source_port", "0-65535"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.destination_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.allow", "true"),
 				),
 			},
 		},
@@ -50,14 +50,14 @@ var testAccSakuraCloudDataSourcePacketFilter_basic = `
 resource "sakuracloud_packet_filter" "foobar" {
   name        = "{{ .arg0 }}"
   description = "description"
-  expressions {
+  expression {
     protocol         = "tcp"
     source_network   = "0.0.0.0/0"
     source_port      = "0-65535"
     destination_port = "80"
     allow            = true
   }
-  expressions {
+  expression {
     protocol         = "udp"
     source_network   = "0.0.0.0/0"
     source_port      = "0-65535"

--- a/sakuracloud/data_source_sakuracloud_proxylb.go
+++ b/sakuracloud/data_source_sakuracloud_proxylb.go
@@ -51,7 +51,7 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"bind_ports": {
+			"bind_port": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -152,7 +152,7 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"additional_certificates": {
+						"additional_certificate": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Resource{
@@ -175,7 +175,7 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 					},
 				},
 			},
-			"servers": {
+			"server": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{

--- a/sakuracloud/data_source_sakuracloud_proxylb_test.go
+++ b/sakuracloud/data_source_sakuracloud_proxylb_test.go
@@ -46,14 +46,14 @@ func TestAccSakuraCloudDataSourceProxyLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.2", "tag3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "tcp"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.delay_loop", "20"),
-					resource.TestCheckResourceAttr(resourceName, "bind_ports.0.proxy_mode", "http"),
-					resource.TestCheckResourceAttr(resourceName, "bind_ports.0.port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.ipaddress", ip0),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.ipaddress", ip1),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "bind_port.0.proxy_mode", "http"),
+					resource.TestCheckResourceAttr(resourceName, "bind_port.0.port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.ipaddress", ip0),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.ipaddress", ip1),
+					resource.TestCheckResourceAttr(resourceName, "server.1.port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.enabled", "true"),
 				),
 			},
 		},
@@ -71,16 +71,16 @@ resource "sakuracloud_proxylb" "foobar" {
     delay_loop = 20
   }
 
-  bind_ports {
+  bind_port {
     proxy_mode = "http"
     port       = 80
   }
 
-  servers {
+  server {
     ipaddress = "{{ .arg1 }}"
     port      = 80
   }
-  servers {
+  server {
     ipaddress = "{{ .arg2 }}"
     port      = 80
   }

--- a/sakuracloud/data_source_sakuracloud_server.go
+++ b/sakuracloud/data_source_sakuracloud_server.go
@@ -52,7 +52,7 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"interfaces": {
+			"network_interface": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{

--- a/sakuracloud/data_source_sakuracloud_server_test.go
+++ b/sakuracloud/data_source_sakuracloud_server_test.go
@@ -41,8 +41,8 @@ func TestAccSakuraCloudDataSourceServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.2", "tag3"),
 					resource.TestCheckResourceAttr(resourceName, "core", "1"),
 					resource.TestCheckResourceAttr(resourceName, "memory", "1"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.upstream", "shared"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.upstream", "shared"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
 				),
 			},
 		},
@@ -54,7 +54,7 @@ resource "sakuracloud_server" "foobar" {
   name        = "{{ .arg0 }}"
   description = "description"
   tags        = ["tag1", "tag2", "tag3"]
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
 

--- a/sakuracloud/data_source_sakuracloud_vpc_router.go
+++ b/sakuracloud/data_source_sakuracloud_vpc_router.go
@@ -85,7 +85,7 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"interfaces": {
+			"network_interface": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -114,7 +114,7 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"dhcp_servers": {
+			"dhcp_server": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -139,7 +139,7 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"dhcp_static_mappings": {
+			"dhcp_static_mapping": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -155,7 +155,7 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"firewalls": {
+			"firewall": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -168,7 +168,7 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"expressions": {
+						"expression": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
@@ -232,7 +232,7 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"port_forwardings": {
+			"port_forwarding": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -327,7 +327,7 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"static_routes": {
+			"static_route": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -343,7 +343,7 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"users": {
+			"user": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{

--- a/sakuracloud/resource_sakuracloud_dns.go
+++ b/sakuracloud/resource_sakuracloud_dns.go
@@ -45,7 +45,7 @@ func resourceSakuraCloudDNS() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"records": {
+			"record": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
@@ -185,7 +185,7 @@ func setDNSResourceData(ctx context.Context, d *schema.ResourceData, client *API
 	if err := d.Set("dns_servers", data.DNSNameServers); err != nil {
 		return err
 	}
-	if err := d.Set("records", flattenDNSRecords(data)); err != nil {
+	if err := d.Set("record", flattenDNSRecords(data)); err != nil {
 		return err
 	}
 	return nil

--- a/sakuracloud/resource_sakuracloud_dns_test.go
+++ b/sakuracloud/resource_sakuracloud_dns_test.go
@@ -47,12 +47,12 @@ func TestAccSakuraCloudDNS_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.name", "www"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.type", "A"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.value", "192.168.11.1"),
-					resource.TestCheckResourceAttr(resourceName, "records.1.name", "www2"),
-					resource.TestCheckResourceAttr(resourceName, "records.1.type", "A"),
-					resource.TestCheckResourceAttr(resourceName, "records.1.value", "192.168.11.2"),
+					resource.TestCheckResourceAttr(resourceName, "record.0.name", "www"),
+					resource.TestCheckResourceAttr(resourceName, "record.0.type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "record.0.value", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "record.1.name", "www2"),
+					resource.TestCheckResourceAttr(resourceName, "record.1.type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "record.1.value", "192.168.11.2"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -68,9 +68,9 @@ func TestAccSakuraCloudDNS_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2-upd"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.name", "www"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.type", "A"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.value", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "record.0.name", "www"),
+					resource.TestCheckResourceAttr(resourceName, "record.0.type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "record.0.value", "192.168.11.1"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 				),
 			},
@@ -139,16 +139,16 @@ func TestAccImportSakuraCloudDNS(t *testing.T) {
 			return fmt.Errorf("expected 1 state: %#v", s)
 		}
 		expects := map[string]string{
-			"zone":            zone,
-			"description":     "description",
-			"tags.0":          "tag1",
-			"tags.1":          "tag2",
-			"records.0.name":  "www",
-			"records.0.type":  "A",
-			"records.0.value": "192.168.11.1",
-			"records.1.name":  "www2",
-			"records.1.type":  "A",
-			"records.1.value": "192.168.11.2",
+			"zone":           zone,
+			"description":    "description",
+			"tags.0":         "tag1",
+			"tags.1":         "tag2",
+			"record.0.name":  "www",
+			"record.0.type":  "A",
+			"record.0.value": "192.168.11.1",
+			"record.1.name":  "www2",
+			"record.1.type":  "A",
+			"record.1.value": "192.168.11.2",
 		}
 
 		if err := compareStateMulti(s[0], expects); err != nil {
@@ -186,12 +186,12 @@ resource "sakuracloud_dns" "foobar" {
   description = "description"
   tags        = ["tag1", "tag2"]
   icon_id     = sakuracloud_icon.foobar.id
-  records {
+  record {
     name  = "www"
     type  = "A"
     value = "192.168.11.1"
   }
-  records {
+  record {
     name  = "www2"
     type  = "A"
     value = "192.168.11.2"
@@ -209,7 +209,7 @@ resource "sakuracloud_dns" "foobar" {
   zone        = "{{ .arg0 }}"
   description = "description-upd"
   tags        = ["tag1-upd", "tag2-upd"]
-  records {
+  record {
     name  = "www"
     type  = "A"
     value = "192.168.11.1"

--- a/sakuracloud/resource_sakuracloud_gslb.go
+++ b/sakuracloud/resource_sakuracloud_gslb.go
@@ -90,7 +90,7 @@ func resourceSakuraCloudGSLB() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"servers": {
+			"server": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
@@ -211,7 +211,7 @@ func setGSLBResourceData(ctx context.Context, d *schema.ResourceData, client *AP
 	if err := d.Set("health_check", flattenGSLBHealthCheck(data)); err != nil {
 		return err
 	}
-	if err := d.Set("servers", flattenGSLBServers(data)); err != nil {
+	if err := d.Set("server", flattenGSLBServers(data)); err != nil {
 		return err
 	}
 	return nil

--- a/sakuracloud/resource_sakuracloud_gslb_test.go
+++ b/sakuracloud/resource_sakuracloud_gslb_test.go
@@ -51,12 +51,12 @@ func TestAccSakuraCloudGSLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "http"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.delay_loop", "10"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.host_header", "usacloud.jp"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.ipaddress", "1.1.1.1"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.weight", "1"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.ipaddress", "2.2.2.2"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.weight", "2"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.ipaddress", "1.1.1.1"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.weight", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.ipaddress", "2.2.2.2"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.weight", "2"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.enabled", "false"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -76,12 +76,12 @@ func TestAccSakuraCloudGSLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "https"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.delay_loop", "20"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.host_header", "usacloud.jp-upd"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.ipaddress", "2.2.2.2"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.weight", "2"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.ipaddress", "3.3.3.3"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.weight", "3"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.ipaddress", "2.2.2.2"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.weight", "2"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.ipaddress", "3.3.3.3"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.weight", "3"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 				),
 			},
@@ -98,12 +98,12 @@ func TestAccSakuraCloudGSLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "https"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.delay_loop", "20"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.host_header", "usacloud.jp-upd"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.ipaddress", "2.2.2.2"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.weight", "2"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.ipaddress", "3.3.3.3"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.weight", "3"),
-					resource.TestCheckResourceAttr(resourceName, "servers.1.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.ipaddress", "2.2.2.2"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.weight", "2"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.ipaddress", "3.3.3.3"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.weight", "3"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.enabled", "false"),
 				),
 			},
 		},
@@ -221,12 +221,12 @@ resource "sakuracloud_gslb" "foobar" {
     status      = "200"
   }
   sorry_server = "8.8.8.8"
-  servers {
+  server {
     ipaddress = "1.1.1.1"
     weight    = 1
     enabled   = true
   }
-  servers {
+  server {
     ipaddress = "2.2.2.2"
     weight    = 2
     enabled   = false
@@ -252,12 +252,12 @@ resource "sakuracloud_gslb" "foobar" {
     path        = "/"
     status      = "200"
   }
-  servers {
+  server {
     ipaddress = "2.2.2.2"
     weight    = 2
     enabled   = true
   }
-  servers {
+  server {
     ipaddress = "3.3.3.3"
     weight    = 3
     enabled   = false

--- a/sakuracloud/resource_sakuracloud_internet_test.go
+++ b/sakuracloud/resource_sakuracloud_internet_test.go
@@ -214,7 +214,7 @@ resource "sakuracloud_disk" "foobar" {
 resource "sakuracloud_server" "foobar" {
   name        = "{{ .arg0 }}"
   disks       = [sakuracloud_disk.foobar.id]
-  interfaces {
+  network_interface {
     upstream = sakuracloud_internet.foobar.switch_id
   }
   ipaddress   = sakuracloud_internet.foobar.ipaddresses[0]

--- a/sakuracloud/resource_sakuracloud_loadbalancer.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer.go
@@ -109,7 +109,7 @@ func resourceSakuraCloudLoadBalancer() *schema.Resource {
 				Description:  "target SakuraCloud zone",
 				ValidateFunc: validateZone([]string{"is1a", "is1b", "tk1a", "tk1v"}),
 			},
-			"vips": {
+			"vip": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
@@ -139,7 +139,7 @@ func resourceSakuraCloudLoadBalancer() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"servers": {
+						"server": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Computed: true,
@@ -287,7 +287,7 @@ func setLoadBalancerResourceData(ctx context.Context, d *schema.ResourceData, cl
 	if err := d.Set("tags", data.Tags); err != nil {
 		return err
 	}
-	if err := d.Set("vips", flattenLoadBalancerVIPs(data)); err != nil {
+	if err := d.Set("vip", flattenLoadBalancerVIPs(data)); err != nil {
 		return err
 	}
 	d.Set("zone", getZone(d, client))

--- a/sakuracloud/resource_sakuracloud_loadbalancer_test.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer_test.go
@@ -54,22 +54,22 @@ func TestAccSakuraCloudLoadBalancer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ipaddress2", ""),
 					resource.TestCheckResourceAttr(resourceName, "nw_mask_len", "24"),
 					resource.TestCheckResourceAttr(resourceName, "default_route", "192.168.11.1"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.vip", "192.168.11.201"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.delay_loop", "10"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.sorry_server", "192.168.11.21"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.0.ipaddress", "192.168.11.51"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.0.check_protocol", "http"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.0.check_path", "/ping.html"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.0.check_status", "200"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.1.ipaddress", "192.168.11.52"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.1.check_protocol", "http"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.1.check_path", "/ping.html"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.1.check_status", "200"),
-					resource.TestCheckResourceAttr(resourceName, "vips.1.vip", "192.168.11.202"),
-					resource.TestCheckResourceAttr(resourceName, "vips.1.port", "443"),
-					resource.TestCheckResourceAttr(resourceName, "vips.1.delay_loop", "20"),
-					resource.TestCheckResourceAttr(resourceName, "vips.1.sorry_server", "192.168.11.22"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.vip", "192.168.11.201"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.delay_loop", "10"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.sorry_server", "192.168.11.21"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.ipaddress", "192.168.11.51"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.check_protocol", "http"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.check_path", "/ping.html"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.check_status", "200"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.ipaddress", "192.168.11.52"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.check_protocol", "http"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.check_path", "/ping.html"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.check_status", "200"),
+					resource.TestCheckResourceAttr(resourceName, "vip.1.vip", "192.168.11.202"),
+					resource.TestCheckResourceAttr(resourceName, "vip.1.port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "vip.1.delay_loop", "20"),
+					resource.TestCheckResourceAttr(resourceName, "vip.1.sorry_server", "192.168.11.22"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -90,18 +90,18 @@ func TestAccSakuraCloudLoadBalancer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ipaddress2", ""),
 					resource.TestCheckResourceAttr(resourceName, "nw_mask_len", "24"),
 					resource.TestCheckResourceAttr(resourceName, "default_route", "192.168.11.1"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.vip", "192.168.11.201"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.port", "8080"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.delay_loop", "10"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.sorry_server", "192.168.11.21"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.0.ipaddress", "192.168.11.51"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.0.check_protocol", "ping"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.1.ipaddress", "192.168.11.52"),
-					resource.TestCheckResourceAttr(resourceName, "vips.0.servers.1.check_protocol", "ping"),
-					resource.TestCheckResourceAttr(resourceName, "vips.1.vip", "192.168.11.202"),
-					resource.TestCheckResourceAttr(resourceName, "vips.1.port", "6443"),
-					resource.TestCheckResourceAttr(resourceName, "vips.1.delay_loop", "20"),
-					resource.TestCheckResourceAttr(resourceName, "vips.1.sorry_server", "192.168.11.22"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.vip", "192.168.11.201"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.delay_loop", "10"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.sorry_server", "192.168.11.21"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.ipaddress", "192.168.11.51"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.check_protocol", "ping"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.ipaddress", "192.168.11.52"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.check_protocol", "ping"),
+					resource.TestCheckResourceAttr(resourceName, "vip.1.vip", "192.168.11.202"),
+					resource.TestCheckResourceAttr(resourceName, "vip.1.port", "6443"),
+					resource.TestCheckResourceAttr(resourceName, "vip.1.delay_loop", "20"),
+					resource.TestCheckResourceAttr(resourceName, "vip.1.sorry_server", "192.168.11.22"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 				),
 			},
@@ -253,25 +253,25 @@ resource "sakuracloud_load_balancer" "foobar" {
   tags        = ["tag1", "tag2"]
   icon_id     = sakuracloud_icon.foobar.id
 
-  vips {
+  vip {
     vip          = "192.168.11.201"
     port         = 80
     delay_loop   = 10
     sorry_server = "192.168.11.21"
-    servers {
+    server {
       ipaddress      = "192.168.11.51"
       check_protocol = "http"
       check_path     = "/ping.html"
       check_status   = 200
     }
-    servers {
+    server {
       ipaddress      = "192.168.11.52"
       check_protocol = "http"
       check_path     = "/ping.html"
       check_status   = 200
     }
   }
-  vips {
+  vip {
     vip          = "192.168.11.202"
     port         = 443
     delay_loop   = 20
@@ -301,21 +301,21 @@ resource "sakuracloud_load_balancer" "foobar" {
   description = "description-upd"
   tags        = ["tag1-upd", "tag2-upd"]
 
-  vips {
+  vip {
     vip          = "192.168.11.201"
     port         = 8080
     delay_loop   = 10
     sorry_server = "192.168.11.21"
-    servers {
+    server {
       ipaddress      = "192.168.11.51"
       check_protocol = "ping"
     }
-    servers {
+    server {
       ipaddress      = "192.168.11.52"
       check_protocol = "ping"
     }
   }
-  vips {
+  vip {
     vip          = "192.168.11.202"
     port         = 6443
     delay_loop   = 20

--- a/sakuracloud/resource_sakuracloud_mobile_gateway.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway.go
@@ -41,7 +41,7 @@ func resourceSakuraCloudMobileGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"private_interface": {
+			"network_interface": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -65,22 +65,13 @@ func resourceSakuraCloudMobileGateway() *schema.Resource {
 					},
 				},
 			},
-			"public_interface": {
-				Type:     schema.TypeList,
+			"public_ip": {
+				Type:     schema.TypeString,
 				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"ipaddress": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"nw_mask_len": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-					},
-				},
+			},
+			"public_netmask": {
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 			"internet_connection": {
 				Type:     schema.TypeBool,
@@ -138,7 +129,7 @@ func resourceSakuraCloudMobileGateway() *schema.Resource {
 					},
 				},
 			},
-			"static_routes": {
+			"static_route": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -319,12 +310,11 @@ func setMobileGatewayResourceData(ctx context.Context, d *schema.ResourceData, c
 	}
 
 	// set data
-	if err := d.Set("private_interface", flattenMobileGatewayPrivateNetworks(data)); err != nil {
+	if err := d.Set("network_interface", flattenMobileGatewayPrivateNetworks(data)); err != nil {
 		return err
 	}
-	if err := d.Set("public_interface", flattenMobileGatewayPublicNetworks(data)); err != nil {
-		return err
-	}
+	d.Set("public_ip", flattenMobileGatewayPublicIPAddress(data))
+	d.Set("public_netmask", flattenMobileGatewayPublicNetmask(data))
 	d.Set("internet_connection", data.Settings.InternetConnectionEnabled.Bool())
 	d.Set("inter_device_communication", data.Settings.InterDeviceCommunicationEnabled.Bool())
 
@@ -333,7 +323,7 @@ func setMobileGatewayResourceData(ctx context.Context, d *schema.ResourceData, c
 	}
 	d.Set("dns_server1", resolver.DNS1)
 	d.Set("dns_server2", resolver.DNS2)
-	if err := d.Set("static_routes", flattenMobileGatewayStaticRoutes(data.Settings.StaticRoute)); err != nil {
+	if err := d.Set("static_route", flattenMobileGatewayStaticRoutes(data.Settings.StaticRoute)); err != nil {
 		return err
 	}
 	d.Set("name", data.Name)

--- a/sakuracloud/resource_sakuracloud_mobile_gateway_test.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway_test.go
@@ -50,11 +50,11 @@ func TestAccSakuraCloudMobileGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2"),
 					resource.TestCheckResourceAttrPair(
-						resourceName, "private_interface.0.switch_id",
+						resourceName, "network_interface.0.switch_id",
 						"sakuracloud_switch.foobar", "id",
 					),
-					resource.TestCheckResourceAttr(resourceName, "private_interface.0.ipaddress", "192.168.11.101"),
-					resource.TestCheckResourceAttr(resourceName, "private_interface.0.nw_mask_len", "24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ipaddress", "192.168.11.101"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.nw_mask_len", "24"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -66,13 +66,13 @@ func TestAccSakuraCloudMobileGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "traffic_control.0.enable_slack", "true"),
 					resource.TestCheckResourceAttr(resourceName, "traffic_control.0.slack_webhook", "https://hooks.slack.com/services/xxx/xxx/xxx"),
 					resource.TestCheckResourceAttr(resourceName, "traffic_control.0.auto_traffic_shaping", "true"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.#", "3"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.0.prefix", "192.168.10.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.0.next_hop", "192.168.11.1"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.1.prefix", "192.168.10.0/25"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.1.next_hop", "192.168.11.2"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.2.prefix", "192.168.10.0/26"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.2.next_hop", "192.168.11.3"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.0.prefix", "192.168.10.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.0.next_hop", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.1.prefix", "192.168.10.0/25"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.1.next_hop", "192.168.11.2"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.2.prefix", "192.168.10.0/26"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.2.next_hop", "192.168.11.3"),
 				),
 			},
 			{
@@ -88,11 +88,11 @@ func TestAccSakuraCloudMobileGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "traffic_control.#", "0"),
 					resource.TestCheckResourceAttrPair(
-						resourceName, "private_interface.0.switch_id",
+						resourceName, "network_interface.0.switch_id",
 						"sakuracloud_switch.foobar", "id"),
-					resource.TestCheckResourceAttr(resourceName, "private_interface.0.ipaddress", "192.168.11.101"),
-					resource.TestCheckResourceAttr(resourceName, "private_interface.0.nw_mask_len", "24"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ipaddress", "192.168.11.101"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.nw_mask_len", "24"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "sims.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "sim_routes.#", "0"),
 				),
@@ -165,8 +165,8 @@ func TestAccImportSakuraCloudMobileGateway(t *testing.T) {
 		}
 		expects := map[string]string{
 			"name":                                   rand,
-			"private_interface.0.ipaddress":          "192.168.11.101",
-			"private_interface.0.nw_mask_len":        "24",
+			"network_interface.0.ipaddress":          "192.168.11.101",
+			"network_interface.0.nw_mask_len":        "24",
 			"description":                            "description",
 			"internet_connection":                    "true",
 			"inter_device_communication":             "false",
@@ -178,18 +178,18 @@ func TestAccImportSakuraCloudMobileGateway(t *testing.T) {
 			"traffic_control.0.enable_slack":         "true",
 			"traffic_control.0.slack_webhook":        "https://hooks.slack.com/services/xxx/xxx/xxx",
 			"traffic_control.0.auto_traffic_shaping": "true",
-			"static_routes.0.prefix":                 "192.168.10.0/24",
-			"static_routes.0.next_hop":               "192.168.11.1",
-			"static_routes.1.prefix":                 "192.168.10.0/25",
-			"static_routes.1.next_hop":               "192.168.11.2",
-			"static_routes.2.prefix":                 "192.168.10.0/26",
-			"static_routes.2.next_hop":               "192.168.11.3",
+			"static_route.0.prefix":                  "192.168.10.0/24",
+			"static_route.0.next_hop":                "192.168.11.1",
+			"static_route.1.prefix":                  "192.168.10.0/25",
+			"static_route.1.next_hop":                "192.168.11.2",
+			"static_route.2.prefix":                  "192.168.10.0/26",
+			"static_route.2.next_hop":                "192.168.11.3",
 		}
 
 		if err := compareStateMulti(s[0], expects); err != nil {
 			return err
 		}
-		return stateNotEmptyMulti(s[0], "private_interface.0.switch_id", "icon_id")
+		return stateNotEmptyMulti(s[0], "network_interface.0.switch_id", "icon_id")
 	}
 
 	resourceName := "sakuracloud_mobile_gateway.foobar"
@@ -224,7 +224,7 @@ resource "sakuracloud_switch" "foobar" {
 }
 
 resource "sakuracloud_mobile_gateway" "foobar" {
-  private_interface {
+  network_interface {
     switch_id   = sakuracloud_switch.foobar.id
     ipaddress   = "192.168.11.101"
     nw_mask_len = 24
@@ -246,15 +246,15 @@ resource "sakuracloud_mobile_gateway" "foobar" {
     auto_traffic_shaping = true
   }
 
-  static_routes {
+  static_route {
     prefix   = "192.168.10.0/24"
     next_hop = "192.168.11.1"
   }
-  static_routes {
+  static_route {
     prefix   = "192.168.10.0/25"
     next_hop = "192.168.11.2"
   }
-  static_routes {
+  static_route {
     prefix   = "192.168.10.0/26"
     next_hop = "192.168.11.3"
   }
@@ -273,7 +273,7 @@ resource "sakuracloud_switch" "foobar" {
   name = "{{ .arg0 }}"
 }
 resource "sakuracloud_mobile_gateway" "foobar" {
-  private_interface {
+  network_interface {
     switch_id   = sakuracloud_switch.foobar.id
     ipaddress   = "192.168.11.101"
     nw_mask_len = 24

--- a/sakuracloud/resource_sakuracloud_packet_filter.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter.go
@@ -43,7 +43,7 @@ func resourceSakuraCloudPacketFilter() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"expressions": {
+			"expression": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
@@ -167,5 +167,5 @@ func setPacketFilterResourceData(ctx context.Context, d *schema.ResourceData, cl
 	d.Set("name", data.Name)
 	d.Set("description", data.Description)
 	d.Set("zone", getZone(d, client))
-	return d.Set("expressions", flattenPacketFilterExpressions(data))
+	return d.Set("expression", flattenPacketFilterExpressions(data))
 }

--- a/sakuracloud/resource_sakuracloud_packet_filter_rules.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter_rules.go
@@ -40,7 +40,7 @@ func resourceSakuraCloudPacketFilterRules() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateSakuracloudIDType,
 			},
-			"expressions": {
+			"expression": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
@@ -162,5 +162,5 @@ func resourceSakuraCloudPacketFilterRulesDelete(d *schema.ResourceData, meta int
 
 func setPacketFilterRulesResourceData(ctx context.Context, d *schema.ResourceData, client *APIClient, data *sacloud.PacketFilter) error {
 	d.Set("zone", getZone(d, client))
-	return d.Set("expressions", flattenPacketFilterExpressions(data))
+	return d.Set("expression", flattenPacketFilterExpressions(data))
 }

--- a/sakuracloud/resource_sakuracloud_packet_filter_rules_test.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter_rules_test.go
@@ -35,45 +35,45 @@ func TestAccSakuraCloudPacketFilterRules_basic(t *testing.T) {
 				Config: buildConfigWithArgs(testAccSakuraCloudPacketFilterRules_basic, rand),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudPacketFilterExists("sakuracloud_packet_filter.foobar", &filter),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.protocol", "tcp"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.source_network", "192.168.2.0"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.source_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.destination_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.allow", "true"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.source_network", "192.168.2.0"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.source_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.destination_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.allow", "true"),
 
-					resource.TestCheckResourceAttr(resourceName, "expressions.1.protocol", "tcp"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.1.source_network", "192.168.2.0"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.1.source_port", "443"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.1.destination_port", "443"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.1.allow", "true"),
+					resource.TestCheckResourceAttr(resourceName, "expression.1.protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "expression.1.source_network", "192.168.2.0"),
+					resource.TestCheckResourceAttr(resourceName, "expression.1.source_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "expression.1.destination_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "expression.1.allow", "true"),
 
-					resource.TestCheckResourceAttr(resourceName, "expressions.2.protocol", "ip"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.2.source_network", ""),
-					resource.TestCheckResourceAttr(resourceName, "expressions.2.source_port", ""),
-					resource.TestCheckResourceAttr(resourceName, "expressions.2.destination_port", ""),
-					resource.TestCheckResourceAttr(resourceName, "expressions.2.allow", "false"),
+					resource.TestCheckResourceAttr(resourceName, "expression.2.protocol", "ip"),
+					resource.TestCheckResourceAttr(resourceName, "expression.2.source_network", ""),
+					resource.TestCheckResourceAttr(resourceName, "expression.2.source_port", ""),
+					resource.TestCheckResourceAttr(resourceName, "expression.2.destination_port", ""),
+					resource.TestCheckResourceAttr(resourceName, "expression.2.allow", "false"),
 				),
 			},
 			{
 				Config: buildConfigWithArgs(testAccSakuraCloudPacketFilterRules_update, rand),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.protocol", "udp"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.source_network", "192.168.2.2"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.source_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.destination_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.allow", "true"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.protocol", "udp"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.source_network", "192.168.2.2"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.source_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.destination_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.allow", "true"),
 
-					resource.TestCheckResourceAttr(resourceName, "expressions.1.protocol", "udp"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.1.source_network", "192.168.2.2"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.1.source_port", "443"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.1.destination_port", "443"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.1.allow", "true"),
+					resource.TestCheckResourceAttr(resourceName, "expression.1.protocol", "udp"),
+					resource.TestCheckResourceAttr(resourceName, "expression.1.source_network", "192.168.2.2"),
+					resource.TestCheckResourceAttr(resourceName, "expression.1.source_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "expression.1.destination_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "expression.1.allow", "true"),
 
-					resource.TestCheckResourceAttr(resourceName, "expressions.2.protocol", "ip"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.2.source_network", ""),
-					resource.TestCheckResourceAttr(resourceName, "expressions.2.source_port", ""),
-					resource.TestCheckResourceAttr(resourceName, "expressions.2.destination_port", ""),
-					resource.TestCheckResourceAttr(resourceName, "expressions.2.allow", "false"),
+					resource.TestCheckResourceAttr(resourceName, "expression.2.protocol", "ip"),
+					resource.TestCheckResourceAttr(resourceName, "expression.2.source_network", ""),
+					resource.TestCheckResourceAttr(resourceName, "expression.2.source_port", ""),
+					resource.TestCheckResourceAttr(resourceName, "expression.2.destination_port", ""),
+					resource.TestCheckResourceAttr(resourceName, "expression.2.allow", "false"),
 				),
 			},
 		},
@@ -87,21 +87,21 @@ resource "sakuracloud_packet_filter" "foobar" {
 
 resource sakuracloud_packet_filter_rules "rules" {
   packet_filter_id = sakuracloud_packet_filter.foobar.id
-  expressions {
+  expression {
  	protocol         = "tcp"
 	source_network   = "192.168.2.0"
 	source_port      = "80"
 	destination_port = "80"
 	allow            = true
   }
-  expressions {
+  expression {
 	protocol         = "tcp"
 	source_network   = "192.168.2.0"
 	source_port      = "443"
 	destination_port = "443"
 	allow            = true
   }
-  expressions {
+  expression {
  	protocol = "ip"
 	allow    = false
   }
@@ -115,21 +115,21 @@ resource "sakuracloud_packet_filter" "foobar" {
 
 resource sakuracloud_packet_filter_rules "rules" {
   packet_filter_id = sakuracloud_packet_filter.foobar.id
-  expressions {
+  expression {
    	protocol         = "udp"
   	source_network   = "192.168.2.2"
   	source_port      = "80"
   	destination_port = "80"
    	allow            = true
   }
-  expressions {
+  expression {
    	protocol         = "udp"
   	source_network   = "192.168.2.2"
   	source_port      = "443"
   	destination_port = "443"
   	allow            = true
   }
-  expressions {
+  expression {
   	protocol = "ip"
 	allow    = false
   }

--- a/sakuracloud/resource_sakuracloud_packet_filter_test.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter_test.go
@@ -41,12 +41,12 @@ func TestAccSakuraCloudPacketFilter_basic(t *testing.T) {
 					testCheckSakuraCloudPacketFilterExists(resourceName, &filter),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.protocol", "tcp"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.source_network", "0.0.0.0"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.source_port", "0-65535"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.destination_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.allow", "true"),
+					resource.TestCheckResourceAttr(resourceName, "expression.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.source_network", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.source_port", "0-65535"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.destination_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.allow", "true"),
 				),
 			},
 			{
@@ -54,14 +54,14 @@ func TestAccSakuraCloudPacketFilter_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rand+"-upd"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description-upd"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.#", "5"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.protocol", "tcp"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.source_network", "192.168.2.0"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.source_port", "8080"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.destination_port", "8080"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.0.allow", "false"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.4.protocol", "ip"),
-					resource.TestCheckResourceAttr(resourceName, "expressions.4.allow", "true"),
+					resource.TestCheckResourceAttr(resourceName, "expression.#", "5"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.source_network", "192.168.2.0"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.source_port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.destination_port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.allow", "false"),
+					resource.TestCheckResourceAttr(resourceName, "expression.4.protocol", "ip"),
+					resource.TestCheckResourceAttr(resourceName, "expression.4.allow", "true"),
 				),
 			},
 		},
@@ -125,14 +125,14 @@ var testAccSakuraCloudPacketFilter_basic = `
 resource "sakuracloud_packet_filter" "foobar" {
   name        = "{{ .arg0 }}"
   description = "description"
-  expressions {
+  expression {
     protocol         = "tcp"
     source_network   = "0.0.0.0"
     source_port      = "0-65535"
     destination_port = "80"
     allow            = true
   }
-  expressions {
+  expression {
     protocol         = "udp"
     source_network   = "0.0.0.0"
     source_port      = "0-65535"
@@ -145,31 +145,31 @@ var testAccSakuraCloudPacketFilter_update = `
 resource "sakuracloud_packet_filter" "foobar" {
   name        = "{{ .arg0 }}-upd"
   description = "description-upd"
-  expressions {
+  expression {
     protocol         = "tcp"
     source_network   = "192.168.2.0"
     source_port      = "8080"
     destination_port = "8080"
     allow            = false
   }
-  expressions {
+  expression {
     protocol         = "udp"
     source_network   = "0.0.0.0"
     source_port      = "0-65535"
     destination_port = "80"
     allow            = true
   }
-  expressions {
+  expression {
     protocol       = "icmp"
     source_network = "0.0.0.0"
     allow          = true
   }
-  expressions {
+  expression {
     protocol       = "fragment"
     source_network = "0.0.0.0"
     allow          = true
   }
-  expressions {
+  expression {
     protocol       = "ip"
     source_network = "0.0.0.0"
     allow          = true

--- a/sakuracloud/resource_sakuracloud_private_host_test.go
+++ b/sakuracloud/resource_sakuracloud_private_host_test.go
@@ -191,7 +191,7 @@ var testAccSakuraCloudPrivateHost_destroy = `
 resource "sakuracloud_server" "foobar" {
   name            = "{{ .arg0 }}"
   private_host_id = sakuracloud_private_host.foobar.id
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
 
@@ -206,7 +206,7 @@ var testAccSakuraCloudPrivateHost_destroyed = `
 resource "sakuracloud_server" "foobar" {
   name = "{{ .arg0 }}"
 
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
 

--- a/sakuracloud/resource_sakuracloud_proxylb.go
+++ b/sakuracloud/resource_sakuracloud_proxylb.go
@@ -77,7 +77,7 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 				}, false),
 				ForceNew: true,
 			},
-			"bind_ports": {
+			"bind_port": {
 				Type:     schema.TypeList,
 				Required: true,
 				MaxItems: 2,
@@ -196,7 +196,7 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
-						"additional_certificates": {
+						"additional_certificate": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Computed: true,
@@ -220,7 +220,7 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 					},
 				},
 			},
-			"servers": {
+			"server": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 40,
@@ -403,7 +403,7 @@ func setProxyLBResourceData(ctx context.Context, d *schema.ResourceData, client 
 	d.Set("sticky_session", flattenProxyLBStickySession(data))
 	d.Set("timeout", flattenProxyLBTimeout(data))
 	d.Set("region", data.Region.String())
-	if err := d.Set("bind_ports", flattenProxyLBBindPorts(data)); err != nil {
+	if err := d.Set("bind_port", flattenProxyLBBindPorts(data)); err != nil {
 		return err
 	}
 	if err := d.Set("health_check", flattenProxyLBHealthCheck(data)); err != nil {
@@ -412,7 +412,7 @@ func setProxyLBResourceData(ctx context.Context, d *schema.ResourceData, client 
 	if err := d.Set("sorry_server", flattenProxyLBSorryServer(data)); err != nil {
 		return err
 	}
-	if err := d.Set("servers", flattenProxyLBServers(data)); err != nil {
+	if err := d.Set("server", flattenProxyLBServers(data)); err != nil {
 		return err
 	}
 	d.Set("fqdn", data.FQDN)

--- a/sakuracloud/resource_sakuracloud_proxylb_acme.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_acme.go
@@ -71,7 +71,7 @@ func resourceSakuraCloudProxyLBACME() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"additional_certificates": {
+						"additional_certificate": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
@@ -237,7 +237,7 @@ func setProxyLBACMEResourceData(ctx context.Context, d *schema.ResourceData, cli
 				"private_key":       cert.PrivateKey,
 			})
 		}
-		proxylbCert["additional_certificates"] = certs
+		proxylbCert["additional_certificate"] = certs
 	}
 
 	if err := d.Set("certificate", []interface{}{proxylbCert}); err != nil {

--- a/sakuracloud/resource_sakuracloud_proxylb_acme_test.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_acme_test.go
@@ -66,15 +66,15 @@ resource "sakuracloud_proxylb" "foobar" {
     host_header = "usacloud.jp"
     path        = "/"
   }
-  bind_ports {
+  bind_port {
     proxy_mode = "http"
     port       = 80
   }
-  bind_ports {
+  bind_port {
     proxy_mode = "https"
     port       = 443
   }
-  servers {
+  server {
     ipaddress = sakuracloud_server.foobar.ipaddress
     port      = 80
   }

--- a/sakuracloud/resource_sakuracloud_proxylb_test.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_test.go
@@ -68,15 +68,15 @@ func TestAccSakuraCloudProxyLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/"),
 					resource.TestCheckResourceAttr(resourceName, "sorry_server.0.ipaddress", ip),
 					resource.TestCheckResourceAttr(resourceName, "sorry_server.0.port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "bind_ports.0.proxy_mode", "http"),
-					resource.TestCheckResourceAttr(resourceName, "bind_ports.0.port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "bind_ports.0.response_header.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "bind_ports.0.response_header.0.header", "Cache-Control"),
-					resource.TestCheckResourceAttr(resourceName, "bind_ports.0.response_header.0.value", "public, max-age=10"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "bind_port.0.proxy_mode", "http"),
+					resource.TestCheckResourceAttr(resourceName, "bind_port.0.port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "bind_port.0.response_header.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "bind_port.0.response_header.0.header", "Cache-Control"),
+					resource.TestCheckResourceAttr(resourceName, "bind_port.0.response_header.0.value", "public, max-age=10"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.enabled", "true"),
 					resource.TestCheckResourceAttrPair(
-						resourceName, "servers.0.ipaddress",
+						resourceName, "server.0.ipaddress",
 						"sakuracloud_server.foobar", "ipaddress",
 					),
 					resource.TestCheckResourceAttrPair(
@@ -100,13 +100,13 @@ func TestAccSakuraCloudProxyLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.host_header", ""),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", ""),
 					resource.TestCheckNoResourceAttr(resourceName, "sorry_server.0.ipaddress.#"),
-					resource.TestCheckResourceAttr(resourceName, "bind_ports.0.proxy_mode", "https"),
-					resource.TestCheckResourceAttr(resourceName, "bind_ports.0.port", "443"),
-					resource.TestCheckResourceAttr(resourceName, "bind_ports.0.response_header.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.port", "443"),
-					resource.TestCheckResourceAttr(resourceName, "servers.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "bind_port.0.proxy_mode", "https"),
+					resource.TestCheckResourceAttr(resourceName, "bind_port.0.port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "bind_port.0.response_header.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.enabled", "true"),
 					resource.TestCheckResourceAttrPair(
-						resourceName, "servers.0.ipaddress",
+						resourceName, "server.0.ipaddress",
 						"sakuracloud_server.foobar", "ipaddress",
 					),
 				),
@@ -186,15 +186,15 @@ func TestAccImportSakuraCloudProxyLB(t *testing.T) {
 			"description":               "description",
 			"tags.0":                    "tag1",
 			"tags.1":                    "tag2",
-			"bind_ports.0.proxy_mode":   "https",
-			"bind_ports.0.port":         "443",
-			"servers.#":                 "2",
-			"servers.0.ipaddress":       ip0,
-			"servers.0.port":            "80",
-			"servers.0.enabled":         "true",
-			"servers.1.ipaddress":       ip1,
-			"servers.1.port":            "80",
-			"servers.1.enabled":         "true",
+			"bind_port.0.proxy_mode":    "https",
+			"bind_port.0.port":          "443",
+			"server.#":                  "2",
+			"server.0.ipaddress":        ip0,
+			"server.0.port":             "80",
+			"server.0.enabled":          "true",
+			"server.1.ipaddress":        ip1,
+			"server.1.port":             "80",
+			"server.1.enabled":          "true",
 		}
 
 		if err := compareStateMulti(s[0], expects); err != nil {
@@ -241,7 +241,7 @@ resource "sakuracloud_proxylb" "foobar" {
     ipaddress = "{{ .arg1 }}"
     port      = 80
   }
-  bind_ports {
+  bind_port {
     proxy_mode = "http"
     port       = 80
     response_header {
@@ -249,7 +249,7 @@ resource "sakuracloud_proxylb" "foobar" {
       value  = "public, max-age=10"
     }
   }
-  servers {
+  server {
     ipaddress = sakuracloud_server.foobar.ipaddress
     port      = 80
   }
@@ -266,7 +266,7 @@ resource "sakuracloud_icon" "foobar" {
 resource sakuracloud_server "foobar" {
   name = "{{ .arg0 }}"
 
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
 
@@ -286,12 +286,12 @@ resource "sakuracloud_proxylb" "foobar" {
     protocol   = "tcp"
     delay_loop = 20
   }
-  bind_ports {
+  bind_port {
     proxy_mode = "https"
     port       = 443
   }
 
-  servers {
+  server {
     ipaddress = sakuracloud_server.foobar.ipaddress
     port      = 443
   }
@@ -303,7 +303,7 @@ resource "sakuracloud_proxylb" "foobar" {
 resource sakuracloud_server "foobar" {
   name = "{{ .arg0 }}"
 
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
 
@@ -322,15 +322,15 @@ resource "sakuracloud_proxylb" "foobar" {
     protocol   = "tcp"
     delay_loop = 20
   }
-  bind_ports {
+  bind_port {
     proxy_mode = "https"
     port       = 443
   }
-  servers {
+  server {
     ipaddress = "{{ .arg1 }}"
     port      = 80
   }
-  servers {
+  server {
     ipaddress = "{{ .arg2 }}"
     port      = 80
   }

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -76,7 +76,7 @@ func resourceSakuraCloudServer() *schema.Resource {
 					types.InterfaceDrivers.E1000.String(),
 				}, false),
 			},
-			"interfaces": {
+			"network_interface": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 10,
@@ -313,7 +313,7 @@ func setServerResourceData(ctx context.Context, d *schema.ResourceData, client *
 	d.Set("interface_driver", data.InterfaceDriver.String())
 	d.Set("private_host_id", data.PrivateHostID.String())
 	d.Set("private_host_name", data.PrivateHostName)
-	if err := d.Set("interfaces", flattenServerNICs(data)); err != nil {
+	if err := d.Set("network_interface", flattenServerNICs(data)); err != nil {
 		return err
 	}
 	d.Set("icon_id", data.IconID.String())
@@ -334,7 +334,7 @@ func setServerResourceData(ctx context.Context, d *schema.ResourceData, client *
 
 func isServerDiskConfigChanged(d *schema.ResourceData) bool {
 	return d.HasChange("disks") ||
-		d.HasChange("interfaces") ||
+		d.HasChange("network_interface") ||
 		d.HasChange("ipaddress") ||
 		d.HasChange("gateway") ||
 		d.HasChange("nw_mask_len") ||

--- a/sakuracloud/resource_sakuracloud_server_test.go
+++ b/sakuracloud/resource_sakuracloud_server_test.go
@@ -58,9 +58,9 @@ func TestAccSakuraCloudServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "disable_pw_auth", "true"),
 					resource.TestCheckResourceAttr(resourceName, "note_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "note_ids.0", "100000000000"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.upstream", "shared"),
-					resource.TestCheckResourceAttrSet(resourceName, "interfaces.0.macaddress"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.upstream", "shared"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interface.0.macaddress"),
 					resource.TestCheckResourceAttrSet(resourceName, "ipaddress"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
@@ -82,7 +82,7 @@ func TestAccSakuraCloudServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2-upd"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.upstream", "shared"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.upstream", "shared"),
 					resource.TestCheckResourceAttrSet(resourceName, "nw_address"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 				),
@@ -106,8 +106,8 @@ func TestAccSakuraCloudServer_interfaces(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudServerExists(resourceName, &server),
 					testCheckSakuraCloudServerAttributes(&server),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.upstream", "shared"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.upstream", "shared"),
 				),
 			},
 			{
@@ -115,8 +115,8 @@ func TestAccSakuraCloudServer_interfaces(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudServerExists(resourceName, &server),
 					testCheckSakuraCloudServerAttributes(&server),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.upstream", "shared"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.upstream", "shared"),
 				),
 			},
 			{
@@ -124,8 +124,8 @@ func TestAccSakuraCloudServer_interfaces(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudServerExists(resourceName, &server),
 					testCheckSakuraCloudServerAttributes(&server),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.#", "4"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.upstream", "shared"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.upstream", "shared"),
 				),
 			},
 			{
@@ -133,8 +133,8 @@ func TestAccSakuraCloudServer_interfaces(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudServerExists(resourceName, &server),
 					testCheckSakuraCloudServerSharedInterface(&server),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.upstream", "disconnect"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.upstream", "disconnect"),
 				),
 			},
 		},
@@ -153,13 +153,13 @@ func TestAccSakuraCloudServer_packetFilter(t *testing.T) {
 			{
 				Config: buildConfigWithArgs(testAccSakuraCloudServer_packetFilter, rand),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "interfaces.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "2"),
 					resource.TestCheckResourceAttrPair(
-						resourceName, "interfaces.0.packet_filter_id",
+						resourceName, "network_interface.0.packet_filter_id",
 						"sakuracloud_packet_filter.foobar", "id",
 					),
 					resource.TestCheckResourceAttrPair(
-						resourceName, "interfaces.1.packet_filter_id",
+						resourceName, "network_interface.1.packet_filter_id",
 						"sakuracloud_packet_filter.foobar", "id",
 					),
 				),
@@ -167,9 +167,9 @@ func TestAccSakuraCloudServer_packetFilter(t *testing.T) {
 			{
 				Config: buildConfigWithArgs(testAccSakuraCloudServer_packetFilterUpdate, rand),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "interfaces.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
 					resource.TestCheckResourceAttrPair(
-						resourceName, "interfaces.0.packet_filter_id",
+						resourceName, "network_interface.0.packet_filter_id",
 						"sakuracloud_packet_filter.foobar", "id",
 					),
 				),
@@ -177,8 +177,8 @@ func TestAccSakuraCloudServer_packetFilter(t *testing.T) {
 			{
 				Config: buildConfigWithArgs(testAccSakuraCloudServer_packetFilterDelete, rand),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "interfaces.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.packet_filter_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.packet_filter_id", ""),
 				),
 			},
 		},
@@ -331,7 +331,7 @@ resource "sakuracloud_server" "foobar" {
   description = "description"
   tags        = ["tag1", "tag2"]
   icon_id     = sakuracloud_icon.foobar.id
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
 
@@ -366,7 +366,7 @@ resource "sakuracloud_server" "foobar" {
   description      = "description-upd"
   tags             = ["tag1-upd", "tag2-upd"]
   interface_driver = "e1000"
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
 }
@@ -376,7 +376,7 @@ const testAccSakuraCloudServer_interfaces = `
 resource "sakuracloud_server" "foobar" {
   name = "{{ .arg0 }}"
 
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
 
@@ -388,10 +388,10 @@ const testAccSakuraCloudServer_interfacesAdded = `
 resource "sakuracloud_server" "foobar" {
   name = "{{ .arg0 }}"
 
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
-  interfaces {
+  network_interface {
     upstream = sakuracloud_switch.foobar0.id
   }
 
@@ -406,16 +406,16 @@ const testAccSakuraCloudServer_interfacesUpdated = `
 resource "sakuracloud_server" "foobar" {
   name = "{{ .arg0 }}"
 
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
-  interfaces {
+  network_interface {
     upstream = sakuracloud_switch.foobar0.id
   }
-  interfaces {
+  network_interface {
     upstream = sakuracloud_switch.foobar1.id
   }
-  interfaces {
+  network_interface {
     upstream = sakuracloud_switch.foobar2.id
   }
 
@@ -437,10 +437,10 @@ const testAccSakuraCloudServer_interfacesDisconnect = `
 resource "sakuracloud_server" "foobar" {
   name = "{{ .arg0 }}"
 
-  interfaces {
+  network_interface {
     upstream = "disconnect"
   }
-  interfaces {
+  network_interface {
     upstream = sakuracloud_switch.foobar0.id
   }
 
@@ -454,7 +454,7 @@ resource "sakuracloud_switch" "foobar0" {
 const testAccSakuraCloudServer_packetFilter = `
 resource "sakuracloud_packet_filter" "foobar" {
   name = "{{ .arg0 }}"
-  expressions {
+  expression {
     protocol         = "tcp"
     source_network   = "0.0.0.0"
     source_port      = "0-65535"
@@ -465,11 +465,11 @@ resource "sakuracloud_packet_filter" "foobar" {
 
 resource "sakuracloud_server" "foobar" {
   name = "{{ .arg0 }}"
-  interfaces {
+  network_interface {
     upstream         = "shared"
     packet_filter_id = sakuracloud_packet_filter.foobar.id
   }
-  interfaces {
+  network_interface {
     upstream         = sakuracloud_switch.foobar.id
     packet_filter_id = sakuracloud_packet_filter.foobar.id
   }
@@ -486,7 +486,7 @@ const testAccSakuraCloudServer_packetFilterUpdate = `
 resource "sakuracloud_packet_filter" "foobar" {
   name = "{{ .arg0 }}-upd"
 
-  expressions {
+  expression {
     protocol         = "udp"
     source_network   = "0.0.0.0"
     source_port      = "0-65535"
@@ -498,7 +498,7 @@ resource "sakuracloud_packet_filter" "foobar" {
 resource "sakuracloud_server" "foobar" {
   name = "{{ .arg0 }}-upd"
 
-  interfaces {
+  network_interface {
     upstream         = "shared"
     packet_filter_id = sakuracloud_packet_filter.foobar.id
   }
@@ -510,7 +510,7 @@ resource "sakuracloud_server" "foobar" {
 const testAccSakuraCloudServer_packetFilterDelete = `
 resource "sakuracloud_server" "foobar" {
   name = "{{ .arg0 }}-del"
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
   force_shutdown = true
@@ -521,7 +521,7 @@ resource "sakuracloud_server" "foobar" {
   name  = "{{ .arg0 }}"
   disks = [sakuracloud_disk.foobar.id]
 
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
   force_shutdown = true
@@ -549,7 +549,7 @@ resource "sakuracloud_server" "foobar" {
   name  = "{{ .arg0 }}"
   disks = [sakuracloud_disk.foobar.id]
 
-  interfaces {
+  network_interface {
     upstream = sakuracloud_switch.foobar.id
   }
 

--- a/sakuracloud/resource_sakuracloud_sim_test.go
+++ b/sakuracloud/resource_sakuracloud_sim_test.go
@@ -268,7 +268,7 @@ resource "sakuracloud_switch" "foobar" {
   name = "{{ .arg0 }}"
 }
 resource "sakuracloud_mobile_gateway" "foobar" {
-  private_interface {
+  network_interface {
     switch_id   = sakuracloud_switch.foobar.id
     ipaddress   = "192.168.0.1"
     nw_mask_len = 24
@@ -312,7 +312,7 @@ resource "sakuracloud_switch" "foobar" {
 }
 
 resource "sakuracloud_mobile_gateway" "foobar" {
-  private_interface {
+  network_interface {
     switch_id   = sakuracloud_switch.foobar.id
     ipaddress   = "192.168.0.1"
     nw_mask_len = 24
@@ -339,7 +339,7 @@ resource "sakuracloud_switch" "foobar" {
   name = "{{ .arg0 }}"
 }
 resource "sakuracloud_mobile_gateway" "foobar" {
-  private_interface {
+  network_interface {
     switch_id   = sakuracloud_switch.foobar.id
     ipaddress   = "192.168.0.1"
     nw_mask_len = 24

--- a/sakuracloud/resource_sakuracloud_switch_test.go
+++ b/sakuracloud/resource_sakuracloud_switch_test.go
@@ -146,10 +146,10 @@ resource "sakuracloud_icon" "foobar" {
 var testAccSakuraCloudSwitch_update = `
 resource "sakuracloud_server" "foobar" {
   name        = "{{ .arg0 }}"
-  interfaces {
+  network_interface {
     upstream = "shared"
   }
-  interfaces {
+  network_interface {
     upstream = sakuracloud_switch.foobar.id
   }
 

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -88,7 +88,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
-			"interfaces": {
+			"network_interface": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 7,
@@ -123,7 +123,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"dhcp_servers": {
+			"dhcp_server": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -151,7 +151,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"dhcp_static_mappings": {
+			"dhcp_static_mapping": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -167,7 +167,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"firewalls": {
+			"firewall": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -182,7 +182,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{"send", "receive"}, false),
 						},
-						"expressions": {
+						"expression": {
 							Type:     schema.TypeList,
 							Required: true,
 							Elem: &schema.Resource{
@@ -252,7 +252,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"port_forwardings": {
+			"port_forwarding": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -359,7 +359,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"static_routes": {
+			"static_route": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -376,7 +376,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
-			"users": {
+			"user": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 100,
@@ -535,16 +535,16 @@ func setVPCRouterResourceData(ctx context.Context, d *schema.ResourceData, clien
 	d.Set("vrid", flattenVPCRouterVRID(data))
 	d.Set("syslog_host", data.Settings.SyslogHost)
 	d.Set("internet_connection", data.Settings.InternetConnectionEnabled.Bool())
-	if err := d.Set("interfaces", flattenVPCRouterInterfaces(data)); err != nil {
+	if err := d.Set("network_interface", flattenVPCRouterInterfaces(data)); err != nil {
 		return err
 	}
-	if err := d.Set("dhcp_servers", flattenVPCRouterDHCPServers(data)); err != nil {
+	if err := d.Set("dhcp_server", flattenVPCRouterDHCPServers(data)); err != nil {
 		return err
 	}
-	if err := d.Set("dhcp_static_mappings", flattenVPCRouterDHCPStaticMappings(data)); err != nil {
+	if err := d.Set("dhcp_static_mapping", flattenVPCRouterDHCPStaticMappings(data)); err != nil {
 		return err
 	}
-	if err := d.Set("firewalls", flattenVPCRouterFirewalls(data)); err != nil {
+	if err := d.Set("firewall", flattenVPCRouterFirewalls(data)); err != nil {
 		return err
 	}
 	if err := d.Set("l2tp", flattenVPCRouterL2TP(data)); err != nil {
@@ -553,7 +553,7 @@ func setVPCRouterResourceData(ctx context.Context, d *schema.ResourceData, clien
 	if err := d.Set("pptp", flattenVPCRouterPPTP(data)); err != nil {
 		return err
 	}
-	if err := d.Set("port_forwardings", flattenVPCRouterPortForwardings(data)); err != nil {
+	if err := d.Set("port_forwarding", flattenVPCRouterPortForwardings(data)); err != nil {
 		return err
 	}
 	if err := d.Set("site_to_site_vpn", flattenVPCRouterSiteToSite(data)); err != nil {
@@ -562,10 +562,10 @@ func setVPCRouterResourceData(ctx context.Context, d *schema.ResourceData, clien
 	if err := d.Set("static_nat", flattenVPCRouterStaticNAT(data)); err != nil {
 		return err
 	}
-	if err := d.Set("static_routes", flattenVPCRouterStaticRoutes(data)); err != nil {
+	if err := d.Set("static_route", flattenVPCRouterStaticRoutes(data)); err != nil {
 		return err
 	}
-	if err := d.Set("users", flattenVPCRouterUsers(data)); err != nil {
+	if err := d.Set("user", flattenVPCRouterUsers(data)); err != nil {
 		return err
 	}
 	d.Set("zone", getZone(d, client))

--- a/sakuracloud/resource_sakuracloud_vpc_router_test.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_test.go
@@ -101,48 +101,48 @@ func TestAccResourceSakuraCloudVPCRouter_Full(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudVPCRouterExists(resourceName, &vpcRouter),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.vip", "192.168.11.1"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ipaddresses.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ipaddresses.0", "192.168.11.2"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ipaddresses.1", "192.168.11.3"),
-					resource.TestCheckResourceAttr(resourceName, "interfaces.0.nw_mask_len", "24"),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_servers.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_servers.0.interface_index", "1"),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_servers.0.range_start", "192.168.11.11"),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_servers.0.range_stop", "192.168.11.20"),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_servers.0.dns_servers.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_servers.0.dns_servers.0", "8.8.8.8"),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_servers.0.dns_servers.1", "8.8.4.4"),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_static_mappings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_static_mappings.0.ipaddress", "192.168.11.10"),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_static_mappings.0.macaddress", "aa:bb:cc:aa:bb:cc"),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.interface_index", "1"),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.direction", "send"),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.0.protocol", "tcp"),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.0.allow", "true"),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.0.source_network", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.0.source_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.0.destination_network", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.0.destination_port", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.1.protocol", "ip"),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.1.allow", "false"),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.1.source_network", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.1.source_port", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.1.destination_network", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewalls.0.expressions.1.destination_port", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.vip", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ipaddresses.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ipaddresses.0", "192.168.11.2"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ipaddresses.1", "192.168.11.3"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.nw_mask_len", "24"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_server.0.interface_index", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_server.0.range_start", "192.168.11.11"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_server.0.range_stop", "192.168.11.20"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_server.0.dns_servers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_server.0.dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_server.0.dns_servers.1", "8.8.4.4"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_static_mapping.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_static_mapping.0.ipaddress", "192.168.11.10"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_static_mapping.0.macaddress", "aa:bb:cc:aa:bb:cc"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.interface_index", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.direction", "send"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.allow", "true"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.source_network", ""),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.source_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.destination_network", ""),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.destination_port", ""),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.protocol", "ip"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.allow", "false"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.source_network", ""),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.source_port", ""),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.destination_network", ""),
+					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.destination_port", ""),
 					resource.TestCheckResourceAttr(resourceName, "l2tp.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "l2tp.0.pre_shared_secret", "example"),
 					resource.TestCheckResourceAttr(resourceName, "l2tp.0.range_start", "192.168.11.21"),
 					resource.TestCheckResourceAttr(resourceName, "l2tp.0.range_stop", "192.168.11.30"),
-					resource.TestCheckResourceAttr(resourceName, "port_forwardings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "port_forwardings.0.protocol", "udp"),
-					resource.TestCheckResourceAttr(resourceName, "port_forwardings.0.global_port", "10022"),
-					resource.TestCheckResourceAttr(resourceName, "port_forwardings.0.private_address", "192.168.11.11"),
-					resource.TestCheckResourceAttr(resourceName, "port_forwardings.0.private_port", "22"),
-					resource.TestCheckResourceAttr(resourceName, "port_forwardings.0.description", "desc"),
+					resource.TestCheckResourceAttr(resourceName, "port_forwarding.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "port_forwarding.0.protocol", "udp"),
+					resource.TestCheckResourceAttr(resourceName, "port_forwarding.0.global_port", "10022"),
+					resource.TestCheckResourceAttr(resourceName, "port_forwarding.0.private_address", "192.168.11.11"),
+					resource.TestCheckResourceAttr(resourceName, "port_forwarding.0.private_port", "22"),
+					resource.TestCheckResourceAttr(resourceName, "port_forwarding.0.description", "desc"),
 					resource.TestCheckResourceAttr(resourceName, "pptp.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "pptp.0.range_start", "192.168.11.31"),
 					resource.TestCheckResourceAttr(resourceName, "pptp.0.range_stop", "192.168.11.40"),
@@ -160,12 +160,12 @@ func TestAccResourceSakuraCloudVPCRouter_Full(t *testing.T) {
 						"sakuracloud_internet.foobar", "ipaddresses.3"),
 					resource.TestCheckResourceAttr(resourceName, "static_nat.0.private_address", "192.168.11.12"),
 					resource.TestCheckResourceAttr(resourceName, "static_nat.0.description", "desc"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.0.prefix", "172.16.0.0/16"),
-					resource.TestCheckResourceAttr(resourceName, "static_routes.0.next_hop", "192.168.11.99"),
-					resource.TestCheckResourceAttr(resourceName, "users.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "users.0.name", "username"),
-					resource.TestCheckResourceAttr(resourceName, "users.0.password", "password"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.0.prefix", "172.16.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "static_route.0.next_hop", "192.168.11.99"),
+					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.name", "username"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.password", "password"),
 				),
 			},
 			{
@@ -173,17 +173,17 @@ func TestAccResourceSakuraCloudVPCRouter_Full(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudVPCRouterExists(resourceName, &vpcRouter),
 					resource.TestCheckResourceAttr(resourceName, "name", rand+"-upd"),
-					resource.TestCheckNoResourceAttr(resourceName, "interfaces"),
-					resource.TestCheckNoResourceAttr(resourceName, "dhcp_servers"),
-					resource.TestCheckNoResourceAttr(resourceName, "dhcp_static_mappings"),
-					resource.TestCheckNoResourceAttr(resourceName, "firewalls"),
+					resource.TestCheckNoResourceAttr(resourceName, "network_interface"),
+					resource.TestCheckNoResourceAttr(resourceName, "dhcp_server"),
+					resource.TestCheckNoResourceAttr(resourceName, "dhcp_static_mapping"),
+					resource.TestCheckNoResourceAttr(resourceName, "firewall"),
 					resource.TestCheckNoResourceAttr(resourceName, "l2tp"),
-					resource.TestCheckNoResourceAttr(resourceName, "port_forwardings"),
+					resource.TestCheckNoResourceAttr(resourceName, "port_forwarding"),
 					resource.TestCheckNoResourceAttr(resourceName, "pptp"),
 					resource.TestCheckNoResourceAttr(resourceName, "site_to_site_vpn"),
 					resource.TestCheckNoResourceAttr(resourceName, "static_nat"),
-					resource.TestCheckNoResourceAttr(resourceName, "static_routes"),
-					resource.TestCheckNoResourceAttr(resourceName, "users"),
+					resource.TestCheckNoResourceAttr(resourceName, "static_route"),
+					resource.TestCheckNoResourceAttr(resourceName, "user"),
 				),
 			},
 		},
@@ -289,7 +289,7 @@ resource "sakuracloud_vpc_router" "foobar" {
   aliases    = [sakuracloud_internet.foobar.ipaddresses[3]]
   vrid       = 1
 
-  interfaces {
+  network_interface {
     index       = 1
     switch_id   = sakuracloud_switch.foobar.id
     vip         = "192.168.11.1"
@@ -297,7 +297,7 @@ resource "sakuracloud_vpc_router" "foobar" {
     nw_mask_len = 24 
   }
 
-  dhcp_servers {
+  dhcp_server {
     interface_index = 1
 
     range_start = "192.168.11.11"
@@ -305,16 +305,16 @@ resource "sakuracloud_vpc_router" "foobar" {
     dns_servers = ["8.8.8.8", "8.8.4.4"]
   }
 
-  dhcp_static_mappings {
+  dhcp_static_mapping {
     ipaddress  = "192.168.11.10"
     macaddress = "aa:bb:cc:aa:bb:cc"
   }
 
-  firewalls {
+  firewall {
     interface_index = 1
 
     direction = "send"
-    expressions {
+    expression {
         protocol            = "tcp"
         source_network      = ""
         source_port         = "80"
@@ -325,7 +325,7 @@ resource "sakuracloud_vpc_router" "foobar" {
         description         = "desc"
     }
 
-    expressions {
+    expression {
         protocol            = "ip"
         source_network      = ""
         source_port         = ""
@@ -343,7 +343,7 @@ resource "sakuracloud_vpc_router" "foobar" {
     range_stop        = "192.168.11.30"
   }
 
-  port_forwardings {
+  port_forwarding {
     protocol        = "udp"
     global_port     = 10022
     private_address = "192.168.11.11"
@@ -370,12 +370,12 @@ resource "sakuracloud_vpc_router" "foobar" {
     description     = "desc"
   }
 
-  static_routes {
+  static_route {
     prefix   = "172.16.0.0/16"
     next_hop = "192.168.11.99"
   }
 
-  users {
+  user {
     name     = "username"
     password = "password"
   }

--- a/sakuracloud/structure_dns.go
+++ b/sakuracloud/structure_dns.go
@@ -29,14 +29,14 @@ func expandDNSCreateRequest(d *schema.ResourceData) *sacloud.DNSCreateRequest {
 		Description: d.Get("description").(string),
 		Tags:        expandTags(d),
 		IconID:      expandSakuraCloudID(d, "icon_id"),
-		Records:     expandDNSRecords(d, "records"),
+		Records:     expandDNSRecords(d, "record"),
 	}
 }
 
 func expandDNSUpdateRequest(d *schema.ResourceData, dns *sacloud.DNS) *sacloud.DNSUpdateRequest {
 	records := dns.Records
-	if d.HasChange("records") {
-		records = expandDNSRecords(d, "records")
+	if d.HasChange("record") {
+		records = expandDNSRecords(d, "record")
 	}
 	return &sacloud.DNSUpdateRequest{
 		Description: d.Get("description").(string),

--- a/sakuracloud/structure_gslb.go
+++ b/sakuracloud/structure_gslb.go
@@ -61,7 +61,7 @@ func expandGSLBDelayLoop(d resourceValueGettable) int {
 
 func expandGSLBServers(d resourceValueGettable) []*sacloud.GSLBServer {
 	var servers []*sacloud.GSLBServer
-	for _, s := range d.Get("servers").([]interface{}) {
+	for _, s := range d.Get("server").([]interface{}) {
 		v := s.(map[string]interface{})
 		server := expandGSLBServer(&resourceMapValue{value: v})
 		servers = append(servers, server)

--- a/sakuracloud/structure_load_balancer.go
+++ b/sakuracloud/structure_load_balancer.go
@@ -22,7 +22,7 @@ import (
 
 func expandLoadBalancerVIPs(d resourceValueGettable) []*sacloud.LoadBalancerVirtualIPAddress {
 	var vips []*sacloud.LoadBalancerVirtualIPAddress
-	vipsConf := d.Get("vips").([]interface{})
+	vipsConf := d.Get("vip").([]interface{})
 	for _, vip := range vipsConf {
 		v := &resourceMapValue{vip.(map[string]interface{})}
 		vips = append(vips, expandLoadBalancerVIP(v))
@@ -56,13 +56,13 @@ func flattenLoadBalancerVIP(vip *sacloud.LoadBalancerVirtualIPAddress) interface
 		"port":         vip.Port.Int(),
 		"delay_loop":   vip.DelayLoop.Int(),
 		"sorry_server": vip.SorryServer,
-		"servers":      flattenLoadBalancerServers(vip.Servers),
+		"server":       flattenLoadBalancerServers(vip.Servers),
 	}
 }
 
 func expandLoadBalancerServers(d resourceValueGettable, vipPort int) []*sacloud.LoadBalancerServer {
 	var servers []*sacloud.LoadBalancerServer
-	for _, v := range d.Get("servers").([]interface{}) {
+	for _, v := range d.Get("server").([]interface{}) {
 		data := &resourceMapValue{v.(map[string]interface{})}
 		server := expandLoadBalancerServer(data, vipPort)
 		servers = append(servers, server)

--- a/sakuracloud/structure_mobile_gateway.go
+++ b/sakuracloud/structure_mobile_gateway.go
@@ -89,7 +89,7 @@ func expandMobileGatewayDNSSetting(d resourceValueGettable) *sacloud.MobileGatew
 }
 
 func expandMobileGatewayPrivateNetworks(d resourceValueGettable) *mobileGatewayBuilder.PrivateInterfaceSetting {
-	if raw, ok := d.Get("private_interface").([]interface{}); ok && len(raw) > 0 {
+	if raw, ok := d.Get("network_interface").([]interface{}); ok && len(raw) > 0 {
 		d := mapToResourceData(raw[0].(map[string]interface{}))
 		return &mobileGatewayBuilder.PrivateInterfaceSetting{
 			SwitchID:       expandSakuraCloudID(d, "switch_id"),
@@ -122,15 +122,18 @@ func flattenMobileGatewayPrivateNetworks(mgw *sacloud.MobileGateway) []interface
 	return nil
 }
 
-func flattenMobileGatewayPublicNetworks(mgw *sacloud.MobileGateway) []interface{} {
-	var results []interface{}
+func flattenMobileGatewayPublicNetmask(mgw *sacloud.MobileGateway) int {
 	if len(mgw.Interfaces) > 0 {
-		results = append(results, map[string]interface{}{
-			"ipaddress":   mgw.Interfaces[0].IPAddress,
-			"nw_mask_len": mgw.Interfaces[0].SubnetNetworkMaskLen,
-		})
+		return mgw.Interfaces[0].SubnetNetworkMaskLen
 	}
-	return results
+	return 0
+}
+
+func flattenMobileGatewayPublicIPAddress(mgw *sacloud.MobileGateway) string {
+	if len(mgw.Interfaces) > 0 {
+		return mgw.Interfaces[0].IPAddress
+	}
+	return ""
 }
 
 func expandMobileGatewaySIMRoutes(d resourceValueGettable) []*mobileGatewayBuilder.SIMRouteSetting {
@@ -203,7 +206,7 @@ func flattenMobileGatewayTrafficConfigs(tc *sacloud.MobileGatewayTrafficControl)
 
 func expandMobileGatewayStaticRoutes(d resourceValueGettable) []*sacloud.MobileGatewayStaticRoute {
 	var routes []*sacloud.MobileGatewayStaticRoute
-	if staticRoutes, ok := d.Get("static_routes").([]interface{}); ok && len(staticRoutes) > 0 {
+	if staticRoutes, ok := d.Get("static_route").([]interface{}); ok && len(staticRoutes) > 0 {
 		for _, v := range staticRoutes {
 			route := expandMobileGatewayStaticRoute(&resourceMapValue{v.(map[string]interface{})})
 			routes = append(routes, route)

--- a/sakuracloud/structure_packet_filter.go
+++ b/sakuracloud/structure_packet_filter.go
@@ -30,7 +30,7 @@ func expandPacketFilterCreateRequest(d *schema.ResourceData) *sacloud.PacketFilt
 
 func expandPacketFilterUpdateRequest(d *schema.ResourceData, pf *sacloud.PacketFilter) *sacloud.PacketFilterUpdateRequest {
 	expressions := pf.Expression
-	if d.HasChange("expressions") {
+	if d.HasChange("expression") {
 		expressions = expandPacketFilterExpressions(d)
 	}
 
@@ -43,7 +43,7 @@ func expandPacketFilterUpdateRequest(d *schema.ResourceData, pf *sacloud.PacketF
 
 func expandPacketFilterExpressions(d resourceValueGettable) []*sacloud.PacketFilterExpression {
 	var expressions []*sacloud.PacketFilterExpression
-	for _, e := range d.Get("expressions").([]interface{}) {
+	for _, e := range d.Get("expression").([]interface{}) {
 		expressions = append(expressions, expandPacketFilterExpression(&resourceMapValue{value: e.(map[string]interface{})}))
 	}
 	return expressions

--- a/sakuracloud/structure_proxylb.go
+++ b/sakuracloud/structure_proxylb.go
@@ -133,7 +133,7 @@ func flattenProxyLBCerts(certs *sacloud.ProxyLBCertificates) []interface{} {
 				"private_key":       cert.PrivateKey,
 			})
 		}
-		proxylbCert["additional_certificates"] = additionalCerts
+		proxylbCert["additional_certificate"] = additionalCerts
 	}
 	return []interface{}{proxylbCert}
 }
@@ -165,7 +165,7 @@ func expandProxyLBStickySession(d resourceValueGettable) *sacloud.ProxyLBStickyS
 
 func expandProxyLBBindPorts(d resourceValueGettable) []*sacloud.ProxyLBBindPort {
 	var results []*sacloud.ProxyLBBindPort
-	if bindPorts, ok := getListFromResource(d, "bind_ports"); ok {
+	if bindPorts, ok := getListFromResource(d, "bind_port"); ok {
 		for _, bindPort := range bindPorts {
 			values := mapToResourceData(bindPort.(map[string]interface{}))
 			var headers []*sacloud.ProxyLBResponseHeader
@@ -229,7 +229,7 @@ func expandProxyLBSorryServer(d resourceValueGettable) *sacloud.ProxyLBSorryServ
 
 func expandProxyLBServers(d resourceValueGettable) []*sacloud.ProxyLBServer {
 	var results []*sacloud.ProxyLBServer
-	if servers, ok := getListFromResource(d, "servers"); ok && len(servers) > 0 {
+	if servers, ok := getListFromResource(d, "server"); ok && len(servers) > 0 {
 		for _, server := range servers {
 			v := mapToResourceData(server.(map[string]interface{}))
 			results = append(results, &sacloud.ProxyLBServer{
@@ -256,7 +256,7 @@ func expandProxyLBCerts(d resourceValueGettable) *sacloud.ProxyLBCertificates {
 			PrivateKey:              values.Get("private_key").(string),
 		}
 
-		if rawAdditionalCerts, ok := getListFromResource(values, "additional_certificates"); ok && len(rawAdditionalCerts) > 0 {
+		if rawAdditionalCerts, ok := getListFromResource(values, "additional_certificate"); ok && len(rawAdditionalCerts) > 0 {
 			for _, rawCert := range rawAdditionalCerts {
 				values := mapToResourceData(rawCert.(map[string]interface{}))
 				cert.AdditionalCerts = append(cert.AdditionalCerts, &sacloud.ProxyLBAdditionalCert{

--- a/sakuracloud/structure_server.go
+++ b/sakuracloud/structure_server.go
@@ -75,7 +75,7 @@ func expandServerDisks(d *schema.ResourceData, client *APIClient) []diskBuilder.
 }
 
 func expandServerNIC(d resourceValueGettable) serverBuilder.NICSettingHolder {
-	nics := d.Get("interfaces").([]interface{})
+	nics := d.Get("network_interface").([]interface{})
 	if len(nics) == 0 {
 		return nil
 	}
@@ -100,7 +100,7 @@ func expandServerNIC(d resourceValueGettable) serverBuilder.NICSettingHolder {
 func expandServerAdditionalNICs(d resourceValueGettable) []serverBuilder.AdditionalNICSettingHolder {
 	var results []serverBuilder.AdditionalNICSettingHolder
 
-	nics := d.Get("interfaces").([]interface{})
+	nics := d.Get("network_interface").([]interface{})
 	if len(nics) < 2 {
 		return results
 	}

--- a/sakuracloud/structure_vpc_router.go
+++ b/sakuracloud/structure_vpc_router.go
@@ -93,7 +93,7 @@ func expandVPCRouterNICSetting(d resourceValueGettable) vpcrouter.NICSettingHold
 func expandVPCRouterAdditionalNICSettings(d resourceValueGettable) []vpcrouter.AdditionalNICSettingHolder {
 	var results []vpcrouter.AdditionalNICSettingHolder
 	planID := expandVPCRouterPlanID(d)
-	interfaces := d.Get("interfaces").([]interface{})
+	interfaces := d.Get("network_interface").([]interface{})
 	for _, iface := range interfaces {
 		d = mapToResourceData(iface.(map[string]interface{}))
 		var nicSetting vpcrouter.AdditionalNICSettingHolder
@@ -252,7 +252,7 @@ func flattenVPCRouterStaticNAT(vpcRouter *sacloud.VPCRouter) []interface{} {
 }
 
 func expandVPCRouterDHCPServerList(d resourceValueGettable) []*sacloud.VPCRouterDHCPServer {
-	if values, ok := getListFromResource(d, "dhcp_servers"); ok && len(values) > 0 {
+	if values, ok := getListFromResource(d, "dhcp_server"); ok && len(values) > 0 {
 		var results []*sacloud.VPCRouterDHCPServer
 		for _, raw := range values {
 			v := mapToResourceData(raw.(map[string]interface{}))
@@ -295,7 +295,7 @@ func vpcRouterInterfaceNameToIndex(ifName string) int {
 }
 
 func expandVPCRouterDHCPStaticMappingList(d resourceValueGettable) []*sacloud.VPCRouterDHCPStaticMapping {
-	if values, ok := getListFromResource(d, "dhcp_static_mappings"); ok && len(values) > 0 {
+	if values, ok := getListFromResource(d, "dhcp_static_mapping"); ok && len(values) > 0 {
 		var results []*sacloud.VPCRouterDHCPStaticMapping
 		for _, raw := range values {
 			v := mapToResourceData(raw.(map[string]interface{}))
@@ -325,7 +325,7 @@ func flattenVPCRouterDHCPStaticMappings(vpcRouter *sacloud.VPCRouter) []interfac
 }
 
 func expandVPCRouterFirewallList(d resourceValueGettable) []*sacloud.VPCRouterFirewall {
-	if values, ok := getListFromResource(d, "firewalls"); ok && len(values) > 0 {
+	if values, ok := getListFromResource(d, "firewall"); ok && len(values) > 0 {
 		var results []*sacloud.VPCRouterFirewall
 		for _, raw := range values {
 			v := mapToResourceData(raw.(map[string]interface{}))
@@ -373,7 +373,7 @@ func expandVPCRouterFirewall(d resourceValueGettable) *sacloud.VPCRouterFirewall
 }
 
 func expandVPCRouterFirewallRuleList(d resourceValueGettable) []*sacloud.VPCRouterFirewallRule {
-	if values, ok := getListFromResource(d, "expressions"); ok && len(values) > 0 {
+	if values, ok := getListFromResource(d, "expression"); ok && len(values) > 0 {
 		var results []*sacloud.VPCRouterFirewallRule
 		for _, raw := range values {
 			v := mapToResourceData(raw.(map[string]interface{}))
@@ -433,7 +433,7 @@ func flattenVPCRouterFirewalls(vpcRouter *sacloud.VPCRouter) []interface{} {
 			firewallRules = append(firewallRules, map[string]interface{}{
 				"interface_index": i,
 				"direction":       direction,
-				"expressions":     expressions,
+				"expression":      expressions,
 			})
 		}
 	}
@@ -491,7 +491,7 @@ func flattenVPCRouterL2TP(vpcRouter *sacloud.VPCRouter) []interface{} {
 }
 
 func expandVPCRouterPortForwardingList(d resourceValueGettable) []*sacloud.VPCRouterPortForwarding {
-	if values, ok := getListFromResource(d, "port_forwardings"); ok && len(values) > 0 {
+	if values, ok := getListFromResource(d, "port_forwarding"); ok && len(values) > 0 {
 		var results []*sacloud.VPCRouterPortForwarding
 		for _, raw := range values {
 			v := mapToResourceData(raw.(map[string]interface{}))
@@ -565,7 +565,7 @@ func flattenVPCRouterSiteToSite(vpcRouter *sacloud.VPCRouter) []interface{} {
 }
 
 func expandVPCRouterStaticRouteList(d resourceValueGettable) []*sacloud.VPCRouterStaticRoute {
-	if values, ok := getListFromResource(d, "static_routes"); ok && len(values) > 0 {
+	if values, ok := getListFromResource(d, "static_route"); ok && len(values) > 0 {
 		var results []*sacloud.VPCRouterStaticRoute
 		for _, raw := range values {
 			v := mapToResourceData(raw.(map[string]interface{}))
@@ -595,7 +595,7 @@ func flattenVPCRouterStaticRoutes(vpcRouter *sacloud.VPCRouter) []interface{} {
 }
 
 func expandVPCRouterUserList(d resourceValueGettable) []*sacloud.VPCRouterRemoteAccessUser {
-	if values, ok := getListFromResource(d, "users"); ok && len(values) > 0 {
+	if values, ok := getListFromResource(d, "user"); ok && len(values) > 0 {
 		var results []*sacloud.VPCRouterRemoteAccessUser
 		for _, raw := range values {
 			v := mapToResourceData(raw.(map[string]interface{}))


### PR DESCRIPTION
Terraform Plugin Best Practices: https://www.terraform.io/docs/extend/best-practices/index.html

- interfaces -> network_interface
- records -> record
- servers -> server
- dhcp_servers -> dhcp_server
- vips -> vip
- private_interface -> network_interface
- public_interface -> public_ip/public_netmask
- expressions -> expression
- bind_ports -> bind_port
- additional_certificates -> additional_certificate
- dhcp_static_mappings -> dhcp_static_mapping
- firewalls -> firewall
- port_forwardings -> port_forwarding
- static_routes -> static_route
- users -> user
