### PR TITLE
サーバリソースのディスク修正API関連パラメータを切り出し

### DIFF
--- a/sakuracloud/resource_sakuracloud_internet_test.go
+++ b/sakuracloud/resource_sakuracloud_internet_test.go
@@ -217,9 +217,11 @@ resource "sakuracloud_server" "foobar" {
   network_interface {
     upstream = sakuracloud_internet.foobar.switch_id
   }
-  ip_address = sakuracloud_internet.foobar.ip_addresses[0]
-  gateway    = sakuracloud_internet.foobar.gateway
-  netmask    = sakuracloud_internet.foobar.netmask
+  disk_edit_parameter {
+    ip_address = sakuracloud_internet.foobar.ip_addresses[0]
+    gateway    = sakuracloud_internet.foobar.gateway
+    netmask    = sakuracloud_internet.foobar.netmask
+  }
 }
 
 resource "sakuracloud_internet" "foobar" {

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -143,44 +143,70 @@ func resourceSakuraCloudServer() *schema.Resource {
 				ForceNew:    true,
 				Description: "target SakuraCloud zone",
 			},
-			"hostname": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
-			},
-			"password": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(8, 64),
-				Sensitive:    true,
-			},
-			"ssh_key_ids": {
+			"disk_edit_parameter": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"disable_pw_auth": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"note_ids": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"dns_servers": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				MaxItems: 1,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hostname": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 64),
+						},
+						"password": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(8, 64),
+							Sensitive:    true,
+						},
+						"ssh_key_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"disable_pw_auth": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"enable_dhcp": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"change_partition_uuid": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"note_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"ip_address": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"gateway": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"netmask": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"ip_address": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"gateway": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"network_address": {
@@ -189,8 +215,12 @@ func resourceSakuraCloudServer() *schema.Resource {
 			},
 			"netmask": {
 				Type:     schema.TypeInt,
-				Optional: true,
 				Computed: true,
+			},
+			"dns_servers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"force_shutdown": {
 				Type:     schema.TypeBool,
@@ -365,12 +395,5 @@ func setServerResourceData(ctx context.Context, d *schema.ResourceData, client *
 func isServerDiskConfigChanged(d *schema.ResourceData) bool {
 	return d.HasChange("disks") ||
 		d.HasChange("network_interface") ||
-		d.HasChange("ip_address") ||
-		d.HasChange("gateway") ||
-		d.HasChange("netmask") ||
-		d.HasChange("hostname") ||
-		d.HasChange("password") ||
-		d.HasChange("ssh_key_ids") ||
-		d.HasChange("disable_pw_auth") ||
-		d.HasChange("note_ids")
+		d.HasChange("disk_edit_parameter")
 }

--- a/sakuracloud/resource_sakuracloud_server_test.go
+++ b/sakuracloud/resource_sakuracloud_server_test.go
@@ -38,7 +38,7 @@ func TestAccSakuraCloudServer_basic(t *testing.T) {
 		CheckDestroy: testCheckSakuraCloudServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: buildConfigWithArgs(testAccCheckSakuraCloudServerConfig_basic, rand, password),
+				Config: buildConfigWithArgs(testAccSakuraCloudServer_basic, rand, password),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudServerExists(resourceName, &server),
 					testCheckSakuraCloudServerAttributes(&server),
@@ -51,13 +51,13 @@ func TestAccSakuraCloudServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2"),
-					resource.TestCheckResourceAttr(resourceName, "hostname", rand),
-					resource.TestCheckResourceAttr(resourceName, "password", password),
-					resource.TestCheckResourceAttr(resourceName, "ssh_key_ids.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "ssh_key_ids.0", "100000000000"),
-					resource.TestCheckResourceAttr(resourceName, "disable_pw_auth", "true"),
-					resource.TestCheckResourceAttr(resourceName, "note_ids.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "note_ids.0", "100000000000"),
+					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.hostname", rand),
+					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.password", password),
+					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.ssh_key_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.ssh_key_ids.0", "100000000000"),
+					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.disable_pw_auth", "true"),
+					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.note_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.note_ids.0", "100000000000"),
 					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_interface.0.upstream", "shared"),
 					resource.TestCheckResourceAttrSet(resourceName, "network_interface.0.mac_address"),
@@ -69,7 +69,7 @@ func TestAccSakuraCloudServer_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: buildConfigWithArgs(testAccCheckSakuraCloudServerConfig_update, rand, password),
+				Config: buildConfigWithArgs(testAccSakuraCloudServer_update, rand, password),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudServerExists(resourceName, &server),
 					testCheckSakuraCloudServerAttributes(&server),
@@ -316,7 +316,7 @@ func testCheckSakuraCloudServerDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccCheckSakuraCloudServerConfig_basic = `
+const testAccSakuraCloudServer_basic = `
 data "sakuracloud_archive" "ubuntu" {
   os_type = "ubuntu"
 }
@@ -335,11 +335,13 @@ resource "sakuracloud_server" "foobar" {
     upstream = "shared"
   }
 
-  hostname        = "{{ .arg0 }}"
-  password        = "{{ .arg1 }}"
-  ssh_key_ids     = ["100000000000", "200000000000"]
-  disable_pw_auth = true
-  note_ids        = ["100000000000", "200000000000"]
+  disk_edit_parameter {
+    hostname        = "{{ .arg0 }}"
+    password        = "{{ .arg1 }}"
+    ssh_key_ids     = ["100000000000", "200000000000"]
+    disable_pw_auth = true
+    note_ids        = ["100000000000", "200000000000"]
+  }
 }
 
 resource "sakuracloud_icon" "foobar" {
@@ -348,7 +350,7 @@ resource "sakuracloud_icon" "foobar" {
 }
 `
 
-const testAccCheckSakuraCloudServerConfig_update = `
+const testAccSakuraCloudServer_update = `
 data "sakuracloud_archive" "ubuntu" {
   os_type = "ubuntu"
 }
@@ -552,9 +554,11 @@ resource "sakuracloud_server" "foobar" {
   network_interface {
     upstream = sakuracloud_switch.foobar.id
   }
-
-  ip_address = "192.168.0.2"
-  netmask    = 24
-  gateway    = "192.168.0.1"
+  
+  disk_edit_parameter {
+    ip_address = "192.168.0.2"
+    netmask    = 24
+    gateway    = "192.168.0.1"
+  }
 }
 `


### PR DESCRIPTION
v2でのスキーマ変更の一環として、サーバリソースで指定するディスク修正API関連パラメータを切り出して独立したフィールド`disk_edit_parameter`とする。

IPアドレス/ネットマスク/ゲートウェイについてはサーバリソース直下と`disk_edit_parameter`配下の両方に存在するようになる。

#### 変更前:

```hcl
resource "sakuracloud_server" "foobar" {
  name        = "foobar"
  disks       = [sakuracloud_disk.foobar.id]
  description = "description"
  tags        = ["tag1", "tag2"]
  icon_id     = sakuracloud_icon.foobar.id
  network_interface {
    upstream = "shared"
  }

  hostname        = "hostname"
  password        = "password"
  ssh_key_ids     = ["100000000000", "200000000000"]
  disable_pw_auth = true
  note_ids        = ["100000000000", "200000000000"]
}
```

#### 変更後:

```hcl
resource "sakuracloud_server" "foobar" {
  name        = "foobar"
  disks       = [sakuracloud_disk.foobar.id]
  description = "description"
  tags        = ["tag1", "tag2"]
  icon_id     = sakuracloud_icon.foobar.id
  network_interface {
    upstream = "shared"
  }

  disk_edit_parameter {
    hostname        = "hostname"
    password        = "password"
    ssh_key_ids     = ["100000000000", "200000000000"]
    disable_pw_auth = true
    note_ids        = ["100000000000", "200000000000"]
  }
}

```