### PR TITLE
専有ホスト Windowsプラン

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222022816-1a03ae0b74bb
+	github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222044132-f1298ba937de
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222022816-1a03ae0b74bb h1:rehDLxDKduFoh5LygmGOe875df8NQ2Rr2PWHmPCYKNY=
-github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222022816-1a03ae0b74bb/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
+github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222044132-f1298ba937de h1:Vq9hhWOxvYg+OuEncp/ACbwll6xfQhvuWslovCDwCGw=
+github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222044132-f1298ba937de/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=

--- a/sakuracloud/data_source_sakuracloud_private_host.go
+++ b/sakuracloud/data_source_sakuracloud_private_host.go
@@ -36,6 +36,10 @@ func dataSourceSakuraCloudPrivateHost() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"class": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"icon_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/sakuracloud/data_source_sakuracloud_private_host_test.go
+++ b/sakuracloud/data_source_sakuracloud_private_host_test.go
@@ -34,6 +34,7 @@ func TestAccSakuraCloudDataSourcePrivateHost_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "class", "dynamic"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.4151227546", "tag1"),

--- a/sakuracloud/resource_sakuracloud_private_host.go
+++ b/sakuracloud/resource_sakuracloud_private_host.go
@@ -20,7 +20,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
 func resourceSakuraCloudPrivateHost() *schema.Resource {
@@ -44,6 +46,12 @@ func resourceSakuraCloudPrivateHost() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"class": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      types.PrivateHostClassDynamic,
+				ValidateFunc: validation.StringInSlice([]string{types.PrivateHostClassDynamic, types.PrivateHostClassWindows}, false),
 			},
 			"icon_id": {
 				Type:         schema.TypeString,
@@ -182,6 +190,7 @@ func resourceSakuraCloudPrivateHostDelete(d *schema.ResourceData, meta interface
 
 func setPrivateHostResourceData(ctx context.Context, d *schema.ResourceData, client *APIClient, data *sacloud.PrivateHost) error {
 	d.Set("name", data.Name)                             // nolint
+	d.Set("class", data.PlanClass)                       // nolint
 	d.Set("icon_id", data.IconID.String())               // nolint
 	d.Set("description", data.Description)               // nolint
 	d.Set("hostname", data.GetHostName())                // nolint

--- a/sakuracloud/resource_sakuracloud_private_host_test.go
+++ b/sakuracloud/resource_sakuracloud_private_host_test.go
@@ -47,6 +47,7 @@ func TestAccSakuraCloudPrivateHost_basic(t *testing.T) {
 					testCheckSakuraCloudPrivateHostExists(resourceName, &privateHost),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "class", "dynamic"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.4151227546", "tag1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
@@ -69,6 +70,39 @@ func TestAccSakuraCloudPrivateHost_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "description-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSakuraCloudPrivateHost_windows(t *testing.T) {
+	skipIfZoneIsDummy(t)
+
+	resourceName := "sakuracloud_private_host.foobar"
+	rand := randomName()
+
+	var privateHost sacloud.PrivateHost
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraCloudPrivateHostDestroy,
+			testCheckSakuraCloudIconDestroy,
+			testCheckSakuraCloudServerDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: buildConfigWithArgs(testAccSakuraCloudPrivateHost_windows, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraCloudPrivateHostExists(resourceName, &privateHost),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "class", "ms_windows"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.4151227546", "tag1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
 					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
 				),
 			},
@@ -184,6 +218,15 @@ var testAccSakuraCloudPrivateHost_update = `
 resource "sakuracloud_private_host" "foobar" {
   name        = "{{ .arg0 }}-upd"
   description = "description-upd"
+}
+`
+
+var testAccSakuraCloudPrivateHost_windows = `
+resource "sakuracloud_private_host" "foobar" {
+  name        = "{{ .arg0 }}"
+  class       = "ms_windows"
+  description = "description"
+  tags        = ["tag1", "tag2"]
 }
 `
 

--- a/sakuracloud/structure_private_host.go
+++ b/sakuracloud/structure_private_host.go
@@ -28,7 +28,7 @@ func expandPrivateHostPlanID(ctx context.Context, d resourceValueGettable, clien
 	op := sacloud.NewPrivateHostPlanOp(client)
 	searched, err := op.Find(ctx, zone, &sacloud.FindCondition{
 		Filter: search.Filter{
-			search.Key("Class"): search.ExactMatch("dynamic"),
+			search.Key("Class"): search.ExactMatch(d.Get("class").(string)),
 		},
 	})
 	if err != nil {

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/accessor/class.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/accessor/class.go
@@ -1,0 +1,21 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accessor
+
+// Class クラス
+type Class interface {
+	GetClass() string
+	SetClass(class string)
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/functions.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/functions.go
@@ -105,7 +105,7 @@ FILTER_APPLY_LOOP:
 
 				// only ID/Name/Tags
 				switch fieldName {
-				case "ID", "Name", "Tags.Name", "Scope":
+				case "ID", "Name", "Tags.Name", "Scope", "Class":
 					exp, ok := expression.(*search.EqualExpression)
 					if !ok {
 						exp = search.OrEqual(expression)
@@ -147,6 +147,10 @@ FILTER_APPLY_LOOP:
 						case "Scope":
 							if v, ok := target.(accessor.Scope); ok {
 								value = v.GetScope()
+							}
+						case "Class":
+							if v, ok := target.(accessor.Class); ok {
+								value = v.GetClass()
 							}
 						}
 

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
@@ -15081,10 +15081,10 @@ type PrivateHost struct {
 	IconID           types.ID `mapconv:"Icon.ID"`
 	CreatedAt        time.Time
 	PlanID           types.ID `mapconv:"Plan.ID,omitempty"`
-	PlanName         string
-	PlanClass        string
-	CPU              int `mapconv:"Plan.CPU"`
-	MemoryMB         int `mapconv:"Plan.MemoryMB"`
+	PlanName         string   `mapconv:"Plan.Name"`
+	PlanClass        string   `mapconv:"Plan.Class"`
+	CPU              int      `mapconv:"Plan.CPU"`
+	MemoryMB         int      `mapconv:"Plan.MemoryMB"`
 	AssignedCPU      int
 	AssignedMemoryMB int
 	HostName         string `mapconv:"Host.Name"`
@@ -15105,10 +15105,10 @@ func (o *PrivateHost) setDefaults() interface{} {
 		IconID           types.ID `mapconv:"Icon.ID"`
 		CreatedAt        time.Time
 		PlanID           types.ID `mapconv:"Plan.ID,omitempty"`
-		PlanName         string
-		PlanClass        string
-		CPU              int `mapconv:"Plan.CPU"`
-		MemoryMB         int `mapconv:"Plan.MemoryMB"`
+		PlanName         string   `mapconv:"Plan.Name"`
+		PlanClass        string   `mapconv:"Plan.Class"`
+		CPU              int      `mapconv:"Plan.CPU"`
+		MemoryMB         int      `mapconv:"Plan.MemoryMB"`
 		AssignedCPU      int
 		AssignedMemoryMB int
 		HostName         string `mapconv:"Host.Name"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/posener/complete/match
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222022816-1a03ae0b74bb
+# github.com/sacloud/libsacloud/v2 v2.0.0-rc1.0.20191222044132-f1298ba937de
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/pkg/cidr
 github.com/sacloud/libsacloud/v2/pkg/mapconv


### PR DESCRIPTION
専有ホストでWindowsプランを利用可能にする

```hcl
# Windowsプランを利用する場合
resource "sakuracloud_private_host" "foobar" {
  name        = "example"
  class       = "ms_windows"
}
```

`class`を省略した通りは従来通りの標準専有ホストとなる。