### PR TITLE
Add set-license to the default goal

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ ACC_TEST_UA ?= (Acceptance Test)
 
 export GO111MODULE=on
 
-default: fmt goimports lint tflint
+default: fmt goimports set-license lint tflint
 
 clean:
 	rm -Rf $(CURDIR)/bin/*
@@ -110,4 +110,4 @@ docker-build: clean
 
 .PHONY: set-license
 set-license:
-	@addlicense -c $(AUTHOR) -y $(COPYRIGHT_YEAR) $(COPYRIGHT_FILES)
+	addlicense -c $(AUTHOR) -y $(COPYRIGHT_YEAR) $(COPYRIGHT_FILES)


### PR DESCRIPTION
related: #619 

Makefileのデフォルトゴールにライセンスコメント挿入タスクを実行する`set-license`を追加する。