### PR TITLE
名前付きプロファイルのサポート

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .mailmap
 .env
 bin/terraform-provider-sakuracloud*
+**/.usacloud
 plugin.log
 terraform-provider-sakuracloud
 terraform.tfstate

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sacloud/terraform-provider-sakuracloud
 go 1.13
 
 require (
+	github.com/hashicorp/go-multierror v1.0.1-0.20190722213833-bdca7bb83f60
 	github.com/hashicorp/terraform-plugin-sdk v1.4.0
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
@@ -10,7 +11,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud/v2 v2.0.0-rc1
+	github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222022816-1a03ae0b74bb
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud/v2 v2.0.0-rc1 h1:wYQbILABRfqV5YnoFB3d2ufOIcUWjvZNgmVwA9PJ6w8=
-github.com/sacloud/libsacloud/v2 v2.0.0-rc1/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
+github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222022816-1a03ae0b74bb h1:rehDLxDKduFoh5LygmGOe875df8NQ2Rr2PWHmPCYKNY=
+github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222022816-1a03ae0b74bb/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=

--- a/sakuracloud/config_test.go
+++ b/sakuracloud/config_test.go
@@ -1,16 +1,32 @@
 package sakuracloud
 
 import (
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/profile"
 )
 
-func TestConfig_NewClient_UseDefaultHTTPClient(t *testing.T) {
-	config := &Config{}
+func TestConfig_NewClient_useDefaultHTTPClient(t *testing.T) {
+	config := &Config{
+		AccessToken:       "dummy",
+		AccessTokenSecret: "dummy",
+	}
 
-	c1 := config.NewClient()
-	c2 := config.NewClient()
+	c1, err := config.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := config.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if c1 == c2 {
 		t.Errorf("Config.NewClient() should return fresh instance: instance1: %p instance2: %p", c1, c2)
 	}
@@ -19,5 +35,233 @@ func TestConfig_NewClient_UseDefaultHTTPClient(t *testing.T) {
 	hc2 := c2.APICaller.(*sacloud.Client).HTTPClient
 	if hc1 != hc2 {
 		t.Errorf("APIClient.HTTPClient should use same instance: instance1: %p instance2: %p", hc1, hc2)
+	}
+}
+
+func initTestProfileDir() func() {
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Setenv("SAKURACLOUD_PROFILE_DIR", wd) // nolint
+	profileDir := filepath.Join(wd, ".usacloud")
+	if _, err := os.Stat(profileDir); err == nil {
+		os.RemoveAll(profileDir) // nolint
+	}
+
+	return func() {
+		os.RemoveAll(profileDir) // nolint
+	}
+}
+
+func TestConfig_NewClient_loadFromProfile(t *testing.T) {
+	defer initTestProfileDir()()
+
+	defaultProfile := &profile.ConfigValue{
+		AccessToken:          "token",
+		AccessTokenSecret:    "secret",
+		Zone:                 "dummy1",
+		Zones:                []string{"dummy1", "dummy2"},
+		UserAgent:            "dummy-ua",
+		AcceptLanguage:       "ja-JP",
+		RetryMax:             1,
+		RetryWaitMin:         2,
+		RetryWaitMax:         3,
+		StatePollingTimeout:  4,
+		StatePollingInterval: 5,
+		HTTPRequestTimeout:   6,
+		HTTPRequestRateLimit: 7,
+		APIRootURL:           "dummy",
+		TraceMode:            "dummy",
+		FakeMode:             true,
+		FakeStorePath:        "dummy",
+	}
+	testProfile := &profile.ConfigValue{
+		AccessToken:          "testtoken",
+		AccessTokenSecret:    "testsecret",
+		Zone:                 "test",
+		Zones:                []string{"test1", "test2"},
+		UserAgent:            "test-ua",
+		AcceptLanguage:       "ja-JP",
+		RetryMax:             7,
+		RetryWaitMin:         6,
+		RetryWaitMax:         5,
+		StatePollingTimeout:  4,
+		StatePollingInterval: 3,
+		HTTPRequestTimeout:   2,
+		HTTPRequestRateLimit: 1,
+		APIRootURL:           "test",
+		TraceMode:            "test",
+		FakeMode:             false,
+		FakeStorePath:        "test",
+	}
+
+	// プロファイル指定なし & デフォルトプロファイルなし
+	// プロファイル指定なし & デフォルトプロファイルあり
+	// プロファイル指定あり & 指定プロファイルが存在しない
+	// プロファイル指定あり 通常
+
+	cases := []struct {
+		scenario string
+		in       *Config
+		profiles map[string]*profile.ConfigValue
+		expect   *Config
+		err      error
+	}{
+		{
+			scenario: "ProfileName is not specified and Profile is not exists",
+			in: &Config{
+				Profile:             "",
+				Zone:                defaultZone,
+				Zones:               defaultZones,
+				RetryMax:            defaultRetryMax,
+				APIRequestTimeout:   defaultAPIRequestTimeout,
+				APIRequestRateLimit: defaultAPIRequestRateLimit,
+			},
+			profiles: map[string]*profile.ConfigValue{},
+			expect: &Config{
+				Profile:             "default",
+				Zone:                defaultZone,
+				Zones:               defaultZones,
+				RetryMax:            defaultRetryMax,
+				APIRequestTimeout:   defaultAPIRequestTimeout,
+				APIRequestRateLimit: defaultAPIRequestRateLimit,
+			},
+		},
+		{
+			scenario: "ProfileName is not specified and Profile is exists",
+			in: &Config{
+				Profile:             "",
+				Zone:                defaultZone,
+				Zones:               defaultZones,
+				RetryMax:            defaultRetryMax,
+				APIRequestTimeout:   defaultAPIRequestTimeout,
+				APIRequestRateLimit: defaultAPIRequestRateLimit,
+			},
+			profiles: map[string]*profile.ConfigValue{
+				"default": defaultProfile,
+			},
+			expect: &Config{
+				Profile:             "default",
+				AccessToken:         defaultProfile.AccessToken,
+				AccessTokenSecret:   defaultProfile.AccessTokenSecret,
+				Zone:                defaultProfile.Zone,
+				Zones:               defaultProfile.Zones,
+				TraceMode:           defaultProfile.TraceMode,
+				FakeMode:            "1",
+				FakeStorePath:       defaultProfile.FakeStorePath,
+				AcceptLanguage:      defaultProfile.AcceptLanguage,
+				APIRootURL:          defaultProfile.APIRootURL,
+				RetryMax:            defaultProfile.RetryMax,
+				RetryWaitMin:        defaultProfile.RetryWaitMin,
+				RetryWaitMax:        defaultProfile.RetryWaitMax,
+				APIRequestTimeout:   defaultProfile.HTTPRequestTimeout,
+				APIRequestRateLimit: defaultProfile.HTTPRequestRateLimit,
+			},
+		},
+		{
+			scenario: "ProfileName is not specified with some values and Profile is exists",
+			in: &Config{
+				Profile:             "",
+				AccessToken:         "from config",
+				AccessTokenSecret:   "from config",
+				Zone:                "from config",
+				Zones:               []string{"zone1", "zone2"},
+				TraceMode:           "from config",
+				FakeMode:            "from config",
+				FakeStorePath:       "from config",
+				AcceptLanguage:      "from config",
+				APIRootURL:          "from config",
+				RetryMax:            8080,
+				RetryWaitMin:        8080,
+				RetryWaitMax:        8080,
+				APIRequestTimeout:   8080,
+				APIRequestRateLimit: 8080,
+			},
+			profiles: map[string]*profile.ConfigValue{
+				"default": defaultProfile,
+			},
+			expect: &Config{
+				Profile:             "default",
+				AccessToken:         "from config",
+				AccessTokenSecret:   "from config",
+				Zone:                "from config",
+				Zones:               []string{"zone1", "zone2"},
+				TraceMode:           "from config",
+				FakeMode:            "from config",
+				FakeStorePath:       "from config",
+				AcceptLanguage:      "from config",
+				APIRootURL:          "from config",
+				RetryMax:            8080,
+				RetryWaitMin:        8080,
+				RetryWaitMax:        8080,
+				APIRequestTimeout:   8080,
+				APIRequestRateLimit: 8080,
+			},
+		},
+		{
+			scenario: "Profile name specified but not exists",
+			in: &Config{
+				Profile: "test",
+			},
+			profiles: map[string]*profile.ConfigValue{
+				"default": defaultProfile,
+			},
+			expect: &Config{
+				Profile: "test",
+			},
+			err: errors.New(`loading profile "test" is failed: profile "test" is not exists`),
+		},
+		{
+			scenario: "Profile name specified with normal profile",
+			in: &Config{
+				Profile:             "test",
+				Zone:                defaultZone,
+				Zones:               defaultZones,
+				RetryMax:            defaultRetryMax,
+				APIRequestTimeout:   defaultAPIRequestTimeout,
+				APIRequestRateLimit: defaultAPIRequestRateLimit,
+			},
+			profiles: map[string]*profile.ConfigValue{
+				"default": defaultProfile,
+				"test":    testProfile,
+			},
+			expect: &Config{
+				Profile:             "test",
+				AccessToken:         testProfile.AccessToken,
+				AccessTokenSecret:   testProfile.AccessTokenSecret,
+				Zone:                testProfile.Zone,
+				Zones:               testProfile.Zones,
+				TraceMode:           testProfile.TraceMode,
+				FakeMode:            "",
+				FakeStorePath:       testProfile.FakeStorePath,
+				AcceptLanguage:      testProfile.AcceptLanguage,
+				APIRootURL:          testProfile.APIRootURL,
+				RetryMax:            testProfile.RetryMax,
+				RetryWaitMin:        testProfile.RetryWaitMin,
+				RetryWaitMax:        testProfile.RetryWaitMax,
+				APIRequestTimeout:   testProfile.HTTPRequestTimeout,
+				APIRequestRateLimit: testProfile.HTTPRequestRateLimit,
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.scenario, func(t *testing.T) {
+			initTestProfileDir()
+			for profileName, profileValue := range tt.profiles {
+				if err := profile.Save(profileName, profileValue); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			err := tt.in.loadFromProfile()
+			if !reflect.DeepEqual(tt.err, err) {
+				t.Errorf("got unexpected error: expected: %s got: %s", tt.err, err)
+			}
+			if !reflect.DeepEqual(tt.expect, tt.in) {
+				t.Errorf("got unexpected state: expected: %+v got: %+v", tt.expect, tt.in)
+			}
+		})
 	}
 }

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/profile/profile.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/profile/profile.go
@@ -1,0 +1,370 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+const (
+	DirectoryNameEnv    = "SAKURACLOUD_PROFILE_DIR" // プロファイルの格納先を指定する環境変数
+	DirectoryNameEnvOld = "USACLOUD_PROFILE_DIR"    // プロファイルの格納先を指定する環境変数(後方互換)
+	DefaultProfileName  = "default"                 // デフォルトのプロファイル名
+)
+
+var (
+	configDirName   = ".usacloud"
+	configFileName  = "config.json"
+	currentFileName = "current"
+)
+
+func ValidateName(profileName string, invalidRunes ...rune) error {
+	invalids := invalidRunes
+	if len(invalids) == 0 {
+		// validate profileName
+		invalids = []rune{filepath.ListSeparator, filepath.Separator}
+	}
+
+	for _, r := range invalids {
+		if strings.ContainsRune(profileName, r) {
+			return fmt.Errorf("got invalid profile name: %s", profileName)
+		}
+	}
+	return nil
+}
+
+func loadProfileDirFromEnvs() (string, error) {
+	dir, err := loadProfileDirFromEnv(DirectoryNameEnv)
+	if err != nil {
+		return "", err
+	}
+	if dir == "" {
+		// fallback
+		dir, err = loadProfileDirFromEnv(DirectoryNameEnvOld)
+		if err != nil {
+			return "", err
+		}
+	}
+	return dir, nil
+}
+
+func loadProfileDirFromEnv(key string) (string, error) {
+	if path, ok := os.LookupEnv(key); ok {
+		if err := ValidateName(path, filepath.ListSeparator); err != nil {
+			return "", fmt.Errorf("loading ProfileDir from environment variables[%s] is failed: %s", key, err)
+		}
+		return filepath.Clean(path), nil
+	}
+	return "", nil
+}
+
+func baseDir() (string, error) {
+	// from profileDirEnv var
+	path, err := loadProfileDirFromEnvs()
+	if path != "" || err != nil {
+		return path, err
+	}
+
+	// default, use homedir
+	homeDir, err := homedir.Dir()
+	if err != nil {
+		return "", fmt.Errorf("getting user's home dir is failed: %s", err)
+	}
+	return homeDir, nil
+}
+
+func ConfigFilePath(profileName string) (string, error) {
+	if err := ValidateName(profileName); err != nil {
+		return "", err
+	}
+
+	if profileName == "" {
+		profileName = DefaultProfileName
+	}
+	baseDir, err := baseDir()
+	if err != nil {
+		return "", fmt.Errorf("getting profile base dir is failed: %s", err)
+	}
+	return filepath.Clean(filepath.Join(baseDir, configDirName, filepath.Clean(profileName), configFileName)), nil
+}
+
+// ConfigValue プロファイル コンフィグ
+type ConfigValue struct {
+	// AccessToken アクセストークン
+	AccessToken string
+	// AccessTokenSecret アクセスシークレット
+	AccessTokenSecret string
+
+	// Zone デフォルトゾーン
+	Zone string
+	// Zones 利用可能なゾーン
+	Zones []string
+
+	// UserAgent ユーザーエージェント
+	UserAgent string `json:",omitempty"`
+	// AcceptLanguage リクエスト時のAccept-Languageヘッダ
+	AcceptLanguage string `json:",omitempty"`
+
+	// RetryMax 423/503時のリトライ回数
+	RetryMax int `json:",omitempty"`
+	// RetryMin 423/503時のリトライ間隔(最小) 単位:秒
+	RetryWaitMin int `json:",omitempty"`
+	// RetryMax 423/503時のリトライ間隔(最大) 単位:秒
+	RetryWaitMax int `json:",omitempty"`
+
+	// StatePollingTimeout StatePollWaiterでのタイムアウト 単位:秒
+	StatePollingTimeout int `json:",omitempty"`
+	// StatePollingInterval StatePollWaiterでのポーリング間隔 単位:秒
+	StatePollingInterval int `json:",omitempty"`
+
+	// HTTPRequestTimeout APIリクエスト時のHTTPタイムアウト 単位:秒
+	HTTPRequestTimeout int
+	// HTTPRequestRateLimit APIリクエスト時の1秒あたりのリクエスト上限数
+	HTTPRequestRateLimit int
+
+	// APIRootURL APIのルートURL
+	APIRootURL string `json:",omitempty"`
+
+	// TraceMode トレースモード
+	TraceMode string `json:",omitempty"`
+	// FakeMode フェイクモード有効化
+	FakeMode bool `json:",omitempty"`
+	// FakeStorePath フェイクモードでのファイルストアパス
+	FakeStorePath string `json:",omitempty"`
+}
+
+// Save プロファイルコンフィグを保存
+func Save(profileName string, val interface{}) error {
+	if val == nil {
+		return fmt.Errorf("config is required")
+	}
+
+	path, err := ConfigFilePath(profileName)
+	if err != nil {
+		return err
+	}
+
+	// create dir
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(dir); err != nil {
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			return fmt.Errorf("creating profile directory[%q] is failed: %s", dir, err)
+		}
+	}
+
+	rawBody, err := json.MarshalIndent(val, "", "\t")
+	if err != nil {
+		return fmt.Errorf("marshalling config to JSON is failed: %s", err)
+	}
+
+	err = ioutil.WriteFile(path, rawBody, 0600)
+	if err != nil {
+		return fmt.Errorf("writing config to %q is failed: %s", path, err)
+	}
+
+	return nil
+}
+
+// Load 指定のプロファイル名からロードする
+//
+// configValueには*profile.ConfigValue(派生)への参照を渡す
+//
+// 指定したプロファイル名に対応するコンフィグファイルが存在しない場合はエラーを返す
+// ただしデフォルトのプロファイル名の場合はファイルが存在しなくてもエラーにしない
+func Load(profileName string, configValue interface{}) error {
+	filePath, err := ConfigFilePath(profileName)
+	if err != nil {
+		return err
+	}
+
+	// file exists?
+	if _, err := os.Stat(filePath); err == nil {
+		// read file
+		buf, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("loading config from %q is failed: %s", filePath, err)
+		}
+		if err := json.Unmarshal(buf, configValue); err != nil {
+			return fmt.Errorf("parsing config is failed: %s", err)
+		}
+	} else if profileName != DefaultProfileName {
+		return fmt.Errorf("profile %q is not exists", profileName)
+	}
+
+	return nil
+}
+
+// Remove 指定のプロファイルのコンフィグを削除する
+//
+// プロファイルディレクトリが空になる場合はディレクトリも合わせて削除する
+// Currentプロファイルが削除された場合はCurrentをデフォルトに設定する
+func Remove(profileName string) error {
+	path, err := ConfigFilePath(profileName)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(dir); err != nil {
+		return fmt.Errorf("removing directory is failed: %q is not exists", dir)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("removing config is failed: %q is not exists", path)
+	}
+
+	// remove file
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("removing config %q is failed: %s", path, err)
+	}
+
+	// remove dir if dir is empty
+	info, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("removing config file is failed: reading %q is failed: %s", dir, err)
+	}
+	if len(info) == 0 {
+		// remove dir
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("removing config dir %q is failed: %s", dir, err)
+		}
+	}
+
+	current, err := CurrentName()
+	if err != nil {
+		return fmt.Errorf("removing config is failed: CurrentName() returns error: %s", err)
+	}
+
+	if current == profileName {
+		if err := SetCurrentName(DefaultProfileName); err != nil {
+			return fmt.Errorf("removing config is failed: SetCurrentName() returns error: %s", err)
+		}
+	}
+	return nil
+}
+
+func CurrentName() (string, error) {
+	baseDir, err := baseDir()
+	if err != nil {
+		return "", err
+	}
+
+	profNameFile := filepath.Join(baseDir, configDirName, currentFileName)
+	if _, err := os.Stat(profNameFile); err == nil {
+		data, err := ioutil.ReadFile(profNameFile)
+		if err != nil {
+			return "", fmt.Errorf("reading current profile is failed: %s", err)
+		}
+		profileName := string(data)
+		if err := ValidateName(profileName); err != nil {
+			return "", err
+		}
+
+		profileName = cleanupProfileName(profileName)
+		if profileName == "" {
+			profileName = DefaultProfileName
+		}
+		return profileName, nil
+	}
+
+	return DefaultProfileName, nil
+}
+
+func cleanupProfileName(profileName string) string {
+	targets := []string{"　", "\t", "\n"}
+	res := profileName
+	for _, s := range targets {
+		res = strings.Replace(res, s, "", -1)
+	}
+	return strings.Trim(res, " ")
+}
+
+func SetCurrentName(profileName string) error {
+	if err := ValidateName(profileName); err != nil {
+		return err
+	}
+
+	profileName = cleanupProfileName(profileName)
+
+	baseDir, err := baseDir()
+	if err != nil {
+		return err
+	}
+
+	configDir := filepath.Join(baseDir, configDirName)
+	if _, err := os.Stat(configDir); err != nil {
+		err := os.MkdirAll(configDir, 0755)
+		if err != nil {
+			return fmt.Errorf("creating config dir %q is failed: %s", configDir, err)
+		}
+	}
+
+	if profileName != DefaultProfileName {
+		profileConfigPath := filepath.Join(configDir, profileName, configFileName)
+		if _, err := os.Stat(profileConfigPath); err != nil {
+			return fmt.Errorf("profile %q is not exists", profileName)
+		}
+	}
+
+	profNameFile := filepath.Join(baseDir, configDirName, currentFileName)
+	if err := ioutil.WriteFile(profNameFile, []byte(profileName), 0600); err != nil {
+		return fmt.Errorf("writing profile to %q is failed: %s", profNameFile, err)
+	}
+
+	return nil
+}
+
+func List() ([]string, error) {
+	res := []string{"default"}
+
+	// get profile dirs under base dir
+	baseDir, err := baseDir()
+	if err != nil {
+		return []string{}, fmt.Errorf("listing profiles is failed: %s", err)
+	}
+	configDirPath := filepath.Join(baseDir, configDirName)
+	if _, err := os.Stat(configDirPath); err != nil {
+		return res, nil
+	}
+	entries, err := ioutil.ReadDir(filepath.Join(baseDir, configDirName))
+	if err != nil {
+		return []string{}, fmt.Errorf("listing profiles is failed: %s", err)
+	}
+
+	// validate each profile dir
+	for _, fi := range entries {
+		if fi.IsDir() {
+			profile := filepath.Base(fi.Name())
+			if profile != DefaultProfileName {
+				if profile != DefaultProfileName {
+					c := &ConfigValue{}
+					if err := Load(profile, c); err == nil {
+						res = append(res, profile)
+					}
+				}
+			}
+		}
+	}
+
+	return res, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/posener/complete/match
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud/v2 v2.0.0-rc1
+# github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222022816-1a03ae0b74bb
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/pkg/cidr
 github.com/sacloud/libsacloud/v2/pkg/mapconv
@@ -239,6 +239,7 @@ github.com/sacloud/libsacloud/v2/sacloud/accessor
 github.com/sacloud/libsacloud/v2/sacloud/fake
 github.com/sacloud/libsacloud/v2/sacloud/naked
 github.com/sacloud/libsacloud/v2/sacloud/ostype
+github.com/sacloud/libsacloud/v2/sacloud/profile
 github.com/sacloud/libsacloud/v2/sacloud/search
 github.com/sacloud/libsacloud/v2/sacloud/search/keys
 github.com/sacloud/libsacloud/v2/sacloud/trace


### PR DESCRIPTION
プロバイダー設定で名前付きプロファイルをサポートする。

```hcl
provider sakuracloud {
  profile = "example"
}
```

プロファイルは[usacloud](https://github.com/sacloud/usacloud)と互換性がある。

- デフォルトだと`~/.usacloud/<プロファイル名>/config.json`が利用される
- 環境変数`SAKURACLOUD_PROFILE_DIR`または`USACLOUD_PROFILE_DIR`で変更可能
- 設定可能な項目はlibsacloudの[*profile.ConfigValue](https://github.com/sacloud/libsacloud/blob/1a03ae0b74bbb0c9106abfc30c2ffbea539b0b31/sacloud/profile/profile.go#L110-L153)を参照
- `profile`が未指定の場合`default`プロファイルが利用される

優先度:

tfファイル、または環境変数で指定したプロバイダーの項目はプロファイルの値を上書きする

- プロファイル
- 環境変数
- tfファイル

下の方が優先される。