### PR TITLE
Rule-based load balancing

### DIFF
--- a/sakuracloud/data_source_sakuracloud_proxylb.go
+++ b/sakuracloud/data_source_sakuracloud_proxylb.go
@@ -193,8 +193,32 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"group": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"enabled": {
 							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"rule": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 					},

--- a/sakuracloud/data_source_sakuracloud_proxylb_test.go
+++ b/sakuracloud/data_source_sakuracloud_proxylb_test.go
@@ -50,10 +50,18 @@ func TestAccSakuraCloudDataSourceProxyLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bind_port.0.port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.ip_address", ip0),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.group", "group1"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "server.1.ip_address", ip1),
 					resource.TestCheckResourceAttr(resourceName, "server.1.port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.group", "group2"),
 					resource.TestCheckResourceAttr(resourceName, "server.1.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.host", ""),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.path", "/path1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.group", "group1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.1.host", ""),
+					resource.TestCheckResourceAttr(resourceName, "rule.1.path", "/path2"),
+					resource.TestCheckResourceAttr(resourceName, "rule.1.group", "group2"),
 				),
 			},
 		},
@@ -79,10 +87,21 @@ resource "sakuracloud_proxylb" "foobar" {
   server {
     ip_address = "{{ .arg1 }}"
     port       = 80
+    group      = "group1"
   }
   server {
     ip_address = "{{ .arg2 }}"
     port       = 80
+    group      = "group2"
+  }
+
+  rule {
+    path  = "/path1"
+    group = "group1"
+  }
+  rule {
+    path  = "/path2"
+    group = "group2"
   }
 }
 

--- a/sakuracloud/resource_sakuracloud_proxylb.go
+++ b/sakuracloud/resource_sakuracloud_proxylb.go
@@ -225,10 +225,36 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 							Required:     true,
 							ValidateFunc: validation.IntBetween(1, 65535),
 						},
+						"group": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 10),
+						},
 						"enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  true,
+						},
+					},
+				},
+			},
+			"rule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"group": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 10),
 						},
 					},
 				},
@@ -429,6 +455,9 @@ func setProxyLBResourceData(ctx context.Context, d *schema.ResourceData, client 
 		return err
 	}
 	if err := d.Set("server", flattenProxyLBServers(data)); err != nil {
+		return err
+	}
+	if err := d.Set("rule", flattenProxyLBRules(data)); err != nil {
 		return err
 	}
 	if err := d.Set("certificate", flattenProxyLBCerts(certs)); err != nil {

--- a/sakuracloud/resource_sakuracloud_proxylb_test.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_test.go
@@ -75,6 +75,10 @@ func TestAccSakuraCloudProxyLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bind_port.0.response_header.0.value", "public, max-age=10"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.group", "group1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.host", "usacloud.jp"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.path", "/path"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.group", "group1"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "server.0.ip_address",
 						"sakuracloud_server.foobar", "ip_address",
@@ -105,6 +109,10 @@ func TestAccSakuraCloudProxyLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bind_port.0.response_header.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.group", "group2"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.host", "upd.usacloud.jp"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.path", "/path-upd"),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.group", "group2"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "server.0.ip_address",
 						"sakuracloud_server.foobar", "ip_address",
@@ -256,7 +264,14 @@ resource "sakuracloud_proxylb" "foobar" {
   server {
     ip_address = sakuracloud_server.foobar.ip_address
     port       = 80
+    group      = "group1"
   }
+  rule {
+    host  = "usacloud.jp"
+    path  = "/path"
+    group = "group1"
+  }
+
   description = "description"
   tags        = ["tag1", "tag2"]
   icon_id     = sakuracloud_icon.foobar.id
@@ -300,6 +315,13 @@ resource "sakuracloud_proxylb" "foobar" {
   server {
     ip_address = sakuracloud_server.foobar.ip_address
     port       = 443
+    group      = "group2"
+  }
+
+  rule {
+    host  = "upd.usacloud.jp"
+    path  = "/path-upd"
+    group = "group2"
   }
 
   description = "description-upd"


### PR DESCRIPTION
エンハンスドロードバランサでルールベースの振り分けをサポートする。

```hcl
resource "sakuracloud_proxylb" "foobar" {
  name           = "example"
  plan           = 100
  vip_failover   = true
  sticky_session = true
  timeout        = 10
  region         = "is1"

  health_check {
    protocol    = "http"
    delay_loop  = 10
    host_header = "usacloud.jp"
    path        = "/"
  }

  bind_port {
    proxy_mode = "http"
    port       = 80
    response_header {
      header = "Cache-Control"
      value  = "public, max-age=10"
    }
  }

  server {
    ip_address = sakuracloud_server.foobar.ip_address
    port       = 80
    group      = "group1"
  }

  rule {
    host  = "usacloud.jp"
    group = "group1"
  }
  rule {
    path  = "/path"
    group = "group1"
  }

}
```