### PR TITLE
Remove NFS size validation

### DIFF
--- a/build_docs/docs/configuration/resources/nfs.md
+++ b/build_docs/docs/configuration/resources/nfs.md
@@ -38,7 +38,7 @@ resource "sakuracloud_switch" "sw" {
 | `name`          | ◯   | NFS名 | -        | 文字列                         | - |
 | `switch_id`     | ◯   | スイッチID      | -        | 文字列                         | - |
 | `plan`          | -   | プラン          |`hdd`| `hdd`<br />`ssd`<br />|- |
-| `size`          | -   | サイズ          |`100`| `100`<br />`500`<br />`1024`<br />`2048`<br />`4096`<br />`8192`(HDDのみ)<br />`12288`(HDDのみ)<br />|- |
+| `size`          | -   | サイズ          |`100`| `20`(SSDのみ)<br />100`<br />`500`<br />`1024`<br />`2048`<br />`4096`<br />`8192`(HDDのみ)<br />`12288`(HDDのみ)<br />|- |
 | `ipaddress`     | ◯   | IPアドレス     | -        | 文字列                         | - |
 | `nw_mask_len`   | ◯   | ネットマスク     | -        | 数値                          | - |
 | `default_route` | -   | ゲートウェイ     | -        | 文字列                        | - |

--- a/sakuracloud/resource_sakuracloud_nfs.go
+++ b/sakuracloud/resource_sakuracloud_nfs.go
@@ -16,7 +16,6 @@ package sakuracloud
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -58,16 +57,7 @@ func resourceSakuraCloudNFS() *schema.Resource {
 				Type:     schema.TypeInt,
 				ForceNew: true,
 				Optional: true,
-				Default:  "100",
-				ValidateFunc: validateIntInWord([]string{
-					strconv.Itoa(int(sacloud.NFSSize100G)),
-					strconv.Itoa(int(sacloud.NFSSize500G)),
-					strconv.Itoa(int(sacloud.NFSSize1T)),
-					strconv.Itoa(int(sacloud.NFSSize2T)),
-					strconv.Itoa(int(sacloud.NFSSize4T)),
-					strconv.Itoa(int(sacloud.NFSSize8T)),
-					strconv.Itoa(int(sacloud.NFSSize12T)),
-				}),
+				Default:  100,
 			},
 			"ipaddress": {
 				Type:     schema.TypeString,
@@ -132,9 +122,6 @@ func resourceSakuraCloudNFSCreate(d *schema.ResourceData, meta interface{}) erro
 	plan := sacloud.NFSPlanHDD
 	if strPlan == "ssd" {
 		plan = sacloud.NFSPlanSSD
-		if _, errs := validation.IntInSlice(sacloud.AllowNFSSSDPlanSizes())(intSize, "size"); len(errs) != 0 {
-			return errs[0]
-		}
 	}
 	size := sacloud.NFSSize(intSize)
 


### PR DESCRIPTION
NFSアプライアンス作成時のサイズ検証を除去する。

現在はlibsacloud側でプラン/サイズに応じてプランIDを取得する処理が行われているため、
有効なサイズかの検証は実行時(`terraform apply`時)に行われる。

v2ではすでに実行時の検証のみとなっているためv1でも合わせる。
