### PR TITLE
Add server_vnc_info data source

### DIFF
--- a/examples/d/server_vnc_info.tf
+++ b/examples/d/server_vnc_info.tf
@@ -1,0 +1,3 @@
+data "sakuracloud_server_vnc_info" "foobar" {
+  server_id = sakuracloud_server.foobar.id
+}

--- a/sakuracloud/data_source_sakuracloud_server_vnc_info.go
+++ b/sakuracloud/data_source_sakuracloud_server_vnc_info.go
@@ -1,0 +1,107 @@
+// Copyright 2016-2020 terraform-provider-sakuracloud authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sakuracloud
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/search"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+func dataSourceSakuraCloudServerVNCInfo() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceSakuraCloudServerVNCInfoRead,
+
+		Schema: map[string]*schema.Schema{
+			"server_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateSakuracloudIDType,
+				Description:  "The id of the Server",
+			},
+			"host": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The host name for connecting by VNC",
+			},
+			"port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The port number for connecting by VNC",
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The password for connecting by VNC",
+			},
+			"zone": schemaDataSourceZone("Server VNC Information"),
+		},
+	}
+}
+
+func dataSourceSakuraCloudServerVNCInfoRead(d *schema.ResourceData, meta interface{}) error {
+	client, zone, err := sakuraCloudClient(d, meta)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
+	// validate account
+	authOp := sacloud.NewAuthStatusOp(client)
+	auth, err := authOp.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("could not read Authentication Status: %s", err)
+	}
+	if auth.Permission == types.Permissions.View {
+		return errors.New("current API key is only permitted to view")
+	}
+
+	// validate zone
+	zoneOp := sacloud.NewZoneOp(client)
+	searched, err := zoneOp.Find(ctx, &sacloud.FindCondition{
+		Filter: search.Filter{
+			search.Key("Name"): search.ExactMatch(zone),
+		},
+	})
+	if err != nil || searched.Count == 0 {
+		return fmt.Errorf("could not find SakuraCkoud Zone[%s]: %s", zone, err)
+	}
+	zoneInfo := searched.Zones[0]
+	if zoneInfo.IsDummy {
+		return fmt.Errorf("reading VNC information is failed: VNC information is not support on zone[%s]", zone)
+	}
+
+	serverOp := sacloud.NewServerOp(client)
+	serverID := expandSakuraCloudID(d, "server_id")
+
+	data, err := serverOp.GetVNCProxy(ctx, zone, serverID)
+	if err != nil {
+		return fmt.Errorf("could not get VNC information: %s", err)
+	}
+
+	d.SetId(serverID.String())
+	d.Set("server_id", serverID.String()) // nolint
+	d.Set("host", data.IOServerHost)      // nolint
+	d.Set("port", data.Port.Int())        // nolint
+	d.Set("password", data.Password)      // nolint
+	d.Set("zone", zone)                   // nolint
+	return nil
+}

--- a/sakuracloud/data_source_sakuracloud_server_vnc_info_test.go
+++ b/sakuracloud/data_source_sakuracloud_server_vnc_info_test.go
@@ -1,0 +1,56 @@
+// Copyright 2016-2020 terraform-provider-sakuracloud authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sakuracloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccSakuraCloudDataSourceServerVNCInfo_basic(t *testing.T) {
+	resourceName := "data.sakuracloud_server_vnc_info.foobar"
+	rand := randomName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: buildConfigWithArgs(testAccSakuraCloudDataSourceServerVNCInfo_basic, rand),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "server_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "host"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+					resource.TestCheckResourceAttrSet(resourceName, "password"),
+					resource.TestCheckResourceAttrSet(resourceName, "zone"),
+				),
+			},
+		},
+	})
+}
+
+var testAccSakuraCloudDataSourceServerVNCInfo_basic = `
+resource "sakuracloud_server" "foobar" {
+  name        = "{{ .arg0 }}"
+  network_interface {
+    upstream = "shared"
+  }
+  force_shutdown = true
+}
+
+data "sakuracloud_server_vnc_info" "foobar" {
+  server_id = sakuracloud_server.foobar.id
+}`

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -153,6 +153,7 @@ func Provider() terraform.ResourceProvider {
 			"sakuracloud_private_host":       dataSourceSakuraCloudPrivateHost(),
 			"sakuracloud_simple_monitor":     dataSourceSakuraCloudSimpleMonitor(),
 			"sakuracloud_server":             dataSourceSakuraCloudServer(),
+			"sakuracloud_server_vnc_info":    dataSourceSakuraCloudServerVNCInfo(),
 			"sakuracloud_ssh_key":            dataSourceSakuraCloudSSHKey(),
 			"sakuracloud_subnet":             dataSourceSakuraCloudSubnet(),
 			"sakuracloud_switch":             dataSourceSakuraCloudSwitch(),

--- a/tools/tfdocgen/cmd/gen-sakuracloud-docs/main.go
+++ b/tools/tfdocgen/cmd/gen-sakuracloud-docs/main.go
@@ -196,6 +196,10 @@ var definitions = map[string]definition{
 		displayName: "Server",
 		category:    CategoryCompute,
 	},
+	"sakuracloud_server_vnc_info": {
+		displayName: "Server VNC Information",
+		category:    CategoryCompute,
+	},
 	"sakuracloud_sim": {
 		displayName: "SIM",
 		category:    CategorySecureMobile,

--- a/website/docs/d/server_vnc_info.md
+++ b/website/docs/d/server_vnc_info.md
@@ -1,0 +1,32 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_server_vnc_info"
+subcategory: "Compute"
+description: |-
+  Get information about VNC for connecting to an existing Server.
+---
+
+# Data Source: sakuracloud_server_vnc_info
+
+Get information about VNC for connecting to an existing Server.
+
+## Example Usage
+
+```hcl
+data "sakuracloud_server_vnc_info" "foobar" {
+  server_id = sakuracloud_server.foobar.id
+}
+```
+
+## Argument Reference
+
+* `server_id` - (Required) The id of the Server.
+* `zone` - (Optional) The name of zone that the Server VNC Information will be created. (e.g. `is1a`, `tk1a`).
+
+## Attribute Reference
+
+* `id` - The id of the Server VNC Information.
+* `host` - The host name for connecting by VNC.
+* `password` - The password for connecting by VNC.
+* `port` - The port number for connecting by VNC.
+

--- a/website/sakuracloud.erb
+++ b/website/sakuracloud.erb
@@ -34,6 +34,9 @@
                 <li>
                   <a href="/docs/providers/sakuracloud/d/server.html">sakuracloud_server</a>
                 </li>
+                <li>
+                  <a href="/docs/providers/sakuracloud/d/server_vnc_info.html">sakuracloud_server_vnc_info</a>
+                </li>
               </ul>
             </li>
 


### PR DESCRIPTION
fixes #498, #509 

VNC接続情報参照用のデータソースを追加する。

```example.tf
data "sakuracloud_server_vnc_info" "foobar" {
  server_id = sakuracloud_server.foobar.id
}
```