### PR TITLE
Fix schema: change type of zone attr from readonly to writable

### DIFF
--- a/sakuracloud/schema.go
+++ b/sakuracloud/schema.go
@@ -126,7 +126,9 @@ func schemaResourceTags(resourceName string) *schema.Schema {
 func schemaDataSourceZone(resourceName string) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeString,
+		Optional:    true,
 		Computed:    true,
+		ForceNew:    true,
 		Description: descf("The name of zone that the %s is in (e.g. `is1a`, `tk1a`)", resourceName),
 	}
 }
@@ -137,7 +139,7 @@ func schemaResourceZone(resourceName string) *schema.Schema {
 		Optional:    true,
 		Computed:    true,
 		ForceNew:    true,
-		Description: descf("The name of zone that the %s will be created. (e.g. `is1a`, `tk1a`)", resourceName),
+		Description: descf("The name of zone that the %s will be created (e.g. `is1a`, `tk1a`)", resourceName),
 	}
 }
 

--- a/website/docs/d/archive.md
+++ b/website/docs/d/archive.md
@@ -22,7 +22,7 @@ data "sakuracloud_archive" "foobar" {
 * `filter` - (Optional) One or more values used for filtering, as defined below.
 * `os_type` - (Optional) The criteria used to filter SakuraCloud archives. This must be one of following:  
 `centos`/`centos8`/`centos7`/`centos6`/`ubuntu`/`ubuntu1804`/`ubuntu1604`/`debian`/`debian10`/`debian9`/`coreos`/`rancheros`/`k3os`/`kusanagi`/`freebsd`/`windows2016`/`windows2016-rds`/`windows2016-rds-office`/`windows2016-sql-web`/`windows2016-sql-standard`/`windows2016-sql-standard-all`/`windows2016-sql2017-standard`/`windows2016-sql2017-enterprise`/`windows2016-sql2017-standard-all`/`windows2019`/`windows2019-rds`/`windows2019-rds-office2016`/`windows2019-rds-office2019`/`windows2019-sql2017-web`/`windows2019-sql2019-web`/`windows2019-sql2017-standard`/`windows2019-sql2019-standard`/`windows2019-sql2017-enterprise`/`windows2019-sql2019-enterprise`/`windows2019-sql2017-standard-all`/`windows2019-sql2019-standard-all`.
-
+* `zone` - (Optional) The name of zone that the Archive is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -49,7 +49,6 @@ A `condition` block supports the following:
 * `name` - The name of the Archive.
 * `size` - The size of Archive in GiB.
 * `tags` - Any tags assigned to the Archive.
-* `zone` - The name of zone that the Archive is in (e.g. `is1a`, `tk1a`).
 
 
 

--- a/website/docs/d/bridge.md
+++ b/website/docs/d/bridge.md
@@ -22,7 +22,7 @@ data "sakuracloud_bridge" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the Bridge is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -45,7 +45,6 @@ A `condition` block supports the following:
 * `id` - The id of the Bridge.
 * `description` - The description of the Bridge.
 * `name` - The name of the Bridge.
-* `zone` - The name of zone that the Bridge is in (e.g. `is1a`, `tk1a`).
 
 
 

--- a/website/docs/d/cdrom.md
+++ b/website/docs/d/cdrom.md
@@ -25,7 +25,7 @@ data "sakuracloud_cdrom" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the CD-ROM is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -52,7 +52,6 @@ A `condition` block supports the following:
 * `name` - The name of the CD-ROM.
 * `size` - The size of CD-ROM in GiB.
 * `tags` - Any tags assigned to the CD-ROM.
-* `zone` - The name of zone that the CD-ROM is in (e.g. `is1a`, `tk1a`).
 
 
 

--- a/website/docs/d/database.md
+++ b/website/docs/d/database.md
@@ -22,7 +22,7 @@ data "sakuracloud_database" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - The name of zone that the Database is in (e.g. `is1a`, `tk1a`).
 
 ---
 

--- a/website/docs/d/disk.md
+++ b/website/docs/d/disk.md
@@ -22,7 +22,7 @@ data "sakuracloud_disk" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the Disk is in (e.g. `is1a`, `tk1a`).
 
 ---
 

--- a/website/docs/d/internet.md
+++ b/website/docs/d/internet.md
@@ -22,7 +22,7 @@ data "sakuracloud_internet" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the Switch+Router is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -61,7 +61,6 @@ A `condition` block supports the following:
 * `server_ids` - A list of the ID of Servers connected to the Switch+Router.
 * `switch_id` - The id of the switch connected from the Switch+Router.
 * `tags` - Any tags assigned to the Switch+Router.
-* `zone` - The name of zone that the Switch+Router is in (e.g. `is1a`, `tk1a`).
 
 
 

--- a/website/docs/d/load_balancer.md
+++ b/website/docs/d/load_balancer.md
@@ -22,7 +22,7 @@ data "sakuracloud_load_balancer" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the LoadBalancer is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -56,7 +56,6 @@ A `condition` block supports the following:
 * `tags` - Any tags assigned to the LoadBalancer.
 * `vip` - A list of `vip` blocks as defined below.
 * `vrid` - The Virtual Router Identifier. This is only used when `high_availability` is set `true`.
-* `zone` - The name of zone that the LoadBalancer is in (e.g. `is1a`, `tk1a`).
 
 
 ---

--- a/website/docs/d/nfs.md
+++ b/website/docs/d/nfs.md
@@ -22,7 +22,7 @@ data "sakuracloud_nfs" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the NFS is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -54,7 +54,6 @@ A `condition` block supports the following:
 * `size` - The size of NFS in GiB.
 * `switch_id` - The id of the switch connected from the NFS.
 * `tags` - Any tags assigned to the NFS.
-* `zone` - The name of zone that the NFS is in (e.g. `is1a`, `tk1a`).
 
 
 

--- a/website/docs/d/packet_filter.md
+++ b/website/docs/d/packet_filter.md
@@ -23,7 +23,7 @@ data "sakuracloud_packet_filter" "foobar" {
 
 * `expression` - (Optional) One or more `expression` blocks as defined below.
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the PacketFilter is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -46,7 +46,6 @@ A `condition` block supports the following:
 * `id` - The id of the Packet Filter.
 * `description` - The description of the PacketFilter.
 * `name` - The name of the PacketFilter.
-* `zone` - The name of zone that the PacketFilter is in (e.g. `is1a`, `tk1a`).
 
 
 ---

--- a/website/docs/d/private_host.md
+++ b/website/docs/d/private_host.md
@@ -22,7 +22,7 @@ data "sakuracloud_private_host" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the PrivateHost is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -52,7 +52,6 @@ A `condition` block supports the following:
 * `icon_id` - The icon id attached to the PrivateHost.
 * `name` - The name of the PrivateHost.
 * `tags` - Any tags assigned to the PrivateHost.
-* `zone` - The name of zone that the PrivateHost is in (e.g. `is1a`, `tk1a`).
 
 
 

--- a/website/docs/d/server.md
+++ b/website/docs/d/server.md
@@ -22,7 +22,7 @@ data "sakuracloud_server" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the Server is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -62,8 +62,6 @@ A `condition` block supports the following:
 * `private_host_id` - The id of the private host which the server is assigned.
 * `private_host_name` - The name of the private host which the server is assigned.
 * `tags` - Any tags assigned to the Server.
-* `zone` - The name of zone that the Server is in (e.g. `is1a`, `tk1a`).
-
 
 ---
 

--- a/website/docs/d/server_vnc_info.md
+++ b/website/docs/d/server_vnc_info.md
@@ -21,7 +21,7 @@ data "sakuracloud_server_vnc_info" "foobar" {
 ## Argument Reference
 
 * `server_id` - (Required) The id of the Server.
-* `zone` - (Optional) The name of zone that the Server VNC Information will be created. (e.g. `is1a`, `tk1a`).
+* `zone` - (Optional) The name of zone that the Server is in (e.g. `is1a`, `tk1a`).
 
 ## Attribute Reference
 

--- a/website/docs/d/subnet.md
+++ b/website/docs/d/subnet.md
@@ -23,7 +23,7 @@ data sakuracloud_subnet "foobar" {
 
 * `index` - (Required) The index of the subnet in assigned to the Switch+Router. Changing this forces a new resource to be created.
 * `internet_id` - (Required) The id of the switch+router resource that the Subnet belongs. Changing this forces a new resource to be created.
-
+* `zone` - (Optional) The name of zone that the Subnet is in (e.g. `is1a`, `tk1a`).
 
 
 ## Attribute Reference
@@ -36,7 +36,6 @@ data sakuracloud_subnet "foobar" {
 * `network_address` - The IPv4 network address assigned to the Subnet.
 * `next_hop` - The ip address of the next-hop at the Subnet.
 * `switch_id` - The id of the switch connected from the Subnet.
-* `zone` - The name of zone that the Subnet is in (e.g. `is1a`, `tk1a`).
 
 
 

--- a/website/docs/d/switch.md
+++ b/website/docs/d/switch.md
@@ -22,7 +22,7 @@ data "sakuracloud_switch" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the Switch is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -50,7 +50,5 @@ A `condition` block supports the following:
 * `name` - The name of the Switch.
 * `server_ids` - A list of server id connected to the Switch.
 * `tags` - Any tags assigned to the Switch.
-* `zone` - The name of zone that the Switch is in (e.g. `is1a`, `tk1a`).
-
 
 

--- a/website/docs/d/vpc_router.md
+++ b/website/docs/d/vpc_router.md
@@ -22,7 +22,7 @@ data "sakuracloud_vpc_router" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-
+* `zone` - (Optional) The name of zone that the VPC Router is in (e.g. `is1a`, `tk1a`).
 
 ---
 
@@ -68,7 +68,6 @@ A `condition` block supports the following:
 * `user` - A list of `user` blocks as defined below.
 * `vip` - The virtual IP address of the VPC Router. This is only used when `plan` is not `standard`.
 * `vrid` - The Virtual Router Identifier. This is only used when `plan` is not `standard`.
-* `zone` - The name of zone that the VPCRouter is in (e.g. `is1a`, `tk1a`).
 
 
 ---

--- a/website/docs/d/zone.md
+++ b/website/docs/d/zone.md
@@ -23,8 +23,6 @@ data "sakuracloud_zone" "is1a" {
 
 * `name` - (Optional) The name of the zone (e.g. `is1a`,`tk1a`).
 
-
-
 ## Attribute Reference
 
 * `id` - The id of the Zone.


### PR DESCRIPTION
データソースでの`zone`が読み取り専用となっていたが、対象リソースの存在するゾーンを指定するための引数とする必要があるためOptional/Computed/ForceNewをtrueにして設定可能な値とする。