### PR TITLE
Use libsacloud v1.35.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud v1.33.0
+	github.com/sacloud/libsacloud v1.35.0
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud v1.33.0 h1:QaPI08/hs9xNDDSI6zcXEwUzgEjHbfTnRG9yV8Vlv20=
-github.com/sacloud/libsacloud v1.33.0/go.mod h1:P7YAOVmnIn3DKHqCZcUKYUXmSwGBm3yS7IBEjKVSrjg=
+github.com/sacloud/libsacloud v1.35.0 h1:YKN67qTONcEf4qX5Fdzv2QA71kgqPO8UUa14QqRbdKo=
+github.com/sacloud/libsacloud v1.35.0/go.mod h1:P7YAOVmnIn3DKHqCZcUKYUXmSwGBm3yS7IBEjKVSrjg=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=

--- a/sakuracloud/resource_sakuracloud_database_read_replica.go
+++ b/sakuracloud/resource_sakuracloud_database_read_replica.go
@@ -281,7 +281,9 @@ func setDatabaseReadReplicaResourceData(d *schema.ResourceData, client *APIClien
 	d.Set("ipaddress1", data.Remark.Servers[0].(map[string]interface{})["IPAddress"])
 	d.Set("icon_id", data.GetIconStrID())
 	d.Set("description", data.Description)
-	d.Set("master_id", data.Settings.DBConf.Replication.Appliance.ID)
+	if data.Settings.DBConf.Replication != nil && data.Settings.DBConf.Replication.Appliance != nil {
+		d.Set("master_id", data.Settings.DBConf.Replication.Appliance.ID.String())
+	}
 	tags := []string{}
 	for _, t := range data.Tags {
 		if !(strings.HasPrefix(t, "@MariaDB-") || strings.HasPrefix(t, "@postgres-")) {

--- a/vendor/github.com/sacloud/libsacloud/.travis.yml
+++ b/vendor/github.com/sacloud/libsacloud/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: "1.12"
+go: "1.13.x"
 
 install:
   - go get -u golang.org/x/lint/golint
@@ -9,4 +9,3 @@ install:
 script:
   - make vet goimports
   - make test
-  - travis_wait 120 make test-builder

--- a/vendor/github.com/sacloud/libsacloud/Dockerfile
+++ b/vendor/github.com/sacloud/libsacloud/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2019 The Libsacloud Authors
+# Copyright 2016-2020 The Libsacloud Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/Makefile
+++ b/vendor/github.com/sacloud/libsacloud/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2019 The Libsacloud Authors
+# Copyright 2016-2020 The Libsacloud Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ TEST            ?=$$(go list ./... | grep -v vendor)
 VETARGS         ?=-all
 GOFMT_FILES     ?=$$(find . -name '*.go' | grep -v vendor)
 AUTHOR          ?="The Libsacloud Authors"
-COPYRIGHT_YEAR  ?="2016-2019"
+COPYRIGHT_YEAR  ?="2016-2020"
 COPYRIGHT_FILES ?=$$(find . -name "*.go" -print | grep -v "/vendor/")
 export GO111MODULE=on
 

--- a/vendor/github.com/sacloud/libsacloud/README.md
+++ b/vendor/github.com/sacloud/libsacloud/README.md
@@ -292,7 +292,7 @@ func main() {
 
 # License
 
-  `libsacloud` Copyright (C) 2016-2019 The Libsacloud Authors.
+  `libsacloud` Copyright (C) 2016-2020 The Libsacloud Authors.
 
   This project is published under [Apache 2.0 License](LICENSE).
 

--- a/vendor/github.com/sacloud/libsacloud/api/archive.go
+++ b/vendor/github.com/sacloud/libsacloud/api/archive.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/archive_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/archive_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/auth_status.go
+++ b/vendor/github.com/sacloud/libsacloud/api/auth_status.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/auto_backup.go
+++ b/vendor/github.com/sacloud/libsacloud/api/auto_backup.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/auto_backup_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/auto_backup_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/base_api.go
+++ b/vendor/github.com/sacloud/libsacloud/api/base_api.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/bill.go
+++ b/vendor/github.com/sacloud/libsacloud/api/bill.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/bridge.go
+++ b/vendor/github.com/sacloud/libsacloud/api/bridge.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/bridge_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/bridge_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/cdrom.go
+++ b/vendor/github.com/sacloud/libsacloud/api/cdrom.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/cdrom_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/cdrom_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/client.go
+++ b/vendor/github.com/sacloud/libsacloud/api/client.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/coupon.go
+++ b/vendor/github.com/sacloud/libsacloud/api/coupon.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/database.go
+++ b/vendor/github.com/sacloud/libsacloud/api/database.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/database_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/database_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/disk.go
+++ b/vendor/github.com/sacloud/libsacloud/api/disk.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/disk_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/disk_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/dns.go
+++ b/vendor/github.com/sacloud/libsacloud/api/dns.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/dns_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/dns_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/doc.go
+++ b/vendor/github.com/sacloud/libsacloud/api/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/error.go
+++ b/vendor/github.com/sacloud/libsacloud/api/error.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/gslb.go
+++ b/vendor/github.com/sacloud/libsacloud/api/gslb.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/gslb_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/gslb_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/icon.go
+++ b/vendor/github.com/sacloud/libsacloud/api/icon.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/icon_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/icon_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/interface.go
+++ b/vendor/github.com/sacloud/libsacloud/api/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/interface_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/interface_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/internet.go
+++ b/vendor/github.com/sacloud/libsacloud/api/internet.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/internet_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/internet_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/ipaddress.go
+++ b/vendor/github.com/sacloud/libsacloud/api/ipaddress.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/ipaddress_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/ipaddress_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/ipv6addr.go
+++ b/vendor/github.com/sacloud/libsacloud/api/ipv6addr.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/ipv6addr_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/ipv6addr_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/ipv6net.go
+++ b/vendor/github.com/sacloud/libsacloud/api/ipv6net.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/ipv6net_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/ipv6net_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/license.go
+++ b/vendor/github.com/sacloud/libsacloud/api/license.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/license_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/license_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/load_balancer.go
+++ b/vendor/github.com/sacloud/libsacloud/api/load_balancer.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/load_balancer_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/load_balancer_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/mobile_gateway.go
+++ b/vendor/github.com/sacloud/libsacloud/api/mobile_gateway.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/mobile_gateway_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/mobile_gateway_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/newsfeed.go
+++ b/vendor/github.com/sacloud/libsacloud/api/newsfeed.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/nfs.go
+++ b/vendor/github.com/sacloud/libsacloud/api/nfs.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/nfs_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/nfs_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/note.go
+++ b/vendor/github.com/sacloud/libsacloud/api/note.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/note_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/note_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/packet_filter.go
+++ b/vendor/github.com/sacloud/libsacloud/api/packet_filter.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/packet_filter_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/packet_filter_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/polling.go
+++ b/vendor/github.com/sacloud/libsacloud/api/polling.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/private_host.go
+++ b/vendor/github.com/sacloud/libsacloud/api/private_host.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/private_host_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/private_host_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/product_disk.go
+++ b/vendor/github.com/sacloud/libsacloud/api/product_disk.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/product_disk_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/product_disk_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/product_internet.go
+++ b/vendor/github.com/sacloud/libsacloud/api/product_internet.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/product_internet_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/product_internet_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/product_license.go
+++ b/vendor/github.com/sacloud/libsacloud/api/product_license.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/product_license_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/product_license_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/product_private_host.go
+++ b/vendor/github.com/sacloud/libsacloud/api/product_private_host.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/product_private_host_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/product_private_host_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/product_server.go
+++ b/vendor/github.com/sacloud/libsacloud/api/product_server.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/product_server_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/product_server_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/proxylb.go
+++ b/vendor/github.com/sacloud/libsacloud/api/proxylb.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/proxylb_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/proxylb_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/public_price.go
+++ b/vendor/github.com/sacloud/libsacloud/api/public_price.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/public_price_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/public_price_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/rate_limit_transport.go
+++ b/vendor/github.com/sacloud/libsacloud/api/rate_limit_transport.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/region.go
+++ b/vendor/github.com/sacloud/libsacloud/api/region.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/region_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/region_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/server.go
+++ b/vendor/github.com/sacloud/libsacloud/api/server.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/server_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/server_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/sim.go
+++ b/vendor/github.com/sacloud/libsacloud/api/sim.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/sim_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/sim_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/simple_monitor.go
+++ b/vendor/github.com/sacloud/libsacloud/api/simple_monitor.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/simple_monitor_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/simple_monitor_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/ssh_key.go
+++ b/vendor/github.com/sacloud/libsacloud/api/ssh_key.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/ssh_key_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/ssh_key_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/subnet.go
+++ b/vendor/github.com/sacloud/libsacloud/api/subnet.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/subnet_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/subnet_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/switch.go
+++ b/vendor/github.com/sacloud/libsacloud/api/switch.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/switch_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/switch_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/vpc_router.go
+++ b/vendor/github.com/sacloud/libsacloud/api/vpc_router.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/vpc_router_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/vpc_router_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/webaccel.go
+++ b/vendor/github.com/sacloud/libsacloud/api/webaccel.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/webaccel_search.go
+++ b/vendor/github.com/sacloud/libsacloud/api/webaccel_search.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/zone.go
+++ b/vendor/github.com/sacloud/libsacloud/api/zone.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/api/zone_gen.go
+++ b/vendor/github.com/sacloud/libsacloud/api/zone_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/docker-compose.yml
+++ b/vendor/github.com/sacloud/libsacloud/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2019 The Libsacloud Authors
+# Copyright 2016-2020 The Libsacloud Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/libsacloud.go
+++ b/vendor/github.com/sacloud/libsacloud/libsacloud.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 package libsacloud
 
 // Version バージョン
-const Version = "1.33.0"
+const Version = "1.35.0"

--- a/vendor/github.com/sacloud/libsacloud/sacloud/account.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/account.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/appliance.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/appliance.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/archive.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/archive.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/auth_status.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/auth_status.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/auto_backup.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/auto_backup.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/bill.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/bill.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/bridge.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/bridge.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/cdrom.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/cdrom.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -383,6 +383,9 @@ var (
 	TagBootCDROM = "@boot-cdrom"
 	// TagBootNetwork 優先ブートデバイスをPXE bootに設定します
 	TagBootNetwork = "@boot-network"
+
+	// TagCPUTopology CPUソケット数を1と認識させる
+	TagCPUTopology = "@cpu-topology"
 )
 
 // DatetimeLayout さくらのクラウドAPIで利用される日付型のレイアウト(RFC3339)

--- a/vendor/github.com/sacloud/libsacloud/sacloud/coupon.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/coupon.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/database_status.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/database_status.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/delete_cache_result.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/delete_cache_result.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/disk.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/disk.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/dns.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/dns.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/doc.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/feed.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/feed.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ftp_server.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ftp_server.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/gslb.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/gslb.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/host.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/host.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/icon.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/icon.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/instance.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/instance.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/interface.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/internet.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/internet.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ipaddress.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ipaddress.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ipv6addr.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ipv6addr.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ipv6net.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ipv6net.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/license.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/license.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/loadbalancer.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/loadbalancer.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/lock.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/lock.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/member.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/member.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/mobile_gateway.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/mobile_gateway.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/monitor.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/monitor.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/nfs.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/nfs.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/note.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/note.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archive_ostype.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archive_ostype.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archiveostypes_string.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archiveostypes_string.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/packet_filter.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/packet_filter.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/private_host.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/private_host.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,3 +30,10 @@ type PrivateHost struct {
 	propCreatedAt // 作成日時
 
 }
+
+const (
+	// PrivateHostClassDynamic 専有ホストプラン(標準)
+	PrivateHostClassDynamic = "dynamic"
+	// PrivateHostClassWindows 専有ホストプラン(windows)
+	PrivateHostClassWindows = "ms_windows"
+)

--- a/vendor/github.com/sacloud/libsacloud/sacloud/product_disk.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/product_disk.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/product_internet.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/product_internet.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/product_license.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/product_license.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/product_privatehost.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/product_privatehost.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/product_server.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/product_server.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_assigned_cpu.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_assigned_cpu.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_assigned_memory.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_assigned_memory.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_availability.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_availability.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_bundle_info.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_bundle_info.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_class.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_class.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_connected_switches.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_connected_switches.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_copy_source.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_copy_source.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_cpu.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_cpu.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_description.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_description.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_disk_connection.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_disk_connection.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_disk_size.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_disk_size.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_disks.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_disks.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_distant_from.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_distant_from.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_host.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_host.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_host_name.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_host_name.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_icon.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_icon.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_instance.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_instance.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_interface_driver.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_interface_driver.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_interfaces.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_interfaces.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_job_status.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_job_status.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_memory.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_memory.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_name.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_name.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_note_class.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_note_class.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_original_archive_id.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_original_archive_id.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_plan_id.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_plan_id.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_private_host.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_private_host.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_private_host_plan.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_private_host_plan.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_region.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_region.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_scope.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_scope.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_server.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_server.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_server_plan.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_server_plan.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_service_class.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_service_class.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_storage.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_storage_class.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_storage_class.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_switch.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_switch.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_tags.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_tags.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_timestamp.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_timestamp.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_wait_disk_migration.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_wait_disk_migration.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_zone.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_zone.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/public_price.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/public_price.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/region.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/region.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/server.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/server.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/sim.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/sim.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/simple_monitor.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/simple_monitor.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/sitetosite_connection_detail.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/sitetosite_connection_detail.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ssh_key.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ssh_key.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/storage.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/storage.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/subnet.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/subnet.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/switch.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/switch.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router_setting.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router_setting.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router_status.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router_status.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/webaccel.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/webaccel.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/sacloud/zone.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/zone.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/utils/mutexkv/mutexkv.go
+++ b/vendor/github.com/sacloud/libsacloud/utils/mutexkv/mutexkv.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/utils/server/rdp.go
+++ b/vendor/github.com/sacloud/libsacloud/utils/server/rdp.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/utils/server/ssh.go
+++ b/vendor/github.com/sacloud/libsacloud/utils/server/ssh.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/utils/server/user_name.go
+++ b/vendor/github.com/sacloud/libsacloud/utils/server/user_name.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/utils/server/vnc_opener.go
+++ b/vendor/github.com/sacloud/libsacloud/utils/server/vnc_opener.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/utils/server/vnc_opener_linux.go
+++ b/vendor/github.com/sacloud/libsacloud/utils/server/vnc_opener_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/utils/server/vnc_opener_windows.go
+++ b/vendor/github.com/sacloud/libsacloud/utils/server/vnc_opener_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/utils/server/vnc_sender.go
+++ b/vendor/github.com/sacloud/libsacloud/utils/server/vnc_sender.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/sacloud/libsacloud/utils/setup/retryable_setup.go
+++ b/vendor/github.com/sacloud/libsacloud/utils/setup/retryable_setup.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 The Libsacloud Authors
+// Copyright 2016-2020 The Libsacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -217,7 +217,7 @@ github.com/posener/complete/match
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud v1.33.0
+# github.com/sacloud/libsacloud v1.35.0
 github.com/sacloud/libsacloud
 github.com/sacloud/libsacloud/api
 github.com/sacloud/libsacloud/sacloud


### PR DESCRIPTION
related: https://github.com/sacloud/libsacloud/pull/487

データベース参照時にUnmarshalエラーが発生することがある問題への対応。
対応済みのlibsacloud v1.35.0を利用するようにする。
