### PR TITLE
schema.Resource#Timeoutを用いたタイムアウト処理

### DIFF
--- a/sakuracloud/config.go
+++ b/sakuracloud/config.go
@@ -51,7 +51,6 @@ type Config struct {
 	AccessToken         string
 	AccessTokenSecret   string
 	Zone                string
-	TimeoutMinute       int
 	TraceMode           string
 	FakeMode            string
 	FakeStorePath       string
@@ -91,16 +90,15 @@ func (c *Config) NewClient() *APIClient {
 		Transport: &sacloud.RateLimitRoundTripper{RateLimitPerSec: c.APIRequestRateLimit},
 	}
 	caller := &sacloud.Client{
-		AccessToken:            c.AccessToken,
-		AccessTokenSecret:      c.AccessTokenSecret,
-		DefaultTimeoutDuration: time.Duration(c.TimeoutMinute) * time.Minute,
-		UserAgent:              ua,
-		AcceptLanguage:         c.AcceptLanguage,
-		RetryMax:               c.RetryMax,
-		RetryInterval:          time.Duration(c.RetryInterval) * time.Second,
-		HTTPClient:             httpClient,
+		AccessToken:       c.AccessToken,
+		AccessTokenSecret: c.AccessTokenSecret,
+		UserAgent:         ua,
+		AcceptLanguage:    c.AcceptLanguage,
+		RetryMax:          c.RetryMax,
+		RetryInterval:     time.Duration(c.RetryInterval) * time.Second,
+		HTTPClient:        httpClient,
 	}
-	sacloud.DefaultStatePollingTimeout = time.Duration(c.TimeoutMinute) * time.Minute
+	sacloud.DefaultStatePollingTimeout = 72 * time.Hour
 
 	if c.TraceMode != "" {
 		enableAPITrace := true

--- a/sakuracloud/data_source_sakuracloud_archive.go
+++ b/sakuracloud/data_source_sakuracloud_archive.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -27,6 +28,10 @@ import (
 func dataSourceSakuraCloudArchive() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudArchiveRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -70,7 +75,10 @@ func dataSourceSakuraCloudArchive() *schema.Resource {
 }
 
 func dataSourceSakuraCloudArchiveRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewArchiveOp(client)
 
 	var data *sacloud.Archive

--- a/sakuracloud/data_source_sakuracloud_bridge.go
+++ b/sakuracloud/data_source_sakuracloud_bridge.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudBridge() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudBridgeRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{excludeTags: true}),
@@ -48,7 +53,10 @@ func dataSourceSakuraCloudBridge() *schema.Resource {
 }
 
 func dataSourceSakuraCloudBridgeRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewBridgeOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_cdrom.go
+++ b/sakuracloud/data_source_sakuracloud_cdrom.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudCDROM() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudCDROMRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -61,7 +66,10 @@ func dataSourceSakuraCloudCDROM() *schema.Resource {
 }
 
 func dataSourceSakuraCloudCDROMRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewCDROMOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_database.go
+++ b/sakuracloud/data_source_sakuracloud_database.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudDatabase() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudDatabaseRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -116,7 +121,10 @@ func dataSourceSakuraCloudDatabase() *schema.Resource {
 }
 
 func dataSourceSakuraCloudDatabaseRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewDatabaseOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_disk.go
+++ b/sakuracloud/data_source_sakuracloud_disk.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudDisk() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudDiskRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -81,7 +86,10 @@ func dataSourceSakuraCloudDisk() *schema.Resource {
 }
 
 func dataSourceSakuraCloudDiskRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewDiskOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_dns.go
+++ b/sakuracloud/data_source_sakuracloud_dns.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudDNS() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudDNSRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -91,7 +96,10 @@ func dataSourceSakuraCloudDNS() *schema.Resource {
 }
 
 func dataSourceSakuraCloudDNSRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewDNSOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_gslb.go
+++ b/sakuracloud/data_source_sakuracloud_gslb.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudGSLB() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudGSLBRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -113,7 +118,10 @@ func dataSourceSakuraCloudGSLB() *schema.Resource {
 }
 
 func dataSourceSakuraCloudGSLBRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewGSLBOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_icon.go
+++ b/sakuracloud/data_source_sakuracloud_icon.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -25,17 +26,16 @@ func dataSourceSakuraCloudIcon() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudIconRead,
 
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
 			"name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			// TODO 廃止
-			//"body": {
-			//	Type:     schema.TypeString,
-			//	Computed: true,
-			//},
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -50,7 +50,10 @@ func dataSourceSakuraCloudIcon() *schema.Resource {
 }
 
 func dataSourceSakuraCloudIconRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewIconOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_internet.go
+++ b/sakuracloud/data_source_sakuracloud_internet.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudInternet() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudInternetRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -111,7 +116,10 @@ func dataSourceSakuraCloudInternet() *schema.Resource {
 }
 
 func dataSourceSakuraCloudInternetRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewInternetOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_loadbalancer.go
+++ b/sakuracloud/data_source_sakuracloud_loadbalancer.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudLoadBalancer() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudLoadBalancerRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -147,7 +152,10 @@ func dataSourceSakuraCloudLoadBalancer() *schema.Resource {
 }
 
 func dataSourceSakuraCloudLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewLoadBalancerOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_nfs.go
+++ b/sakuracloud/data_source_sakuracloud_nfs.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudNFS() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudNFSRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -81,7 +86,10 @@ func dataSourceSakuraCloudNFS() *schema.Resource {
 }
 
 func dataSourceSakuraCloudNFSRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewNFSOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_note.go
+++ b/sakuracloud/data_source_sakuracloud_note.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudNote() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudNoteRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -57,7 +62,10 @@ func dataSourceSakuraCloudNote() *schema.Resource {
 }
 
 func dataSourceSakuraCloudNoteRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewNoteOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_packet_filter.go
+++ b/sakuracloud/data_source_sakuracloud_packet_filter.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudPacketFilter() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudPacketFilterRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{excludeTags: true}),
@@ -83,7 +88,10 @@ func dataSourceSakuraCloudPacketFilter() *schema.Resource {
 }
 
 func dataSourceSakuraCloudPacketFilterRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewPacketFilterOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_private_host.go
+++ b/sakuracloud/data_source_sakuracloud_private_host.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudPrivateHost() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudPrivateHostRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -69,7 +74,10 @@ func dataSourceSakuraCloudPrivateHost() *schema.Resource {
 }
 
 func dataSourceSakuraCloudPrivateHostRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewPrivateHostOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_proxylb.go
+++ b/sakuracloud/data_source_sakuracloud_proxylb.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudProxyLB() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudProxyLBRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -226,7 +231,10 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 }
 
 func dataSourceSakuraCloudProxyLBRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewProxyLBOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_server.go
+++ b/sakuracloud/data_source_sakuracloud_server.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudServer() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudServerRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -131,7 +136,10 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 }
 
 func dataSourceSakuraCloudServerRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewServerOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_simple_monitor.go
+++ b/sakuracloud/data_source_sakuracloud_simple_monitor.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudSimpleMonitor() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudSimpleMonitorRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -138,7 +143,10 @@ func dataSourceSakuraCloudSimpleMonitor() *schema.Resource {
 }
 
 func dataSourceSakuraCloudSimpleMonitorRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewSimpleMonitorOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_ssh_key.go
+++ b/sakuracloud/data_source_sakuracloud_ssh_key.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudSSHKey() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudSSHKeyRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{excludeTags: true}),
@@ -48,7 +53,10 @@ func dataSourceSakuraCloudSSHKey() *schema.Resource {
 }
 
 func dataSourceSakuraCloudSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewSSHKeyOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_subnet.go
+++ b/sakuracloud/data_source_sakuracloud_subnet.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudSubnet() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudSubnetRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"internet_id": {
@@ -80,7 +85,10 @@ func dataSourceSakuraCloudSubnet() *schema.Resource {
 }
 
 func dataSourceSakuraCloudSubnetRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	internetOp := sacloud.NewInternetOp(client)
 	subnetOp := sacloud.NewSubnetOp(client)
 

--- a/sakuracloud/data_source_sakuracloud_switch.go
+++ b/sakuracloud/data_source_sakuracloud_switch.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudSwitch() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudSwitchRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -67,7 +72,10 @@ func dataSourceSakuraCloudSwitch() *schema.Resource {
 }
 
 func dataSourceSakuraCloudSwitchRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewSwitchOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_vpc_router.go
+++ b/sakuracloud/data_source_sakuracloud_vpc_router.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudVPCRouterRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			filterAttrName: filterSchema(&filterSchemaOption{}),
@@ -370,7 +375,10 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 }
 
 func dataSourceSakuraCloudVPCRouterRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	searcher := sacloud.NewVPCRouterOp(client)
 
 	findCondition := &sacloud.FindCondition{}

--- a/sakuracloud/data_source_sakuracloud_zone.go
+++ b/sakuracloud/data_source_sakuracloud_zone.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -24,6 +25,10 @@ import (
 func dataSourceSakuraCloudZone() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceSakuraCloudZoneRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -58,7 +63,10 @@ func dataSourceSakuraCloudZone() *schema.Resource {
 }
 
 func dataSourceSakuraCloudZoneRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zoneSlug := getSacloudClient(d, meta)
+	client, zoneSlug := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	zoneOp := sacloud.NewZoneOp(client)
 
 	if v, ok := d.GetOk("name"); ok {

--- a/sakuracloud/ftps_client.go
+++ b/sakuracloud/ftps_client.go
@@ -19,11 +19,12 @@ func uploadFileViaFTPS(ctx context.Context, user, pass, host, file string) error
 
 	compCh := make(chan struct{})
 	errCh := make(chan error)
-	defer close(compCh)
-	defer close(errCh)
 
 	ftpClient := ftps.NewClient(user, pass, host)
 	go func() {
+		defer close(compCh)
+		defer close(errCh)
+
 		if err := ftpClient.UploadFile(filepath.Base(file), f); err != nil {
 			errCh <- err
 		}

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -75,11 +75,6 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc:  schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_RETRY_INTERVAL"}, 5),
 				ValidateFunc: validation.IntBetween(0, 600),
 			},
-			"timeout": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_TIMEOUT"}, 20),
-			},
 			"api_request_timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -190,7 +185,6 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		AccessToken:         d.Get("token").(string),
 		AccessTokenSecret:   d.Get("secret").(string),
 		Zone:                d.Get("zone").(string),
-		TimeoutMinute:       d.Get("timeout").(int),
 		TraceMode:           d.Get("trace").(string),
 		APIRootURL:          d.Get("api_root_url").(string),
 		RetryMax:            d.Get("retry_max").(int),

--- a/sakuracloud/resource_sakuracloud_archive.go
+++ b/sakuracloud/resource_sakuracloud_archive.go
@@ -46,7 +46,7 @@ func resourceSakuraCloudArchive() *schema.Resource {
 			Create: schema.DefaultTimeout(24 * time.Hour),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(24 * time.Hour),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sakuracloud/resource_sakuracloud_archive.go
+++ b/sakuracloud/resource_sakuracloud_archive.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -40,6 +41,14 @@ func resourceSakuraCloudArchive() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(24 * time.Hour),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(24 * time.Hour),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -88,7 +97,10 @@ func resourceSakuraCloudArchive() *schema.Resource {
 }
 
 func resourceSakuraCloudArchiveCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	archiveOp := sacloud.NewArchiveOp(client)
 
 	archive, ftpServer, err := archiveOp.CreateBlank(ctx, zone, expandArchiveCreateRequest(d))
@@ -106,7 +118,10 @@ func resourceSakuraCloudArchiveCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceSakuraCloudArchiveRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	archiveOp := sacloud.NewArchiveOp(client)
 
 	archive, err := archiveOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -121,7 +136,10 @@ func resourceSakuraCloudArchiveRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceSakuraCloudArchiveUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	archiveOp := sacloud.NewArchiveOp(client)
 
 	archive, err := archiveOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -145,7 +163,10 @@ func resourceSakuraCloudArchiveUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceSakuraCloudArchiveDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	archiveOp := sacloud.NewArchiveOp(client)
 
 	archive, err := archiveOp.Read(ctx, zone, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_auto_backup.go
+++ b/sakuracloud/resource_sakuracloud_auto_backup.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -32,6 +33,14 @@ func resourceSakuraCloudAutoBackup() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -82,7 +91,10 @@ func resourceSakuraCloudAutoBackup() *schema.Resource {
 }
 
 func resourceSakuraCloudAutoBackupCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	autoBackupOp := sacloud.NewAutoBackupOp(client)
 
 	if err := validateBackupWeekdays(d, "weekdays"); err != nil {
@@ -99,7 +111,10 @@ func resourceSakuraCloudAutoBackupCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceSakuraCloudAutoBackupRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	autoBackupOp := sacloud.NewAutoBackupOp(client)
 
 	autoBackup, err := autoBackupOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -114,7 +129,10 @@ func resourceSakuraCloudAutoBackupRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceSakuraCloudAutoBackupUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	autoBackupOp := sacloud.NewAutoBackupOp(client)
 
 	autoBackup, err := autoBackupOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -135,7 +153,10 @@ func resourceSakuraCloudAutoBackupUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceSakuraCloudAutoBackupDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	autoBackupOp := sacloud.NewAutoBackupOp(client)
 
 	autoBackup, err := autoBackupOp.Read(ctx, zone, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_bridge.go
+++ b/sakuracloud/resource_sakuracloud_bridge.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -31,6 +32,14 @@ func resourceSakuraCloudBridge() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -53,7 +62,10 @@ func resourceSakuraCloudBridge() *schema.Resource {
 }
 
 func resourceSakuraCloudBridgeCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	bridgeOp := sacloud.NewBridgeOp(client)
 
 	bridge, err := bridgeOp.Create(ctx, zone, &sacloud.BridgeCreateRequest{
@@ -69,7 +81,10 @@ func resourceSakuraCloudBridgeCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSakuraCloudBridgeRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	bridgeOp := sacloud.NewBridgeOp(client)
 
 	bridge, err := bridgeOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -84,7 +99,10 @@ func resourceSakuraCloudBridgeRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudBridgeUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	bridgeOp := sacloud.NewBridgeOp(client)
 
 	bridge, err := bridgeOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -103,7 +121,10 @@ func resourceSakuraCloudBridgeUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSakuraCloudBridgeDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	bridgeOp := sacloud.NewBridgeOp(client)
 
 	bridge, err := bridgeOp.Read(ctx, zone, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_cdrom.go
+++ b/sakuracloud/resource_sakuracloud_cdrom.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -43,6 +44,14 @@ func resourceSakuraCloudCDROM() *schema.Resource {
 			}),
 			hasTagResourceCustomizeDiff,
 		),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(24 * time.Hour),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(24 * time.Hour),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -106,7 +115,10 @@ const (
 )
 
 func resourceSakuraCloudCDROMCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	cdromOp := sacloud.NewCDROMOp(client)
 
 	cdrom, ftpServer, err := cdromOp.Create(ctx, zone, expandCDROMCreateRequest(d))
@@ -131,7 +143,10 @@ func resourceSakuraCloudCDROMCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceSakuraCloudCDROMRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	cdromOp := sacloud.NewCDROMOp(client)
 
 	cdrom, err := cdromOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -146,7 +161,10 @@ func resourceSakuraCloudCDROMRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceSakuraCloudCDROMUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	cdromOp := sacloud.NewCDROMOp(client)
 
 	cdrom, err := cdromOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -176,7 +194,10 @@ func resourceSakuraCloudCDROMUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceSakuraCloudCDROMDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	cdromOp := sacloud.NewCDROMOp(client)
 
 	cdrom, err := cdromOp.Read(ctx, zone, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_database_read_replica.go
+++ b/sakuracloud/resource_sakuracloud_database_read_replica.go
@@ -35,6 +35,12 @@ func resourceSakuraCloudDatabaseReadReplica() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
 		Schema: map[string]*schema.Schema{
 			"master_id": {
 				Type:         schema.TypeString,
@@ -106,7 +112,9 @@ func resourceSakuraCloudDatabaseReadReplica() *schema.Resource {
 }
 
 func resourceSakuraCloudDatabaseReadReplicaCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
 
 	// validate master instance
 	builder, err := expandDatabaseReadReplicaBuilder(ctx, d, client, zone)
@@ -128,7 +136,10 @@ func resourceSakuraCloudDatabaseReadReplicaCreate(d *schema.ResourceData, meta i
 }
 
 func resourceSakuraCloudDatabaseReadReplicaRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	dbOp := sacloud.NewDatabaseOp(client)
 
 	data, err := dbOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -143,7 +154,10 @@ func resourceSakuraCloudDatabaseReadReplicaRead(d *schema.ResourceData, meta int
 }
 
 func resourceSakuraCloudDatabaseReadReplicaUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	dbOp := sacloud.NewDatabaseOp(client)
 
 	db, err := dbOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -165,7 +179,10 @@ func resourceSakuraCloudDatabaseReadReplicaUpdate(d *schema.ResourceData, meta i
 }
 
 func resourceSakuraCloudDatabaseReadReplicaDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	dbOp := sacloud.NewDatabaseOp(client)
 
 	data, err := dbOp.Read(ctx, zone, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_dns.go
+++ b/sakuracloud/resource_sakuracloud_dns.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -34,6 +35,14 @@ func resourceSakuraCloudDNS() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"zone": {
 				Type:     schema.TypeString,
@@ -107,7 +116,10 @@ func resourceSakuraCloudDNS() *schema.Resource {
 }
 
 func resourceSakuraCloudDNSCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	dnsOp := sacloud.NewDNSOp(client)
 
 	dns, err := dnsOp.Create(ctx, expandDNSCreateRequest(d))
@@ -120,7 +132,10 @@ func resourceSakuraCloudDNSCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceSakuraCloudDNSRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	dnsOp := sacloud.NewDNSOp(client)
 
 	dns, err := dnsOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -136,7 +151,10 @@ func resourceSakuraCloudDNSRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceSakuraCloudDNSUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	dnsOp := sacloud.NewDNSOp(client)
 
 	sakuraMutexKV.Lock(d.Id())
@@ -154,7 +172,10 @@ func resourceSakuraCloudDNSUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceSakuraCloudDNSDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	dnsOp := sacloud.NewDNSOp(client)
 
 	sakuraMutexKV.Lock(d.Id())

--- a/sakuracloud/resource_sakuracloud_dns_record.go
+++ b/sakuracloud/resource_sakuracloud_dns_record.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
@@ -33,6 +34,13 @@ func resourceSakuraCloudDNSRecord() *schema.Resource {
 		Create: resourceSakuraCloudDNSRecordCreate,
 		Read:   resourceSakuraCloudDNSRecordRead,
 		Delete: resourceSakuraCloudDNSRecordDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"dns_id": {
 				Type:         schema.TypeString,
@@ -85,7 +93,10 @@ func resourceSakuraCloudDNSRecord() *schema.Resource {
 }
 
 func resourceSakuraCloudDNSRecordCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	dnsOp := sacloud.NewDNSOp(client)
 	dnsID := d.Get("dns_id").(string)
 
@@ -108,7 +119,10 @@ func resourceSakuraCloudDNSRecordCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceSakuraCloudDNSRecordRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	dnsOp := sacloud.NewDNSOp(client)
 	dnsID := d.Get("dns_id").(string)
 
@@ -138,7 +152,10 @@ func resourceSakuraCloudDNSRecordRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceSakuraCloudDNSRecordDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	dnsOp := sacloud.NewDNSOp(client)
 	dnsID := d.Get("dns_id").(string)
 

--- a/sakuracloud/resource_sakuracloud_gslb.go
+++ b/sakuracloud/resource_sakuracloud_gslb.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -34,6 +35,14 @@ func resourceSakuraCloudGSLB() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -134,7 +143,10 @@ func resourceSakuraCloudGSLB() *schema.Resource {
 }
 
 func resourceSakuraCloudGSLBCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	gslbOp := sacloud.NewGSLBOp(client)
 
 	gslb, err := gslbOp.Create(ctx, expandGSLBCreateRequest(d))
@@ -147,7 +159,10 @@ func resourceSakuraCloudGSLBCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudGSLBRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	gslbOp := sacloud.NewGSLBOp(client)
 
 	gslb, err := gslbOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -163,7 +178,10 @@ func resourceSakuraCloudGSLBRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceSakuraCloudGSLBUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	gslbOp := sacloud.NewGSLBOp(client)
 
 	gslb, err := gslbOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -180,7 +198,10 @@ func resourceSakuraCloudGSLBUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudGSLBDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	gslbOp := sacloud.NewGSLBOp(client)
 
 	gslb, err := gslbOp.Read(ctx, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_icon.go
+++ b/sakuracloud/resource_sakuracloud_icon.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -29,6 +30,14 @@ func resourceSakuraCloudIcon() *schema.Resource {
 		Update:        resourceSakuraCloudIconUpdate,
 		Delete:        resourceSakuraCloudIconDelete,
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -64,7 +73,10 @@ func resourceSakuraCloudIcon() *schema.Resource {
 }
 
 func resourceSakuraCloudIconCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	iconOp := sacloud.NewIconOp(client)
 
 	req, err := expandIconCreateRequest(d)
@@ -81,7 +93,10 @@ func resourceSakuraCloudIconCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudIconRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	iconOp := sacloud.NewIconOp(client)
 
 	icon, err := iconOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -97,7 +112,10 @@ func resourceSakuraCloudIconRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceSakuraCloudIconUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	iconOp := sacloud.NewIconOp(client)
 
 	_, err := iconOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -113,7 +131,10 @@ func resourceSakuraCloudIconUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudIconDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	iconOp := sacloud.NewIconOp(client)
 
 	icon, err := iconOp.Read(ctx, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_internet.go
+++ b/sakuracloud/resource_sakuracloud_internet.go
@@ -41,7 +41,7 @@ func resourceSakuraCloudInternet() *schema.Resource {
 			Create: schema.DefaultTimeout(60 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sakuracloud/resource_sakuracloud_loadbalancer.go
+++ b/sakuracloud/resource_sakuracloud_loadbalancer.go
@@ -43,7 +43,7 @@ func resourceSakuraCloudLoadBalancer() *schema.Resource {
 			Create: schema.DefaultTimeout(60 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sakuracloud/resource_sakuracloud_mobile_gateway.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway.go
@@ -42,7 +42,7 @@ func resourceSakuraCloudMobileGateway() *schema.Resource {
 			Create: schema.DefaultTimeout(60 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sakuracloud/resource_sakuracloud_nfs.go
+++ b/sakuracloud/resource_sakuracloud_nfs.go
@@ -44,7 +44,7 @@ func resourceSakuraCloudNFS() *schema.Resource {
 			Create: schema.DefaultTimeout(24 * time.Hour),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(24 * time.Hour),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sakuracloud/resource_sakuracloud_note.go
+++ b/sakuracloud/resource_sakuracloud_note.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -33,6 +34,14 @@ func resourceSakuraCloudNote() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -70,7 +79,10 @@ func resourceSakuraCloudNote() *schema.Resource {
 }
 
 func resourceSakuraCloudNoteCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	noteOp := sacloud.NewNoteOp(client)
 
 	note, err := noteOp.Create(ctx, expandNoteCreateRequest(d))
@@ -83,7 +95,10 @@ func resourceSakuraCloudNoteCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudNoteRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	noteOp := sacloud.NewNoteOp(client)
 
 	note, err := noteOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -99,7 +114,10 @@ func resourceSakuraCloudNoteRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceSakuraCloudNoteUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	noteOp := sacloud.NewNoteOp(client)
 
 	note, err := noteOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -116,7 +134,10 @@ func resourceSakuraCloudNoteUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudNoteDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	noteOp := sacloud.NewNoteOp(client)
 
 	note, err := noteOp.Read(ctx, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_packet_filter.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter.go
@@ -39,7 +39,7 @@ func resourceSakuraCloudPacketFilter() *schema.Resource {
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sakuracloud/resource_sakuracloud_packet_filter.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -32,6 +33,13 @@ func resourceSakuraCloudPacketFilter() *schema.Resource {
 		Delete: resourceSakuraCloudPacketFilterDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -95,7 +103,10 @@ func resourceSakuraCloudPacketFilter() *schema.Resource {
 }
 
 func resourceSakuraCloudPacketFilterCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	pfOp := sacloud.NewPacketFilterOp(client)
 
 	pf, err := pfOp.Create(ctx, zone, expandPacketFilterCreateRequest(d))
@@ -108,7 +119,10 @@ func resourceSakuraCloudPacketFilterCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceSakuraCloudPacketFilterRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	pfOp := sacloud.NewPacketFilterOp(client)
 
 	pf, err := pfOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -124,7 +138,10 @@ func resourceSakuraCloudPacketFilterRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceSakuraCloudPacketFilterUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	pfOp := sacloud.NewPacketFilterOp(client)
 
 	pf, err := pfOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -141,7 +158,10 @@ func resourceSakuraCloudPacketFilterUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceSakuraCloudPacketFilterDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	pfOp := sacloud.NewPacketFilterOp(client)
 
 	pf, err := pfOp.Read(ctx, zone, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_packet_filter_rules.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter_rules.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -31,6 +32,12 @@ func resourceSakuraCloudPacketFilterRules() *schema.Resource {
 		Delete: resourceSakuraCloudPacketFilterRulesDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -98,7 +105,10 @@ func resourceSakuraCloudPacketFilterRules() *schema.Resource {
 }
 
 func resourceSakuraCloudPacketFilterRulesRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	pfOp := sacloud.NewPacketFilterOp(client)
 
 	pfID := d.Get("packet_filter_id").(string)
@@ -116,7 +126,10 @@ func resourceSakuraCloudPacketFilterRulesRead(d *schema.ResourceData, meta inter
 }
 
 func resourceSakuraCloudPacketFilterRulesUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	pfOp := sacloud.NewPacketFilterOp(client)
 
 	pfID := d.Get("packet_filter_id").(string)
@@ -138,7 +151,10 @@ func resourceSakuraCloudPacketFilterRulesUpdate(d *schema.ResourceData, meta int
 }
 
 func resourceSakuraCloudPacketFilterRulesDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	pfOp := sacloud.NewPacketFilterOp(client)
 
 	pfID := d.Get("packet_filter_id").(string)

--- a/sakuracloud/resource_sakuracloud_private_host.go
+++ b/sakuracloud/resource_sakuracloud_private_host.go
@@ -38,7 +38,7 @@ func resourceSakuraCloudPrivateHost() *schema.Resource {
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sakuracloud/resource_sakuracloud_private_host.go
+++ b/sakuracloud/resource_sakuracloud_private_host.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -32,6 +33,14 @@ func resourceSakuraCloudPrivateHost() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -76,7 +85,10 @@ func resourceSakuraCloudPrivateHost() *schema.Resource {
 }
 
 func resourceSakuraCloudPrivateHostCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	phOp := sacloud.NewPrivateHostOp(client)
 
 	planID, err := expandPrivateHostPlanID(ctx, d, client, zone)
@@ -94,7 +106,10 @@ func resourceSakuraCloudPrivateHostCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceSakuraCloudPrivateHostRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	phOp := sacloud.NewPrivateHostOp(client)
 
 	ph, err := phOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -109,7 +124,10 @@ func resourceSakuraCloudPrivateHostRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceSakuraCloudPrivateHostUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	phOp := sacloud.NewPrivateHostOp(client)
 
 	ph, err := phOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -126,7 +144,10 @@ func resourceSakuraCloudPrivateHostUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceSakuraCloudPrivateHostDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	phOp := sacloud.NewPrivateHostOp(client)
 
 	ph, err := phOp.Read(ctx, zone, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_proxylb.go
+++ b/sakuracloud/resource_sakuracloud_proxylb.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -34,6 +35,14 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -275,7 +284,10 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 }
 
 func resourceSakuraCloudProxyLBCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	proxyLBOp := sacloud.NewProxyLBOp(client)
 
 	proxyLB, err := proxyLBOp.Create(ctx, expandProxyLBCreateRequest(d))
@@ -301,7 +313,10 @@ func resourceSakuraCloudProxyLBCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceSakuraCloudProxyLBRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	proxyLBOp := sacloud.NewProxyLBOp(client)
 
 	proxyLB, err := proxyLBOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -317,7 +332,10 @@ func resourceSakuraCloudProxyLBRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceSakuraCloudProxyLBUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	proxyLBOp := sacloud.NewProxyLBOp(client)
 
 	sakuraMutexKV.Lock(d.Id())
@@ -366,7 +384,10 @@ func resourceSakuraCloudProxyLBUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceSakuraCloudProxyLBDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	proxyLBOp := sacloud.NewProxyLBOp(client)
 
 	sakuraMutexKV.Lock(d.Id())

--- a/sakuracloud/resource_sakuracloud_proxylb_acme.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_acme.go
@@ -31,6 +31,13 @@ func resourceSakuraCloudProxyLBACME() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"proxylb_id": {
 				Type:         schema.TypeString,
@@ -99,7 +106,10 @@ func resourceSakuraCloudProxyLBACME() *schema.Resource {
 }
 
 func resourceSakuraCloudProxyLBACMECreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	proxyLBOp := sacloud.NewProxyLBOp(client)
 
 	proxyLBID := d.Get("proxylb_id").(string)
@@ -153,7 +163,10 @@ func resourceSakuraCloudProxyLBACMECreate(d *schema.ResourceData, meta interface
 }
 
 func resourceSakuraCloudProxyLBACMERead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	proxyLBOp := sacloud.NewProxyLBOp(client)
 
 	proxyLBID := d.Get("proxylb_id").(string)
@@ -171,7 +184,10 @@ func resourceSakuraCloudProxyLBACMERead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceSakuraCloudProxyLBACMEDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	proxyLBOp := sacloud.NewProxyLBOp(client)
 
 	proxyLBID := d.Get("proxylb_id").(string)

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -43,7 +43,7 @@ func resourceSakuraCloudServer() *schema.Resource {
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -37,6 +38,14 @@ func resourceSakuraCloudServer() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -195,7 +204,10 @@ func resourceSakuraCloudServer() *schema.Resource {
 }
 
 func resourceSakuraCloudServerCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	builder := expandServerBuilder(d, client)
 
 	if err := builder.Validate(ctx, zone); err != nil {
@@ -212,7 +224,10 @@ func resourceSakuraCloudServerCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSakuraCloudServerRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	serverOp := sacloud.NewServerOp(client)
 
 	server, err := serverOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -228,7 +243,10 @@ func resourceSakuraCloudServerRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudServerUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	serverOp := sacloud.NewServerOp(client)
 
 	sakuraMutexKV.Lock(d.Id())
@@ -255,7 +273,10 @@ func resourceSakuraCloudServerUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSakuraCloudServerDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	serverOp := sacloud.NewServerOp(client)
 
 	sakuraMutexKV.Lock(d.Id())

--- a/sakuracloud/resource_sakuracloud_sim.go
+++ b/sakuracloud/resource_sakuracloud_sim.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -35,6 +36,14 @@ func resourceSakuraCloudSIM() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -93,7 +102,9 @@ func resourceSakuraCloudSIM() *schema.Resource {
 }
 
 func resourceSakuraCloudSIMCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
 
 	if err := validateCarrier(d); err != nil {
 		return err
@@ -114,7 +125,10 @@ func resourceSakuraCloudSIMCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceSakuraCloudSIMRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	simOp := sacloud.NewSIMOp(client)
 
 	sim, err := query.FindSIMByID(ctx, simOp, sakuraCloudID(d.Id()))
@@ -129,7 +143,10 @@ func resourceSakuraCloudSIMRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceSakuraCloudSIMUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	simOp := sacloud.NewSIMOp(client)
 
 	if err := validateCarrier(d); err != nil {
@@ -155,7 +172,10 @@ func resourceSakuraCloudSIMUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceSakuraCloudSIMDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	simOp := sacloud.NewSIMOp(client)
 
 	// read sim info

--- a/sakuracloud/resource_sakuracloud_simple_monitor.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -34,6 +35,14 @@ func resourceSakuraCloudSimpleMonitor() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"target": {
 				Type:     schema.TypeString,
@@ -166,7 +175,10 @@ func resourceSakuraCloudSimpleMonitor() *schema.Resource {
 }
 
 func resourceSakuraCloudSimpleMonitorCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	smOp := sacloud.NewSimpleMonitorOp(client)
 
 	simpleMonitor, err := smOp.Create(ctx, expandSimpleMonitorCreateRequest(d))
@@ -179,7 +191,10 @@ func resourceSakuraCloudSimpleMonitorCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceSakuraCloudSimpleMonitorRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	smOp := sacloud.NewSimpleMonitorOp(client)
 
 	simpleMonitor, err := smOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -195,7 +210,10 @@ func resourceSakuraCloudSimpleMonitorRead(d *schema.ResourceData, meta interface
 }
 
 func resourceSakuraCloudSimpleMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	smOp := sacloud.NewSimpleMonitorOp(client)
 
 	simpleMonitor, err := smOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -212,7 +230,10 @@ func resourceSakuraCloudSimpleMonitorUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceSakuraCloudSimpleMonitorDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	smOp := sacloud.NewSimpleMonitorOp(client)
 
 	simpleMonitor, err := smOp.Read(ctx, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_ssh_key.go
+++ b/sakuracloud/resource_sakuracloud_ssh_key.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -32,6 +33,14 @@ func resourceSakuraCloudSSHKey() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -57,7 +66,10 @@ func resourceSakuraCloudSSHKey() *schema.Resource {
 }
 
 func resourceSakuraCloudSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	sshKeyOp := sacloud.NewSSHKeyOp(client)
 
 	key, err := sshKeyOp.Create(ctx, expandSSHKeyCreateRequest(d))
@@ -70,7 +82,10 @@ func resourceSakuraCloudSSHKeyCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSakuraCloudSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	sshKeyOp := sacloud.NewSSHKeyOp(client)
 
 	key, err := sshKeyOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -85,7 +100,10 @@ func resourceSakuraCloudSSHKeyRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	sshKeyOp := sacloud.NewSSHKeyOp(client)
 
 	key, err := sshKeyOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -101,7 +119,10 @@ func resourceSakuraCloudSSHKeyUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSakuraCloudSSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	sshKeyOp := sacloud.NewSSHKeyOp(client)
 
 	key, err := sshKeyOp.Read(ctx, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_ssh_key_gen.go
+++ b/sakuracloud/resource_sakuracloud_ssh_key_gen.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -27,6 +28,13 @@ func resourceSakuraCloudSSHKeyGen() *schema.Resource {
 		Create: resourceSakuraCloudSSHKeyGenCreate,
 		Read:   resourceSakuraCloudSSHKeyGenRead,
 		Delete: resourceSakuraCloudSSHKeyGenDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -64,7 +72,10 @@ func resourceSakuraCloudSSHKeyGen() *schema.Resource {
 }
 
 func resourceSakuraCloudSSHKeyGenCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	sshKeyOp := sacloud.NewSSHKeyOp(client)
 
 	key, err := sshKeyOp.Generate(ctx, expandSSHKeyGenerateRequest(d))
@@ -79,7 +90,10 @@ func resourceSakuraCloudSSHKeyGenCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceSakuraCloudSSHKeyGenRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	sshKeyOp := sacloud.NewSSHKeyOp(client)
 
 	key, err := sshKeyOp.Read(ctx, sakuraCloudID(d.Id()))
@@ -95,7 +109,10 @@ func resourceSakuraCloudSSHKeyGenRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceSakuraCloudSSHKeyGenDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, _ := getSacloudClient(d, meta)
+	client, _ := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	sshKeyOp := sacloud.NewSSHKeyOp(client)
 
 	key, err := sshKeyOp.Read(ctx, sakuraCloudID(d.Id()))

--- a/sakuracloud/resource_sakuracloud_subnet.go
+++ b/sakuracloud/resource_sakuracloud_subnet.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -31,6 +32,13 @@ func resourceSakuraCloudSubnet() *schema.Resource {
 		Delete: resourceSakuraCloudSubnetDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -85,7 +93,10 @@ func resourceSakuraCloudSubnet() *schema.Resource {
 }
 
 func resourceSakuraCloudSubnetCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	internetOp := sacloud.NewInternetOp(client)
 
 	internetID := d.Get("internet_id").(string)
@@ -111,7 +122,10 @@ func resourceSakuraCloudSubnetCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSakuraCloudSubnetRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	subnetOp := sacloud.NewSubnetOp(client)
 
 	subnet, err := subnetOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -126,7 +140,10 @@ func resourceSakuraCloudSubnetRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	subnetOp := sacloud.NewSubnetOp(client)
 	internetOp := sacloud.NewInternetOp(client)
 
@@ -150,7 +167,10 @@ func resourceSakuraCloudSubnetUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSakuraCloudSubnetDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	subnetOp := sacloud.NewSubnetOp(client)
 	internetOp := sacloud.NewInternetOp(client)
 

--- a/sakuracloud/resource_sakuracloud_switch.go
+++ b/sakuracloud/resource_sakuracloud_switch.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -32,6 +33,14 @@ func resourceSakuraCloudSwitch() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -74,7 +83,10 @@ func resourceSakuraCloudSwitch() *schema.Resource {
 }
 
 func resourceSakuraCloudSwitchCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
 	swOp := sacloud.NewSwitchOp(client)
 
 	req := &sacloud.SwitchCreateRequest{
@@ -102,7 +114,10 @@ func resourceSakuraCloudSwitchCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSakuraCloudSwitchRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	swOp := sacloud.NewSwitchOp(client)
 
 	sw, err := swOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -117,7 +132,10 @@ func resourceSakuraCloudSwitchRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceSakuraCloudSwitchUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	swOp := sacloud.NewSwitchOp(client)
 
 	sakuraMutexKV.Lock(d.Id())
@@ -159,7 +177,10 @@ func resourceSakuraCloudSwitchUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSakuraCloudSwitchDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	swOp := sacloud.NewSwitchOp(client)
 
 	sakuraMutexKV.Lock(d.Id())

--- a/sakuracloud/resource_sakuracloud_switch.go
+++ b/sakuracloud/resource_sakuracloud_switch.go
@@ -38,7 +38,7 @@ func resourceSakuraCloudSwitch() *schema.Resource {
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -40,7 +40,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 			Create: schema.DefaultTimeout(60 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -34,6 +35,14 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		CustomizeDiff: hasTagResourceCustomizeDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -426,7 +435,9 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 }
 
 func resourceSakuraCloudVPCRouterCreate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
 
 	builder := expandVPCRouterBuilder(d, client)
 	if err := builder.Validate(ctx, zone); err != nil {
@@ -442,7 +453,10 @@ func resourceSakuraCloudVPCRouterCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceSakuraCloudVPCRouterRead(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
 	vrOp := sacloud.NewVPCRouterOp(client)
 
 	vpcRouter, err := vrOp.Read(ctx, zone, sakuraCloudID(d.Id()))
@@ -458,7 +472,10 @@ func resourceSakuraCloudVPCRouterRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceSakuraCloudVPCRouterUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutUpdate)
+	defer cancel()
+
 	vrOp := sacloud.NewVPCRouterOp(client)
 
 	sakuraMutexKV.Lock(d.Id())
@@ -482,7 +499,10 @@ func resourceSakuraCloudVPCRouterUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceSakuraCloudVPCRouterDelete(d *schema.ResourceData, meta interface{}) error {
-	client, ctx, zone := getSacloudClient(d, meta)
+	client, zone := getSacloudClient(d, meta)
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
 	vrOp := sacloud.NewVPCRouterOp(client)
 
 	sakuraMutexKV.Lock(d.Id())

--- a/sakuracloud/structure.go
+++ b/sakuracloud/structure.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
 	"github.com/mitchellh/go-homedir"
 
 	"github.com/sacloud/libsacloud/v2/sacloud/search"
@@ -101,11 +103,10 @@ func getListFromResource(d resourceValueGettable, key string) ([]interface{}, bo
 	return nil, false
 }
 
-func getSacloudClient(d resourceValueGettable, meta interface{}) (*APIClient, context.Context, string) {
+func getSacloudClient(d resourceValueGettable, meta interface{}) (*APIClient, string) {
 	client := meta.(*APIClient)
-	ctx := context.Background()
 	zone := getZone(d, client)
-	return client, ctx, zone
+	return client, zone
 }
 
 func getZone(d resourceValueGettable, client *APIClient) string {
@@ -116,6 +117,10 @@ func getZone(d resourceValueGettable, client *APIClient) string {
 		}
 	}
 	return client.defaultZone
+}
+
+func operationContext(d *schema.ResourceData, opKey string) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), d.Timeout(opKey))
 }
 
 func sakuraCloudID(id string) types.ID {


### PR DESCRIPTION
fixes #582 

タイムアウト値:

- Read/Delete: 5分
  - シャットダウンを伴うものは20分
- Create/Update:
  - アーカイブ/CD-ROM: 24時間
  - ディスクやアプライアンス: 60分
  - CommonServiceItem: 5分

エラーメッセージの例:

```console
Error: creating SakuraCloud VPCRouter is failed: Post https://secure.sakura.ad.jp/cloud/zone/is1b/api/cloud/1.1/appliance: context deadline exceeded
```

```console
Error: errors during apply: waiting deletion is failed: Internet[000000000000] still used by others
```