### PR TITLE
Rename fields of ContainerRegistry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud/v2 v2.0.0-rc2.0.20191223115943-899ad7b5272b
+	github.com/sacloud/libsacloud/v2 v2.0.0-rc2.0.20191224002111-a5e28d35bd8b
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud/v2 v2.0.0-rc2.0.20191223115943-899ad7b5272b h1:i8zZKK+6nsvsA7pBHF7E7eE6rd/4wBrpFEx94r9PDos=
-github.com/sacloud/libsacloud/v2 v2.0.0-rc2.0.20191223115943-899ad7b5272b/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
+github.com/sacloud/libsacloud/v2 v2.0.0-rc2.0.20191224002111-a5e28d35bd8b h1:NZ6XrnI1BXv+C4lB66BANobktUhaM0ZlpRo+m3ckDK0=
+github.com/sacloud/libsacloud/v2 v2.0.0-rc2.0.20191224002111-a5e28d35bd8b/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=

--- a/sakuracloud/data_source_sakuracloud_container_registry.go
+++ b/sakuracloud/data_source_sakuracloud_container_registry.go
@@ -36,11 +36,11 @@ func dataSourceSakuraCloudContainerRegistry() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"visibility": {
+			"access_level": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"prefix": {
+			"subdomain_label": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/sakuracloud/data_source_sakuracloud_container_registry_test.go
+++ b/sakuracloud/data_source_sakuracloud_container_registry_test.go
@@ -45,9 +45,9 @@ func TestAccSakuraCloudDataSourceContainerRegistry_basic(t *testing.T) {
 
 var testAccSakuraCloudDataSourceContainerRegistry_basic = `
 resource "sakuracloud_container_registry" "foobar" {
-  name        = "{{ .arg0 }}"
-  prefix      = "{{ .arg1 }}"
-  visibility  = "readwrite"
+  name            = "{{ .arg0 }}"
+  subdomain_label = "{{ .arg1 }}"
+  access_level    = "readwrite"
 
   description = "description"
   tags        = ["tag1", "tag2"]

--- a/sakuracloud/resource_sakuracloud_container_registry.go
+++ b/sakuracloud/resource_sakuracloud_container_registry.go
@@ -44,12 +44,12 @@ func resourceSakuraCloudContainerRegistry() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"visibility": {
+			"access_level": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice(types.ContainerRegistryVisibilityStrings, false),
 			},
-			"prefix": {
+			"subdomain_label": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -182,11 +182,11 @@ func resourceSakuraCloudContainerRegistryDelete(d *schema.ResourceData, meta int
 }
 
 func setContainerRegistryResourceData(ctx context.Context, d *schema.ResourceData, client *APIClient, data *sacloud.ContainerRegistry) error {
-	d.Set("name", data.Name)               // nolint
-	d.Set("visibility", data.Visibility)   // nolint
-	d.Set("prefix", data.NamePrefix)       // nolint
-	d.Set("fqdn", data.FQDN)               // nolint
-	d.Set("icon_id", data.IconID.String()) // nolint
-	d.Set("description", data.Description) // nolint
+	d.Set("name", data.Name)                         // nolint
+	d.Set("access_level", data.AccessLevel.String()) // nolint
+	d.Set("subdomain_label", data.SubDomainLabel)    // nolint
+	d.Set("fqdn", data.FQDN)                         // nolint
+	d.Set("icon_id", data.IconID.String())           // nolint
+	d.Set("description", data.Description)           // nolint
 	return d.Set("tags", flattenTags(data.Tags))
 }

--- a/sakuracloud/resource_sakuracloud_container_registry_test.go
+++ b/sakuracloud/resource_sakuracloud_container_registry_test.go
@@ -29,7 +29,7 @@ import (
 func TestAccSakuraCloudContainerRegistry_basic(t *testing.T) {
 	resourceName := "sakuracloud_container_registry.foobar"
 	rand := randomName()
-	prefix := acctest.RandStringFromCharSet(60, acctest.CharSetAlpha)
+	subDomainLabel := acctest.RandStringFromCharSet(60, acctest.CharSetAlpha)
 	password := randomPassword()
 
 	var reg sacloud.ContainerRegistry
@@ -42,13 +42,13 @@ func TestAccSakuraCloudContainerRegistry_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: buildConfigWithArgs(testAccSakuraCloudContainerRegistry_basic, rand, prefix, password),
+				Config: buildConfigWithArgs(testAccSakuraCloudContainerRegistry_basic, rand, subDomainLabel, password),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudContainerRegistryExists(resourceName, &reg),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
-					resource.TestCheckResourceAttr(resourceName, "prefix", prefix),
-					resource.TestCheckResourceAttr(resourceName, "fqdn", prefix+".sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "visibility", "readwrite"),
+					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
+					resource.TestCheckResourceAttr(resourceName, "fqdn", subDomainLabel+".sakuracr.jp"),
+					resource.TestCheckResourceAttr(resourceName, "access_level", "readwrite"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.4151227546", "tag1"),
@@ -63,13 +63,13 @@ func TestAccSakuraCloudContainerRegistry_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: buildConfigWithArgs(testAccSakuraCloudContainerRegistry_update, rand, prefix, password),
+				Config: buildConfigWithArgs(testAccSakuraCloudContainerRegistry_update, rand, subDomainLabel, password),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudContainerRegistryExists(resourceName, &reg),
 					resource.TestCheckResourceAttr(resourceName, "name", rand+"-upd"),
-					resource.TestCheckResourceAttr(resourceName, "prefix", prefix),
-					resource.TestCheckResourceAttr(resourceName, "fqdn", prefix+".sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "visibility", "readonly"),
+					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
+					resource.TestCheckResourceAttr(resourceName, "fqdn", subDomainLabel+".sakuracr.jp"),
+					resource.TestCheckResourceAttr(resourceName, "access_level", "readonly"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.2362157161", "tag1-upd"),
@@ -138,9 +138,9 @@ func testCheckSakuraCloudContainerRegistryDestroy(s *terraform.State) error {
 
 var testAccSakuraCloudContainerRegistry_basic = `
 resource "sakuracloud_container_registry" "foobar" {
-  name        = "{{ .arg0 }}"
-  prefix      = "{{ .arg1 }}"
-  visibility  = "readwrite"
+  name            = "{{ .arg0 }}"
+  subdomain_label = "{{ .arg1 }}"
+  access_level    = "readwrite"
 
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -164,9 +164,9 @@ resource "sakuracloud_icon" "foobar" {
 
 var testAccSakuraCloudContainerRegistry_update = `
 resource "sakuracloud_container_registry" "foobar" {
-  name        = "{{ .arg0 }}-upd"
-  prefix      = "{{ .arg1 }}"
-  visibility  = "readonly"
+  name            = "{{ .arg0 }}-upd"
+  subdomain_label = "{{ .arg1 }}"
+  access_level    = "readonly"
 
   description = "description-upd"
   tags        = ["tag1-upd", "tag2-upd"]

--- a/sakuracloud/structure_container_registry.go
+++ b/sakuracloud/structure_container_registry.go
@@ -22,15 +22,15 @@ import (
 
 func expandContainerRegistryBuilder(d *schema.ResourceData, client *APIClient, settingsHash string) *registryUtil.Builder {
 	return &registryUtil.Builder{
-		Name:         d.Get("name").(string),
-		Description:  d.Get("description").(string),
-		Tags:         expandTags(d),
-		IconID:       expandSakuraCloudID(d, "icon_id"),
-		Visibility:   types.EContainerRegistryVisibility(d.Get("visibility").(string)),
-		NamePrefix:   d.Get("prefix").(string),
-		Users:        expandContainerRegistryUsers(d),
-		SettingsHash: settingsHash,
-		Client:       registryUtil.NewAPIClient(client),
+		Name:           d.Get("name").(string),
+		Description:    d.Get("description").(string),
+		Tags:           expandTags(d),
+		IconID:         expandSakuraCloudID(d, "icon_id"),
+		AccessLevel:    types.EContainerRegistryAccessLevel(d.Get("access_level").(string)),
+		SubDomainLabel: d.Get("subdomain_label").(string),
+		Users:          expandContainerRegistryUsers(d),
+		SettingsHash:   settingsHash,
+		Client:         registryUtil.NewAPIClient(client),
 	}
 }
 

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_container_registry.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_container_registry.go
@@ -44,7 +44,7 @@ func (o *ContainerRegistryOp) Create(ctx context.Context, param *sacloud.Contain
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt)
 
-	result.FQDN = result.NamePrefix + ".sakuracr.jp"
+	result.FQDN = result.SubDomainLabel + ".sakuracr.jp"
 	result.Availability = types.Availabilities.Available
 	putContainerRegistry(sacloud.APIDefaultZone, result)
 	return result, nil

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/container_registry.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/container_registry.go
@@ -50,14 +50,14 @@ type ContainerRegistrySettings struct {
 
 // ContainerRegistrySetting セッティング
 type ContainerRegistrySetting struct {
-	Public        types.EContainerRegistryVisibility `json:"public" yaml:"public"` // readwrite or readonly or none
-	VirtualDomain string                             `json:"virtual_domain" yaml:"virtual_domain"`
+	Public        types.EContainerRegistryAccessLevel `json:"public" yaml:"public"` // readwrite or readonly or none
+	VirtualDomain string                              `json:"virtual_domain" yaml:"virtual_domain"`
 }
 
 // ContainerRegistryStatus ステータス
 type ContainerRegistryStatus struct {
 	RegistryName string `json:"registry_name" yaml:"registry_name"`
-	FQDN         string `json:"hostname,omitempty" yanl:"hostname,omitempty"`
+	FQDN         string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
 }
 
 // ContainerRegistryUser コンテナレジストリのユーザ

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/types/container_registry_visibility.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/types/container_registry_visibility.go
@@ -14,18 +14,18 @@
 
 package types
 
-type EContainerRegistryVisibility string
+type EContainerRegistryAccessLevel string
 
 // String EContainerRegistryVisibilityの文字列表現
-func (v EContainerRegistryVisibility) String() string {
+func (v EContainerRegistryAccessLevel) String() string {
 	return string(v)
 }
 
-// ContainerRegistryVisibilities コンテナレジストリのアクセス範囲
-var ContainerRegistryVisibilities = struct {
-	ReadWrite EContainerRegistryVisibility
-	ReadOnly  EContainerRegistryVisibility
-	None      EContainerRegistryVisibility
+// ContainerRegistryAccessLevels コンテナレジストリのアクセス範囲
+var ContainerRegistryAccessLevels = struct {
+	ReadWrite EContainerRegistryAccessLevel
+	ReadOnly  EContainerRegistryAccessLevel
+	None      EContainerRegistryAccessLevel
 }{
 	ReadWrite: "readwrite",
 	ReadOnly:  "readonly",
@@ -34,14 +34,14 @@ var ContainerRegistryVisibilities = struct {
 
 // ContainerRegistryVisibilityStrings アクセス範囲に指定可能な文字列
 var ContainerRegistryVisibilityStrings = []string{
-	ContainerRegistryVisibilities.ReadWrite.String(),
-	ContainerRegistryVisibilities.ReadOnly.String(),
-	ContainerRegistryVisibilities.None.String(),
+	ContainerRegistryAccessLevels.ReadWrite.String(),
+	ContainerRegistryAccessLevels.ReadOnly.String(),
+	ContainerRegistryAccessLevels.None.String(),
 }
 
 // ContainerRegistryVisibilityMap 文字列とEContainerRegistryVisibilityのマップ
-var ContainerRegistryVisibilityMap = map[string]EContainerRegistryVisibility{
-	ContainerRegistryVisibilities.ReadWrite.String(): ContainerRegistryVisibilities.ReadWrite,
-	ContainerRegistryVisibilities.ReadOnly.String():  ContainerRegistryVisibilities.ReadOnly,
-	ContainerRegistryVisibilities.None.String():      ContainerRegistryVisibilities.None,
+var ContainerRegistryVisibilityMap = map[string]EContainerRegistryAccessLevel{
+	ContainerRegistryAccessLevels.ReadWrite.String(): ContainerRegistryAccessLevels.ReadWrite,
+	ContainerRegistryAccessLevels.ReadOnly.String():  ContainerRegistryAccessLevels.ReadOnly,
+	ContainerRegistryAccessLevels.None.String():      ContainerRegistryAccessLevels.None,
 }

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
@@ -3246,18 +3246,18 @@ func (o *CDROMUpdateRequest) SetIconID(v types.ID) {
 
 // ContainerRegistry represents API parameter/response structure
 type ContainerRegistry struct {
-	ID           types.ID
-	Name         string `validate:"required"`
-	Description  string `validate:"min=0,max=512"`
-	Tags         types.Tags
-	Availability types.EAvailability
-	IconID       types.ID `mapconv:"Icon.ID"`
-	CreatedAt    time.Time
-	ModifiedAt   time.Time
-	Visibility   types.EContainerRegistryVisibility `mapconv:"Settings.ContainerRegistry.Public"`
-	SettingsHash string                             `json:",omitempty" mapconv:",omitempty"`
-	NamePrefix   string                             `mapconv:"Status.RegistryName"`
-	FQDN         string                             `mapconv:"Status.FQDN"`
+	ID             types.ID
+	Name           string `validate:"required"`
+	Description    string `validate:"min=0,max=512"`
+	Tags           types.Tags
+	Availability   types.EAvailability
+	IconID         types.ID `mapconv:"Icon.ID"`
+	CreatedAt      time.Time
+	ModifiedAt     time.Time
+	AccessLevel    types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+	SettingsHash   string                              `json:",omitempty" mapconv:",omitempty"`
+	SubDomainLabel string                              `mapconv:"Status.RegistryName"`
+	FQDN           string                              `mapconv:"Status.FQDN"`
 }
 
 // Validate validates by field tags
@@ -3268,31 +3268,31 @@ func (o *ContainerRegistry) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ContainerRegistry) setDefaults() interface{} {
 	return &struct {
-		ID           types.ID
-		Name         string `validate:"required"`
-		Description  string `validate:"min=0,max=512"`
-		Tags         types.Tags
-		Availability types.EAvailability
-		IconID       types.ID `mapconv:"Icon.ID"`
-		CreatedAt    time.Time
-		ModifiedAt   time.Time
-		Visibility   types.EContainerRegistryVisibility `mapconv:"Settings.ContainerRegistry.Public"`
-		SettingsHash string                             `json:",omitempty" mapconv:",omitempty"`
-		NamePrefix   string                             `mapconv:"Status.RegistryName"`
-		FQDN         string                             `mapconv:"Status.FQDN"`
+		ID             types.ID
+		Name           string `validate:"required"`
+		Description    string `validate:"min=0,max=512"`
+		Tags           types.Tags
+		Availability   types.EAvailability
+		IconID         types.ID `mapconv:"Icon.ID"`
+		CreatedAt      time.Time
+		ModifiedAt     time.Time
+		AccessLevel    types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+		SettingsHash   string                              `json:",omitempty" mapconv:",omitempty"`
+		SubDomainLabel string                              `mapconv:"Status.RegistryName"`
+		FQDN           string                              `mapconv:"Status.FQDN"`
 	}{
-		ID:           o.GetID(),
-		Name:         o.GetName(),
-		Description:  o.GetDescription(),
-		Tags:         o.GetTags(),
-		Availability: o.GetAvailability(),
-		IconID:       o.GetIconID(),
-		CreatedAt:    o.GetCreatedAt(),
-		ModifiedAt:   o.GetModifiedAt(),
-		Visibility:   o.GetVisibility(),
-		SettingsHash: o.GetSettingsHash(),
-		NamePrefix:   o.GetNamePrefix(),
-		FQDN:         o.GetFQDN(),
+		ID:             o.GetID(),
+		Name:           o.GetName(),
+		Description:    o.GetDescription(),
+		Tags:           o.GetTags(),
+		Availability:   o.GetAvailability(),
+		IconID:         o.GetIconID(),
+		CreatedAt:      o.GetCreatedAt(),
+		ModifiedAt:     o.GetModifiedAt(),
+		AccessLevel:    o.GetAccessLevel(),
+		SettingsHash:   o.GetSettingsHash(),
+		SubDomainLabel: o.GetSubDomainLabel(),
+		FQDN:           o.GetFQDN(),
 	}
 }
 
@@ -3416,14 +3416,14 @@ func (o *ContainerRegistry) SetModifiedAt(v time.Time) {
 	o.ModifiedAt = v
 }
 
-// GetVisibility returns value of Visibility
-func (o *ContainerRegistry) GetVisibility() types.EContainerRegistryVisibility {
-	return o.Visibility
+// GetAccessLevel returns value of AccessLevel
+func (o *ContainerRegistry) GetAccessLevel() types.EContainerRegistryAccessLevel {
+	return o.AccessLevel
 }
 
-// SetVisibility sets value to Visibility
-func (o *ContainerRegistry) SetVisibility(v types.EContainerRegistryVisibility) {
-	o.Visibility = v
+// SetAccessLevel sets value to AccessLevel
+func (o *ContainerRegistry) SetAccessLevel(v types.EContainerRegistryAccessLevel) {
+	o.AccessLevel = v
 }
 
 // GetSettingsHash returns value of SettingsHash
@@ -3436,14 +3436,14 @@ func (o *ContainerRegistry) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 
-// GetNamePrefix returns value of NamePrefix
-func (o *ContainerRegistry) GetNamePrefix() string {
-	return o.NamePrefix
+// GetSubDomainLabel returns value of SubDomainLabel
+func (o *ContainerRegistry) GetSubDomainLabel() string {
+	return o.SubDomainLabel
 }
 
-// SetNamePrefix sets value to NamePrefix
-func (o *ContainerRegistry) SetNamePrefix(v string) {
-	o.NamePrefix = v
+// SetSubDomainLabel sets value to SubDomainLabel
+func (o *ContainerRegistry) SetSubDomainLabel(v string) {
+	o.SubDomainLabel = v
 }
 
 // GetFQDN returns value of FQDN
@@ -3462,12 +3462,12 @@ func (o *ContainerRegistry) SetFQDN(v string) {
 
 // ContainerRegistryCreateRequest represents API parameter/response structure
 type ContainerRegistryCreateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
-	Tags        types.Tags
-	IconID      types.ID                           `mapconv:"Icon.ID"`
-	Visibility  types.EContainerRegistryVisibility `mapconv:"Settings.ContainerRegistry.Public"`
-	NamePrefix  string                             `mapconv:"Status.RegistryName"`
+	Name           string `validate:"required"`
+	Description    string `validate:"min=0,max=512"`
+	Tags           types.Tags
+	IconID         types.ID                            `mapconv:"Icon.ID"`
+	AccessLevel    types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+	SubDomainLabel string                              `mapconv:"Status.RegistryName"`
 }
 
 // Validate validates by field tags
@@ -3478,21 +3478,21 @@ func (o *ContainerRegistryCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ContainerRegistryCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
-		Tags        types.Tags
-		IconID      types.ID                           `mapconv:"Icon.ID"`
-		Visibility  types.EContainerRegistryVisibility `mapconv:"Settings.ContainerRegistry.Public"`
-		NamePrefix  string                             `mapconv:"Status.RegistryName"`
-		Class       string                             `mapconv:"Provider.Class"`
+		Name           string `validate:"required"`
+		Description    string `validate:"min=0,max=512"`
+		Tags           types.Tags
+		IconID         types.ID                            `mapconv:"Icon.ID"`
+		AccessLevel    types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+		SubDomainLabel string                              `mapconv:"Status.RegistryName"`
+		Class          string                              `mapconv:"Provider.Class"`
 	}{
-		Name:        o.GetName(),
-		Description: o.GetDescription(),
-		Tags:        o.GetTags(),
-		IconID:      o.GetIconID(),
-		Visibility:  o.GetVisibility(),
-		NamePrefix:  o.GetNamePrefix(),
-		Class:       "containerregistry",
+		Name:           o.GetName(),
+		Description:    o.GetDescription(),
+		Tags:           o.GetTags(),
+		IconID:         o.GetIconID(),
+		AccessLevel:    o.GetAccessLevel(),
+		SubDomainLabel: o.GetSubDomainLabel(),
+		Class:          "containerregistry",
 	}
 }
 
@@ -3556,24 +3556,24 @@ func (o *ContainerRegistryCreateRequest) SetIconID(v types.ID) {
 	o.IconID = v
 }
 
-// GetVisibility returns value of Visibility
-func (o *ContainerRegistryCreateRequest) GetVisibility() types.EContainerRegistryVisibility {
-	return o.Visibility
+// GetAccessLevel returns value of AccessLevel
+func (o *ContainerRegistryCreateRequest) GetAccessLevel() types.EContainerRegistryAccessLevel {
+	return o.AccessLevel
 }
 
-// SetVisibility sets value to Visibility
-func (o *ContainerRegistryCreateRequest) SetVisibility(v types.EContainerRegistryVisibility) {
-	o.Visibility = v
+// SetAccessLevel sets value to AccessLevel
+func (o *ContainerRegistryCreateRequest) SetAccessLevel(v types.EContainerRegistryAccessLevel) {
+	o.AccessLevel = v
 }
 
-// GetNamePrefix returns value of NamePrefix
-func (o *ContainerRegistryCreateRequest) GetNamePrefix() string {
-	return o.NamePrefix
+// GetSubDomainLabel returns value of SubDomainLabel
+func (o *ContainerRegistryCreateRequest) GetSubDomainLabel() string {
+	return o.SubDomainLabel
 }
 
-// SetNamePrefix sets value to NamePrefix
-func (o *ContainerRegistryCreateRequest) SetNamePrefix(v string) {
-	o.NamePrefix = v
+// SetSubDomainLabel sets value to SubDomainLabel
+func (o *ContainerRegistryCreateRequest) SetSubDomainLabel(v string) {
+	o.SubDomainLabel = v
 }
 
 /*************************************************
@@ -3585,9 +3585,9 @@ type ContainerRegistryUpdateRequest struct {
 	Name         string `validate:"required"`
 	Description  string `validate:"min=0,max=512"`
 	Tags         types.Tags
-	IconID       types.ID                           `mapconv:"Icon.ID"`
-	Visibility   types.EContainerRegistryVisibility `mapconv:"Settings.ContainerRegistry.Public"`
-	SettingsHash string                             `json:",omitempty" mapconv:",omitempty"`
+	IconID       types.ID                            `mapconv:"Icon.ID"`
+	AccessLevel  types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+	SettingsHash string                              `json:",omitempty" mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -3601,15 +3601,15 @@ func (o *ContainerRegistryUpdateRequest) setDefaults() interface{} {
 		Name         string `validate:"required"`
 		Description  string `validate:"min=0,max=512"`
 		Tags         types.Tags
-		IconID       types.ID                           `mapconv:"Icon.ID"`
-		Visibility   types.EContainerRegistryVisibility `mapconv:"Settings.ContainerRegistry.Public"`
-		SettingsHash string                             `json:",omitempty" mapconv:",omitempty"`
+		IconID       types.ID                            `mapconv:"Icon.ID"`
+		AccessLevel  types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+		SettingsHash string                              `json:",omitempty" mapconv:",omitempty"`
 	}{
 		Name:         o.GetName(),
 		Description:  o.GetDescription(),
 		Tags:         o.GetTags(),
 		IconID:       o.GetIconID(),
-		Visibility:   o.GetVisibility(),
+		AccessLevel:  o.GetAccessLevel(),
 		SettingsHash: o.GetSettingsHash(),
 	}
 }
@@ -3674,14 +3674,14 @@ func (o *ContainerRegistryUpdateRequest) SetIconID(v types.ID) {
 	o.IconID = v
 }
 
-// GetVisibility returns value of Visibility
-func (o *ContainerRegistryUpdateRequest) GetVisibility() types.EContainerRegistryVisibility {
-	return o.Visibility
+// GetAccessLevel returns value of AccessLevel
+func (o *ContainerRegistryUpdateRequest) GetAccessLevel() types.EContainerRegistryAccessLevel {
+	return o.AccessLevel
 }
 
-// SetVisibility sets value to Visibility
-func (o *ContainerRegistryUpdateRequest) SetVisibility(v types.EContainerRegistryVisibility) {
-	o.Visibility = v
+// SetAccessLevel sets value to AccessLevel
+func (o *ContainerRegistryUpdateRequest) SetAccessLevel(v types.EContainerRegistryAccessLevel) {
+	o.AccessLevel = v
 }
 
 // GetSettingsHash returns value of SettingsHash
@@ -3700,8 +3700,8 @@ func (o *ContainerRegistryUpdateRequest) SetSettingsHash(v string) {
 
 // ContainerRegistryUpdateSettingsRequest represents API parameter/response structure
 type ContainerRegistryUpdateSettingsRequest struct {
-	Visibility   types.EContainerRegistryVisibility `mapconv:"Settings.ContainerRegistry.Public"`
-	SettingsHash string                             `json:",omitempty" mapconv:",omitempty"`
+	AccessLevel  types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+	SettingsHash string                              `json:",omitempty" mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -3712,22 +3712,22 @@ func (o *ContainerRegistryUpdateSettingsRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ContainerRegistryUpdateSettingsRequest) setDefaults() interface{} {
 	return &struct {
-		Visibility   types.EContainerRegistryVisibility `mapconv:"Settings.ContainerRegistry.Public"`
-		SettingsHash string                             `json:",omitempty" mapconv:",omitempty"`
+		AccessLevel  types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+		SettingsHash string                              `json:",omitempty" mapconv:",omitempty"`
 	}{
-		Visibility:   o.GetVisibility(),
+		AccessLevel:  o.GetAccessLevel(),
 		SettingsHash: o.GetSettingsHash(),
 	}
 }
 
-// GetVisibility returns value of Visibility
-func (o *ContainerRegistryUpdateSettingsRequest) GetVisibility() types.EContainerRegistryVisibility {
-	return o.Visibility
+// GetAccessLevel returns value of AccessLevel
+func (o *ContainerRegistryUpdateSettingsRequest) GetAccessLevel() types.EContainerRegistryAccessLevel {
+	return o.AccessLevel
 }
 
-// SetVisibility sets value to Visibility
-func (o *ContainerRegistryUpdateSettingsRequest) SetVisibility(v types.EContainerRegistryVisibility) {
-	o.Visibility = v
+// SetAccessLevel sets value to AccessLevel
+func (o *ContainerRegistryUpdateSettingsRequest) SetAccessLevel(v types.EContainerRegistryAccessLevel) {
+	o.AccessLevel = v
 }
 
 // GetSettingsHash returns value of SettingsHash

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/registry/builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/registry/builder.go
@@ -22,15 +22,15 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
-// Builder SIMのセットアップを行う
+// Builder コンテナレジストリのセットアップを行う
 type Builder struct {
-	Name        string
-	Description string
-	Tags        types.Tags
-	IconID      types.ID
-	Visibility  types.EContainerRegistryVisibility
-	NamePrefix  string
-	Users       []*User
+	Name           string
+	Description    string
+	Tags           types.Tags
+	IconID         types.ID
+	AccessLevel    types.EContainerRegistryAccessLevel
+	SubDomainLabel string
+	Users          []*User
 
 	SettingsHash string
 	Client       *APIClient
@@ -44,7 +44,7 @@ type User struct {
 
 // Validate 値の検証
 func (b *Builder) Validate(ctx context.Context) error {
-	if b.NamePrefix == "" {
+	if b.SubDomainLabel == "" {
 		return fmt.Errorf("name prefix is required")
 	}
 	return nil
@@ -57,12 +57,12 @@ func (b *Builder) Build(ctx context.Context) (*sacloud.ContainerRegistry, error)
 	}
 
 	reg, err := b.Client.ContainerRegistry.Create(ctx, &sacloud.ContainerRegistryCreateRequest{
-		Name:        b.Name,
-		Description: b.Description,
-		Tags:        b.Tags,
-		IconID:      b.IconID,
-		Visibility:  b.Visibility,
-		NamePrefix:  b.NamePrefix,
+		Name:           b.Name,
+		Description:    b.Description,
+		Tags:           b.Tags,
+		IconID:         b.IconID,
+		AccessLevel:    b.AccessLevel,
+		SubDomainLabel: b.SubDomainLabel,
 	})
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func (b *Builder) Build(ctx context.Context) (*sacloud.ContainerRegistry, error)
 	return reg, nil
 }
 
-// Update SIMの更新
+// Update コンテナレジストリの更新
 func (b *Builder) Update(ctx context.Context, id types.ID) (*sacloud.ContainerRegistry, error) {
 	if err := b.Validate(ctx); err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (b *Builder) Update(ctx context.Context, id types.ID) (*sacloud.ContainerRe
 		Description:  b.Description,
 		Tags:         b.Tags,
 		IconID:       b.IconID,
-		Visibility:   b.Visibility,
+		AccessLevel:  b.AccessLevel,
 		SettingsHash: b.SettingsHash,
 	})
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/posener/complete/match
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud/v2 v2.0.0-rc2.0.20191223115943-899ad7b5272b
+# github.com/sacloud/libsacloud/v2 v2.0.0-rc2.0.20191224002111-a5e28d35bd8b
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/pkg/cidr
 github.com/sacloud/libsacloud/v2/pkg/mapconv


### PR DESCRIPTION
from https://github.com/sacloud/libsacloud/issues/471
related: #617  

libsacloudでのコンテナレジストリのフィールド名を変更を反映する。

- visibility -> access_level
- prefix -> subdomain_label