### PR TITLE
Use http.DefaultClient instead of creating it at each time

### DIFF
--- a/sakuracloud/config.go
+++ b/sakuracloud/config.go
@@ -85,10 +85,10 @@ func (c *Config) NewClient() *APIClient {
 		log.Printf("[DEBUG] Using modified User-Agent: %s", ua)
 	}
 
-	httpClient := &http.Client{
-		Timeout:   time.Duration(c.APIRequestTimeout) * time.Second,
-		Transport: &sacloud.RateLimitRoundTripper{RateLimitPerSec: c.APIRequestRateLimit},
-	}
+	httpClient := http.DefaultClient
+	httpClient.Timeout = time.Duration(c.APIRequestTimeout) * time.Second
+	httpClient.Transport = &sacloud.RateLimitRoundTripper{RateLimitPerSec: c.APIRequestRateLimit}
+
 	caller := &sacloud.Client{
 		AccessToken:       c.AccessToken,
 		AccessTokenSecret: c.AccessTokenSecret,

--- a/sakuracloud/config_test.go
+++ b/sakuracloud/config_test.go
@@ -1,0 +1,23 @@
+package sakuracloud
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+func TestConfig_NewClient_UseDefaultHTTPClient(t *testing.T) {
+	config := &Config{}
+
+	c1 := config.NewClient()
+	c2 := config.NewClient()
+	if c1 == c2 {
+		t.Errorf("Config.NewClient() should return fresh instance: instance1: %p instance2: %p", c1, c2)
+	}
+
+	hc1 := c1.APICaller.(*sacloud.Client).HTTPClient
+	hc2 := c2.APICaller.(*sacloud.Client).HTTPClient
+	if hc1 != hc2 {
+		t.Errorf("APIClient.HTTPClient should use same instance: instance1: %p instance2: %p", hc1, hc2)
+	}
+}


### PR DESCRIPTION
APIクライアントが使用するhttp.Clientとしてhttp.DefaultClientを利用する。