### PR TITLE
update schema: introduce network_interface block

### DIFF
--- a/examples/r/database.tf
+++ b/examples/r/database.tf
@@ -10,17 +10,19 @@ resource "sakuracloud_database" "foobar" {
 
   replica_password = var.replica_password
 
-  source_ranges = ["192.168.11.0/24", "192.168.12.0/24"]
+  network_interface {
+    switch_id     = sakuracloud_switch.foobar.id
+    ip_address    = "192.168.11.11"
+    netmask       = 24
+    gateway       = "192.168.11.1"
+    port          = 3306
+    source_ranges = ["192.168.11.0/24", "192.168.12.0/24"]
+  }
 
-  port = 3306
-
-  backup_time     = "00:00"
-  backup_weekdays = ["mon", "tue"]
-
-  switch_id  = sakuracloud_switch.foobar.id
-  ip_address = "192.168.11.11"
-  netmask    = 24
-  gateway    = "192.168.11.1"
+  backup {
+    time     = "00:00"
+    weekdays = ["mon", "tue"]
+  }
 
   name        = "foobar"
   description = "description"

--- a/examples/r/database_read_replica.tf
+++ b/examples/r/database_read_replica.tf
@@ -1,6 +1,8 @@
 resource "sakuracloud_database_read_replica" "foobar" {
   master_id   = data.sakuracloud_database.master.id
-  ip_address  = "192.168.11.111"
+  network_interface {
+    ip_address  = "192.168.11.111"
+  }
   name        = "foobar"
   description = "description"
   tags        = ["tag1", "tag2"]

--- a/examples/r/load_balancer.tf
+++ b/examples/r/load_balancer.tf
@@ -1,10 +1,14 @@
 resource "sakuracloud_load_balancer" "foobar" {
-  name         = "foobar"
-  switch_id    = sakuracloud_switch.foobar.id
-  vrid         = 1
-  ip_addresses = ["192.168.11.101"]
-  netmask      = 24
-  gateway      = "192.168.11.1"
+  name = "foobar"
+  plan = "standard"
+
+  network_interface {
+    switch_id    = sakuracloud_switch.foobar.id
+    vrid         = 1
+    ip_addresses = ["192.168.11.101"]
+    netmask      = 24
+    gateway      = "192.168.11.1"
+  }
 
   description = "description"
   tags        = ["tag1", "tag2"]

--- a/examples/r/nfs.tf
+++ b/examples/r/nfs.tf
@@ -1,11 +1,15 @@
 resource "sakuracloud_nfs" "foobar" {
-  name        = "foobar"
-  switch_id   = sakuracloud_switch.foobar.id
-  plan        = "ssd"
-  size        = "500"
-  ip_address  = "192.168.11.101"
-  netmask     = 24
-  gateway     = "192.168.11.1"
+  name = "foobar"
+  plan = "ssd"
+  size = "500"
+
+  network_interface {
+    switch_id   = sakuracloud_switch.foobar.id
+    ip_address  = "192.168.11.101"
+    netmask     = 24
+    gateway     = "192.168.11.1"
+  }
+
   description = "description"
   tags        = ["tag1", "tag2"]
 }

--- a/examples/r/vpc_router.tf
+++ b/examples/r/vpc_router.tf
@@ -13,13 +13,15 @@ resource "sakuracloud_vpc_router" "premium" {
 
   internet_connection = true
 
-  switch_id    = sakuracloud_internet.foobar.switch_id
-  vip          = sakuracloud_internet.foobar.ip_addresses[0]
-  ip_addresses = [sakuracloud_internet.foobar.ip_addresses[1], sakuracloud_internet.foobar.ip_addresses[2]]
-  aliases      = [sakuracloud_internet.foobar.ip_addresses[3]]
-  vrid         = 1
+  public_network_interface {
+    switch_id    = sakuracloud_internet.foobar.switch_id
+    vip          = sakuracloud_internet.foobar.ip_addresses[0]
+    ip_addresses = [sakuracloud_internet.foobar.ip_addresses[1], sakuracloud_internet.foobar.ip_addresses[2]]
+    aliases      = [sakuracloud_internet.foobar.ip_addresses[3]]
+    vrid         = 1
+  }
 
-  network_interface {
+  private_network_interface {
     index        = 1
     switch_id    = sakuracloud_switch.foobar.id
     vip          = "192.168.11.1"

--- a/sakuracloud/data_source_sakuracloud_database.go
+++ b/sakuracloud/data_source_sakuracloud_database.go
@@ -62,26 +62,42 @@ func dataSourceSakuraCloudDatabase() *schema.Resource {
 				Sensitive:   true,
 				Description: "The password of user that processing a replication",
 			},
-			"source_ranges": schemaDataSourceSourceRanges(resourceName),
-			"port":          schemaDataSourcePort(),
-			"backup_weekdays": {
+			"network_interface": {
 				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
-				Description: descf(
-					"The list of name of weekday that doing backup. This will be in [%s]",
-					types.BackupWeekdayStrings,
-				),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"switch_id":     schemaDataSourceSwitchID(resourceName),
+						"ip_address":    schemaDataSourceIPAddress(resourceName),
+						"netmask":       schemaDataSourceNetMask(resourceName),
+						"gateway":       schemaDataSourceGateway(resourceName),
+						"port":          schemaDataSourcePort(),
+						"source_ranges": schemaDataSourceSourceRanges(resourceName),
+					},
+				},
 			},
-			"backup_time": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The time to take backup. This will be formatted with `HH:mm`",
+			"backup": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"weekdays": {
+							Type:     schema.TypeList,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+							Description: descf(
+								"The list of name of weekday that doing backup. This will be in [%s]",
+								types.BackupWeekdayStrings,
+							),
+						},
+						"time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The time to take backup. This will be formatted with `HH:mm`",
+						},
+					},
+				},
 			},
-			"switch_id":   schemaDataSourceSwitchID(resourceName),
-			"ip_address":  schemaDataSourceIPAddress(resourceName),
-			"netmask":     schemaDataSourceNetMask(resourceName),
-			"gateway":     schemaDataSourceGateway(resourceName),
 			"icon_id":     schemaDataSourceIconID(resourceName),
 			"description": schemaDataSourceDescription(resourceName),
 			"tags":        schemaDataSourceTags(resourceName),

--- a/sakuracloud/data_source_sakuracloud_database_test.go
+++ b/sakuracloud/data_source_sakuracloud_database_test.go
@@ -59,14 +59,18 @@ resource "sakuracloud_database" "foobar" {
   username = "defuser"
   password = "{{ .arg1 }}"
 
-  switch_id       = "${sakuracloud_switch.foobar.id}"
-  ip_address      = "192.168.11.101"
-  netmask         = 24
-  gateway         = "192.168.11.1"
-  source_ranges   = ["192.168.11.0/24", "192.168.12.0/24"]
-  port            = 54321
-  backup_weekdays = ["mon", "tue"]
-  backup_time     = "00:00"
+  network_interface {
+    switch_id       = "${sakuracloud_switch.foobar.id}"
+    ip_address      = "192.168.11.101"
+    netmask         = 24
+    gateway         = "192.168.11.1"
+    port            = 54321
+    source_ranges   = ["192.168.11.0/24", "192.168.12.0/24"]
+  }
+  backup {
+    weekdays = ["mon", "tue"]
+    time     = "00:00"
+  }
 }
 
 data "sakuracloud_database" "foobar" {

--- a/sakuracloud/data_source_sakuracloud_load_balancer.go
+++ b/sakuracloud/data_source_sakuracloud_load_balancer.go
@@ -31,19 +31,22 @@ func dataSourceSakuraCloudLoadBalancer() *schema.Resource {
 			filterAttrName: filterSchema(&filterSchemaOption{}),
 			"name":         schemaDataSourceName(resourceName),
 			"plan":         schemaDataSourcePlan(resourceName, []string{"standard", "highspec"}),
-			"switch_id":    schemaDataSourceSwitchID(resourceName),
-			"ip_addresses": schemaDataSourceIPAddresses(resourceName),
-			"netmask":      schemaDataSourceNetMask(resourceName),
-			"gateway":      schemaDataSourceGateway(resourceName),
-			"vrid": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The Virtual Router Identifier. This is only used when `high_availability` is set `true`",
-			},
-			"high_availability": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "The flag to enable HA mode",
+			"network_interface": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"switch_id":    schemaDataSourceSwitchID(resourceName),
+						"ip_addresses": schemaDataSourceIPAddresses(resourceName),
+						"netmask":      schemaDataSourceNetMask(resourceName),
+						"gateway":      schemaDataSourceGateway(resourceName),
+						"vrid": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The Virtual Router Identifier",
+						},
+					},
+				},
 			},
 			"vip": {
 				Type:     schema.TypeList,

--- a/sakuracloud/data_source_sakuracloud_load_balancer_test.go
+++ b/sakuracloud/data_source_sakuracloud_load_balancer_test.go
@@ -50,11 +50,13 @@ resource sakuracloud_switch "foobar" {
 }
 
 resource "sakuracloud_load_balancer" "foobar" {
-  switch_id    = sakuracloud_switch.foobar.id
-  vrid         = 1
-  ip_addresses = ["192.168.11.101"]
-  netmask      = 24
-  gateway      = "192.168.11.1"
+  network_interface {
+    switch_id    = sakuracloud_switch.foobar.id
+    vrid         = 1
+    ip_addresses = ["192.168.11.101"]
+    netmask      = 24
+    gateway      = "192.168.11.1"
+  }
 
   name        = "{{ .arg0 }}"
   description = "description"

--- a/sakuracloud/data_source_sakuracloud_nfs.go
+++ b/sakuracloud/data_source_sakuracloud_nfs.go
@@ -32,14 +32,22 @@ func dataSourceSakuraCloudNFS() *schema.Resource {
 			"name":         schemaDataSourceName(resourceName),
 			"plan":         schemaDataSourcePlan(resourceName, types.NFSPlanStrings),
 			"size":         schemaDataSourceSize(resourceName),
-			"switch_id":    schemaDataSourceSwitchID(resourceName),
-			"ip_address":   schemaDataSourceIPAddress(resourceName),
-			"netmask":      schemaDataSourceNetMask(resourceName),
-			"gateway":      schemaDataSourceGateway(resourceName),
-			"icon_id":      schemaDataSourceIconID(resourceName),
-			"description":  schemaDataSourceDescription(resourceName),
-			"tags":         schemaDataSourceTags(resourceName),
-			"zone":         schemaDataSourceZone(resourceName),
+			"network_interface": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"switch_id":  schemaDataSourceSwitchID(resourceName),
+						"ip_address": schemaDataSourceIPAddress(resourceName),
+						"netmask":    schemaDataSourceNetMask(resourceName),
+						"gateway":    schemaDataSourceGateway(resourceName),
+					},
+				},
+			},
+			"icon_id":     schemaDataSourceIconID(resourceName),
+			"description": schemaDataSourceDescription(resourceName),
+			"tags":        schemaDataSourceTags(resourceName),
+			"zone":        schemaDataSourceZone(resourceName),
 		},
 	}
 }

--- a/sakuracloud/data_source_sakuracloud_nfs_test.go
+++ b/sakuracloud/data_source_sakuracloud_nfs_test.go
@@ -39,12 +39,12 @@ func TestAccSakuraCloudDataSourceNFS_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.425776566", "tag3"),
 					resource.TestCheckResourceAttrPair(
-						resourceName, "switch_id",
+						resourceName, "network_interface.0.switch_id",
 						"sakuracloud_switch.foobar", "id",
 					),
-					resource.TestCheckResourceAttr(resourceName, "ip_address", "192.168.11.101"),
-					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
-					resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_address", "192.168.11.101"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.gateway", "192.168.11.1"),
 				),
 			},
 		},
@@ -60,11 +60,13 @@ resource "sakuracloud_nfs" "foobar" {
   name        = "{{ .arg0 }}"
   description = "description"
   tags        = ["tag1", "tag2", "tag3"]
-  switch_id   = sakuracloud_switch.foobar.id
-  ip_address  = "192.168.11.101"
-  netmask     = 24
-  gateway     = "192.168.11.1"
 
+  network_interface {
+    switch_id   = sakuracloud_switch.foobar.id
+    ip_address  = "192.168.11.101"
+    netmask     = 24
+    gateway     = "192.168.11.1"
+  }
 }
 
 data "sakuracloud_nfs" "foobar" {

--- a/sakuracloud/data_source_sakuracloud_vpc_router.go
+++ b/sakuracloud/data_source_sakuracloud_vpc_router.go
@@ -31,28 +31,37 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 			filterAttrName: filterSchema(&filterSchemaOption{}),
 			"name":         schemaDataSourceSwitchID(resourceName),
 			"plan":         schemaDataSourcePlan(resourceName, types.VPCRouterPlanStrings),
-			"switch_id":    schemaDataSourceSwitchID(resourceName),
-			"vip": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The virtual IP address of the VPC Router. This is only used when `plan` is not `standard`",
-			},
-			"ip_addresses": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Computed:    true,
-				Description: "The list of the IP address assigned to the VPC Router. This will be only one value when `plan` is `standard`, two values otherwise",
-			},
-			"vrid": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The Virtual Router Identifier. This is only used when `plan` is not `standard`",
-			},
-			"aliases": {
+			"public_network_interface": {
 				Type:        schema.TypeList,
 				Computed:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "A list of ip alias assigned to the VPC Router. This is only used when `plan` is not `standard`",
+				Description: "A list of additional network interface setting. This doesn't include primary network interface setting",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"switch_id": schemaDataSourceSwitchID(resourceName),
+						"vip": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The virtual IP address of the VPC Router. This is only used when `plan` is not `standard`",
+						},
+						"ip_addresses": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: "The list of the IP address assigned to the VPC Router. This will be only one value when `plan` is `standard`, two values otherwise",
+						},
+						"vrid": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The Virtual Router Identifier. This is only used when `plan` is not `standard`",
+						},
+						"aliases": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "A list of ip alias assigned to the VPC Router. This is only used when `plan` is not `standard`",
+						},
+					},
+				},
 			},
 			"icon_id":     schemaDataSourceIconID(resourceName),
 			"description": schemaDataSourceDescription(resourceName),
@@ -61,6 +70,11 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The public ip address of the VPC Router",
+			},
+			"public_netmask": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The bit length of the subnet to assign to the public network interface",
 			},
 			"syslog_host": {
 				Type:        schema.TypeString,
@@ -72,7 +86,7 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 				Computed:    true,
 				Description: "The flag to enable connecting to the Internet from the VPC Router",
 			},
-			"network_interface": {
+			"private_network_interface": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "A list of additional network interface setting. This doesn't include primary network interface setting",

--- a/sakuracloud/data_source_sakuracloud_vpc_router_test.go
+++ b/sakuracloud/data_source_sakuracloud_vpc_router_test.go
@@ -39,6 +39,7 @@ func TestAccSakuraCloudDataSourceVPCRouter_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.425776566", "tag3"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_netmask"),
 					resource.TestCheckResourceAttrSet(resourceName, "internet_connection"),
 				),
 			},

--- a/sakuracloud/resource_sakuracloud_database_read_replica.go
+++ b/sakuracloud/resource_sakuracloud_database_read_replica.go
@@ -19,8 +19,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/utils/power"
 )
@@ -51,47 +52,57 @@ func resourceSakuraCloudDatabaseReadReplica() *schema.Resource {
 				Description:  "The id of the replication master database",
 			},
 			"name": schemaResourceName(resourceName),
-			"switch_id": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validateSakuracloudIDType,
-				Description:  descf("The id of the switch to which the %s connects. If `switch_id` isn't specified, it will be set to the same value of the master database", resourceName),
-			},
-			"ip_address": {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Required:    true,
-				Description: descf("The IP address to assign to the %s", resourceName),
-			},
-			"netmask": {
-				Type:         schema.TypeInt,
-				ForceNew:     true,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntBetween(8, 29),
-				Description: descf(
-					"The bit length of the subnet to assign to the %s. %s. If `netmask` isn't specified, it will be set to the same value of the master database",
-					resourceName,
-					descRange(8, 29),
-				),
-			},
-			"gateway": {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Computed:    true,
-				Description: descf("The IP address of the gateway used by %s. If `gateway` isn't specified, it will be set to the same value of the master database", resourceName),
-			},
-			"source_ranges": {
+			"network_interface": {
 				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Description: descf(
-					"The range of source IP addresses that allow to access to the %s via network",
-					resourceName,
-				),
+				Required: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"switch_id": {
+							Type:         schema.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validateSakuracloudIDType,
+							Description:  descf("The id of the switch to which the %s connects. If `switch_id` isn't specified, it will be set to the same value of the master database", resourceName),
+						},
+						"ip_address": {
+							Type:        schema.TypeString,
+							ForceNew:    true,
+							Required:    true,
+							Description: descf("The IP address to assign to the %s", resourceName),
+						},
+						"netmask": {
+							Type:         schema.TypeInt,
+							ForceNew:     true,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntBetween(8, 29),
+							Description: descf(
+								"The bit length of the subnet to assign to the %s. %s. If `netmask` isn't specified, it will be set to the same value of the master database",
+								resourceName,
+								descRange(8, 29),
+							),
+						},
+						"gateway": {
+							Type:        schema.TypeString,
+							ForceNew:    true,
+							Optional:    true,
+							Computed:    true,
+							Description: descf("The IP address of the gateway used by %s. If `gateway` isn't specified, it will be set to the same value of the master database", resourceName),
+						},
+						"source_ranges": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Description: descf(
+								"The range of source IP addresses that allow to access to the %s via network",
+								resourceName,
+							),
+						},
+					},
+				},
 			},
 			"icon_id":     schemaResourceIconID(resourceName),
 			"description": schemaResourceDescription(resourceName),
@@ -224,13 +235,7 @@ func setDatabaseReadReplicaResourceData(ctx context.Context, d *schema.ResourceD
 
 	d.Set("master_id", data.ReplicationSetting.ApplianceID.String()) // nolint
 	d.Set("name", data.Name)                                         // nolint
-	d.Set("switch_id", data.SwitchID.String())                       // nolint
-	d.Set("netmask", data.NetworkMaskLen)                            // nolint
-	d.Set("gateway", data.DefaultRoute)                              // nolint
-	if len(data.IPAddresses) > 0 {
-		d.Set("ip_address", data.IPAddresses[0]) // nolint
-	}
-	if err := d.Set("source_ranges", data.CommonSetting.SourceNetwork); err != nil {
+	if err := d.Set("network_interface", flattenDatabaseReadReplicaNetworkInterface(data)); err != nil {
 		return err
 	}
 	d.Set("icon_id", data.IconID.String()) // nolint

--- a/sakuracloud/resource_sakuracloud_database_read_replica_test.go
+++ b/sakuracloud/resource_sakuracloud_database_read_replica_test.go
@@ -48,9 +48,9 @@ func TestAccSakuraCloudDatabaseReplica_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.4151227546", "tag1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
-					resource.TestCheckResourceAttr(resourceName, "ip_address", "192.168.11.111"),
-					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
-					resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_address", "192.168.11.111"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.gateway", "192.168.11.1"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -65,9 +65,9 @@ func TestAccSakuraCloudDatabaseReplica_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.2362157161", "tag1-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.3412841145", "tag2-upd"),
-					resource.TestCheckResourceAttr(resourceName, "ip_address", "192.168.11.111"),
-					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
-					resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_address", "192.168.11.111"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.gateway", "192.168.11.1"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 				),
 			},
@@ -84,19 +84,19 @@ func TestAccImportSakuraCloudDatabaseReadReplica_basic(t *testing.T) {
 			return fmt.Errorf("expected 1 state: %#v", s)
 		}
 		expects := map[string]string{
-			"name":            rand,
-			"description":     "description",
-			"ip_address":      "192.168.11.111",
-			"netmask":         "24",
-			"gateway":         "192.168.11.1",
-			"tags.4151227546": "tag1",
-			"tags.1852302624": "tag2",
+			"name":                           rand,
+			"description":                    "description",
+			"network_interface.0.ip_address": "192.168.11.111",
+			"network_interface.0.netmask":    "24",
+			"network_interface.0.gateway":    "192.168.11.1",
+			"tags.4151227546":                "tag1",
+			"tags.1852302624":                "tag2",
 		}
 
 		if err := compareStateMulti(s[0], expects); err != nil {
 			return err
 		}
-		return stateNotEmptyMulti(s[0], "icon_id", "switch_id", "master_id")
+		return stateNotEmptyMulti(s[0], "icon_id", "network_interface.0.switch_id", "master_id")
 	}
 
 	resourceName := "sakuracloud_database_read_replica.foobar"
@@ -160,10 +160,12 @@ resource "sakuracloud_database" "foobar" {
 
   replica_password = "{{ .arg1 }}"
 
-  switch_id    = sakuracloud_switch.foobar.id
-  ip_address   = "192.168.11.101"
-  netmask      = 24
-  gateway      = "192.168.11.1"
+  network_interface{
+    switch_id    = sakuracloud_switch.foobar.id
+    ip_address   = "192.168.11.101"
+    netmask      = 24
+    gateway      = "192.168.11.1"
+  }
 
   name = "{{ .arg0 }}"
   icon_id = sakuracloud_icon.foobar.id
@@ -171,7 +173,9 @@ resource "sakuracloud_database" "foobar" {
 
 resource "sakuracloud_database_read_replica" "foobar" {
   master_id    = sakuracloud_database.foobar.id
-  ip_address   = "192.168.11.111"
+  network_interface {
+    ip_address   = "192.168.11.111"
+  }
   name         = "{{ .arg0 }}"
   description  = "description"
   tags         = ["tag1" , "tag2"]
@@ -198,17 +202,21 @@ resource "sakuracloud_database" "foobar" {
 
   replica_password = "{{ .arg1 }}"
 
-  switch_id    = sakuracloud_switch.foobar.id
-  ip_address   = "192.168.11.101"
-  netmask      = 24
-  gateway      = "192.168.11.1"
+  network_interface {
+    switch_id    = sakuracloud_switch.foobar.id
+    ip_address   = "192.168.11.101"
+    netmask      = 24
+    gateway      = "192.168.11.1"
+  }
 
   name = "{{ .arg0 }}"
 }
 
 resource "sakuracloud_database_read_replica" "foobar" {
   master_id    = sakuracloud_database.foobar.id
-  ip_address   = "192.168.11.111"
+  network_interface {
+    ip_address   = "192.168.11.111"
+  }
   name         = "{{ .arg0 }}-upd"
   description  = "description-upd"
   tags         = ["tag1-upd" , "tag2-upd"]

--- a/sakuracloud/resource_sakuracloud_database_test.go
+++ b/sakuracloud/resource_sakuracloud_database_test.go
@@ -56,16 +56,17 @@ func TestAccSakuraCloudDatabase_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "username", "defuser"),
 					resource.TestCheckResourceAttr(resourceName, "password", password),
 					resource.TestCheckResourceAttr(resourceName, "replica_password", password),
-					resource.TestCheckResourceAttr(resourceName, "source_ranges.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "source_ranges.0", "192.168.11.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "source_ranges.1", "192.168.12.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "port", "33061"),
-					resource.TestCheckResourceAttr(resourceName, "backup_time", "00:00"),
-					resource.TestCheckResourceAttr(resourceName, "backup_weekdays.0", "mon"),
-					resource.TestCheckResourceAttr(resourceName, "backup_weekdays.1", "tue"),
-					resource.TestCheckResourceAttr(resourceName, "ip_address", "192.168.11.101"),
-					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
-					resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_address", "192.168.11.101"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.port", "33061"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.source_ranges.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.source_ranges.0", "192.168.11.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.source_ranges.1", "192.168.12.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "backup.0.time", "00:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup.0.weekdays.0", "mon"),
+					resource.TestCheckResourceAttr(resourceName, "backup.0.weekdays.1", "tue"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -86,16 +87,16 @@ func TestAccSakuraCloudDatabase_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.3412841145", "tag2-upd"),
 					resource.TestCheckResourceAttr(resourceName, "username", "defuser"),
 					resource.TestCheckResourceAttr(resourceName, "password", password+"-upd"),
-					resource.TestCheckResourceAttr(resourceName, "source_ranges.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "source_ranges.0", "192.168.110.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "source_ranges.1", "192.168.120.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "port", "33062"),
-					resource.TestCheckResourceAttr(resourceName, "backup_time", "00:30"),
-					resource.TestCheckResourceAttr(resourceName, "backup_weekdays.0", "sun"),
-					resource.TestCheckResourceAttr(resourceName, "backup_weekdays.1", "sat"),
-					resource.TestCheckResourceAttr(resourceName, "ip_address", "192.168.11.101"),
-					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
-					resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_address", "192.168.11.101"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.port", "33062"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.source_ranges.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.source_ranges.0", "192.168.110.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.source_ranges.1", "192.168.120.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "backup.0.time", "00:30"),
+					resource.TestCheckResourceAttr(resourceName, "backup.0.weekdays.0", "sun"),
+					resource.TestCheckResourceAttr(resourceName, "backup.0.weekdays.1", "sat"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 				),
 			},
@@ -181,30 +182,30 @@ func TestAccImportSakuraCloudDatabase_basic(t *testing.T) {
 			return fmt.Errorf("expected 1 state: %#v", s)
 		}
 		expects := map[string]string{
-			"name":              name,
-			"database_type":     "mariadb",
-			"description":       "description",
-			"plan":              "30g",
-			"username":          "defuser",
-			"password":          password,
-			"replica_password":  password,
-			"source_ranges.0":   "192.168.11.0/24",
-			"source_ranges.1":   "192.168.12.0/24",
-			"port":              "33061",
-			"backup_time":       "00:00",
-			"backup_weekdays.0": "mon",
-			"backup_weekdays.1": "tue",
-			"ip_address":        "192.168.11.101",
-			"netmask":           "24",
-			"gateway":           "192.168.11.1",
-			"tags.4151227546":   "tag1",
-			"tags.1852302624":   "tag2",
+			"name":                                name,
+			"database_type":                       "mariadb",
+			"description":                         "description",
+			"plan":                                "30g",
+			"username":                            "defuser",
+			"password":                            password,
+			"replica_password":                    password,
+			"network_interface.0.ip_address":      "192.168.11.101",
+			"network_interface.0.netmask":         "24",
+			"network_interface.0.gateway":         "192.168.11.1",
+			"network_interface.0.source_ranges.0": "192.168.11.0/24",
+			"network_interface.0.source_ranges.1": "192.168.12.0/24",
+			"network_interface.0.port":            "33061",
+			"backup.0.time":                       "00:00",
+			"backup.0.weekdays.0":                 "mon",
+			"backup.0.weekdays.1":                 "tue",
+			"tags.4151227546":                     "tag1",
+			"tags.1852302624":                     "tag2",
 		}
 
 		if err := compareStateMulti(s[0], expects); err != nil {
 			return err
 		}
-		return stateNotEmptyMulti(s[0], "icon_id", "switch_id")
+		return stateNotEmptyMulti(s[0], "icon_id", "network_interface.0.switch_id")
 	}
 
 	resourceName := "sakuracloud_database.foobar"
@@ -245,17 +246,19 @@ resource "sakuracloud_database" "foobar" {
 
   replica_password = "{{ .arg1 }}"
 
-  source_ranges = ["192.168.11.0/24", "192.168.12.0/24"]
+  network_interface {
+    switch_id     = sakuracloud_switch.foobar.id
+    ip_address    = "192.168.11.101"
+    netmask       = 24
+    gateway       = "192.168.11.1"
+    port          = 33061
+    source_ranges = ["192.168.11.0/24", "192.168.12.0/24"]
+  }
 
-  port = 33061
-
-  backup_time     = "00:00"
-  backup_weekdays = ["mon", "tue"]
-
-  switch_id    = sakuracloud_switch.foobar.id
-  ip_address   = "192.168.11.101"
-  netmask      = 24
-  gateway      = "192.168.11.1"
+  backup {
+    time     = "00:00"
+    weekdays = ["mon", "tue"]
+  }
 
   name        = "{{ .arg0 }}"
   description = "description"
@@ -280,19 +283,21 @@ resource "sakuracloud_database" "foobar" {
   username = "defuser"
   password = "{{ .arg1 }}-upd"
 
-  source_ranges = ["192.168.110.0/24", "192.168.120.0/24"]
-
-  port = 33062
-
-  backup_time     = "00:30"
-  backup_weekdays = ["sun", "sat"]
+  network_interface {
+    switch_id     = sakuracloud_switch.foobar.id
+    ip_address    = "192.168.11.101"
+    netmask       = 24
+    gateway       = "192.168.11.1"
+    port          = 33062
+    source_ranges = ["192.168.110.0/24", "192.168.120.0/24"]
+  }
+  
+  backup {
+    time     = "00:30"
+    weekdays = ["sun", "sat"]
+  }
 
   name        = "{{ .arg0 }}-upd"
   description = "description-upd"
   tags        = ["tag1-upd", "tag2-upd"]
-
-  switch_id    = sakuracloud_switch.foobar.id
-  ip_address   = "192.168.11.101"
-  netmask      = 24
-  gateway      = "192.168.11.1"
 }`

--- a/sakuracloud/resource_sakuracloud_load_balancer_test.go
+++ b/sakuracloud/resource_sakuracloud_load_balancer_test.go
@@ -49,11 +49,11 @@ func TestAccSakuraCloudLoadBalancer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.4151227546", "tag1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
-					resource.TestCheckResourceAttr(resourceName, "vrid", "1"),
-					resource.TestCheckResourceAttr(resourceName, "ip_addresses.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "ip_addresses.0", "192.168.11.101"),
-					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
-					resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.vrid", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_addresses.0", "192.168.11.101"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.gateway", "192.168.11.1"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.vip", "192.168.11.201"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.delay_loop", "10"),
@@ -85,11 +85,11 @@ func TestAccSakuraCloudLoadBalancer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.2362157161", "tag1-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.3412841145", "tag2-upd"),
-					resource.TestCheckResourceAttr(resourceName, "vrid", "1"),
-					resource.TestCheckResourceAttr(resourceName, "ip_addresses.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "ip_addresses.0", "192.168.11.101"),
-					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
-					resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.vrid", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_addresses.0", "192.168.11.101"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.gateway", "192.168.11.1"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.vip", "192.168.11.201"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.port", "8080"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.delay_loop", "10"),
@@ -197,23 +197,22 @@ func TestAccImportSakuraCloudLoadBalancer_basic(t *testing.T) {
 			return fmt.Errorf("expected 1 state: %#v", s)
 		}
 		expects := map[string]string{
-			"name":              rand,
-			"vrid":              "1",
-			"high_availability": "false",
-			"plan":              "standard",
-			"ip_addresses.0":    "192.168.11.101",
-			"netmask":           "24",
-			"gateway":           "192.168.11.1",
-			"description":       "description",
-			"tags.4151227546":   "tag1",
-			"tags.1852302624":   "tag2",
-			"zone":              os.Getenv("SAKURACLOUD_ZONE"),
+			"name":                               rand,
+			"plan":                               "standard",
+			"network_interface.0.vrid":           "1",
+			"network_interface.0.ip_addresses.0": "192.168.11.101",
+			"network_interface.0.netmask":        "24",
+			"network_interface.0.gateway":        "192.168.11.1",
+			"description":                        "description",
+			"tags.4151227546":                    "tag1",
+			"tags.1852302624":                    "tag2",
+			"zone":                               os.Getenv("SAKURACLOUD_ZONE"),
 		}
 
 		if err := compareStateMulti(s[0], expects); err != nil {
 			return err
 		}
-		return stateNotEmptyMulti(s[0], "switch_id", "icon_id")
+		return stateNotEmptyMulti(s[0], "network_interface.0.switch_id", "icon_id")
 	}
 
 	resourceName := "sakuracloud_load_balancer.foobar"
@@ -241,11 +240,13 @@ resource "sakuracloud_switch" "foobar" {
   name = "{{ .arg0 }}"
 }
 resource "sakuracloud_load_balancer" "foobar" {
-  switch_id    = sakuracloud_switch.foobar.id
-  vrid         = 1
-  ip_addresses = ["192.168.11.101"]
-  netmask      = 24
-  gateway      = "192.168.11.1"
+  network_interface {
+    switch_id    = sakuracloud_switch.foobar.id
+    vrid         = 1
+    ip_addresses = ["192.168.11.101"]
+    netmask      = 24
+    gateway      = "192.168.11.1"
+  }
 
   name        = "{{ .arg0 }}"
   description = "description"
@@ -290,11 +291,13 @@ resource "sakuracloud_switch" "foobar" {
   name = "{{ .arg0 }}"
 }
 resource "sakuracloud_load_balancer" "foobar" {
-  switch_id    = sakuracloud_switch.foobar.id
-  vrid         = 1
-  ip_addresses = ["192.168.11.101"]
-  netmask      = 24
-  gateway      = "192.168.11.1"
+  network_interface {
+    switch_id    = sakuracloud_switch.foobar.id
+    vrid         = 1
+    ip_addresses = ["192.168.11.101"]
+    netmask      = 24
+    gateway      = "192.168.11.1"
+  }
 
   name        = "{{ .arg0 }}-upd"
   description = "description-upd"
@@ -329,14 +332,14 @@ resource "sakuracloud_internet" "foobar" {
 }
 
 resource "sakuracloud_load_balancer" "foobar" {
-  switch_id         = sakuracloud_internet.foobar.switch_id
-  plan              = "highspec"
-  high_availability = true
-
-  vrid         = 1
-  ip_addresses = [sakuracloud_internet.foobar.ip_addresses[0], sakuracloud_internet.foobar.ip_addresses[1]]
-  netmask      = sakuracloud_internet.foobar.netmask
-  gateway      = sakuracloud_internet.foobar.gateway
+  plan = "highspec"
+  network_interface {
+    switch_id    = sakuracloud_internet.foobar.switch_id
+    vrid         = 1
+    ip_addresses = [sakuracloud_internet.foobar.ip_addresses[0], sakuracloud_internet.foobar.ip_addresses[1]]
+    netmask      = sakuracloud_internet.foobar.netmask
+    gateway      = sakuracloud_internet.foobar.gateway
+  }
 
   name        = "{{ .arg0 }}"
   description = "description"

--- a/sakuracloud/resource_sakuracloud_nfs_test.go
+++ b/sakuracloud/resource_sakuracloud_nfs_test.go
@@ -50,9 +50,9 @@ func TestAccSakuraCloudNFS_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.4151227546", "tag1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
-					resource.TestCheckResourceAttr(resourceName, "ip_address", "192.168.11.101"),
-					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
-					resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_address", "192.168.11.101"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.gateway", "192.168.11.1"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -70,9 +70,9 @@ func TestAccSakuraCloudNFS_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.2362157161", "tag1-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.3412841145", "tag2-upd"),
-					resource.TestCheckResourceAttr(resourceName, "ip_address", "192.168.11.101"),
-					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
-					resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_address", "192.168.11.101"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.gateway", "192.168.11.1"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 				),
 			},
@@ -137,13 +137,17 @@ resource "sakuracloud_switch" "foobar" {
   name = "{{ .arg0 }}"
 }
 resource "sakuracloud_nfs" "foobar" {
-  switch_id   = sakuracloud_switch.foobar.id
-  plan        = "ssd"
-  size        = "500"
-  ip_address  = "192.168.11.101"
-  netmask     = 24
-  gateway     = "192.168.11.1"
-  name        = "{{ .arg0 }}"
+  name = "{{ .arg0 }}"
+  plan = "ssd"
+  size = "500"
+
+  network_interface {
+    switch_id   = sakuracloud_switch.foobar.id
+    ip_address  = "192.168.11.101"
+    netmask     = 24
+    gateway     = "192.168.11.1"
+  }
+
   description = "description"
   tags        = ["tag1" , "tag2"]
   icon_id     = sakuracloud_icon.foobar.id
@@ -160,13 +164,17 @@ resource "sakuracloud_switch" "foobar" {
   name = "{{ .arg0 }}"
 }
 resource "sakuracloud_nfs" "foobar" {
-  switch_id   = sakuracloud_switch.foobar.id
-  plan        = "ssd"
-  size        = "500"
-  ip_address  = "192.168.11.101"
-  netmask     = 24
-  gateway     = "192.168.11.1"
-  name        = "{{ .arg0 }}-upd"
+  name = "{{ .arg0 }}-upd"
+  plan = "ssd"
+  size = "500"
+
+  network_interface {
+    switch_id   = sakuracloud_switch.foobar.id
+    ip_address  = "192.168.11.101"
+    netmask     = 24
+    gateway     = "192.168.11.1"
+  }
+
   description = "description-upd"
   tags        = ["tag1-upd" , "tag2-upd"]
 }`

--- a/sakuracloud/resource_sakuracloud_vpc_router_test.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_test.go
@@ -49,9 +49,7 @@ func TestAccSakuraCloudVPCRouter_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
 					resource.TestCheckResourceAttr(resourceName, "plan", "standard"),
 					resource.TestCheckResourceAttr(resourceName, "internet_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "switch_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "vip", ""),
-					resource.TestCheckResourceAttr(resourceName, "ip_addresses.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "public_network_interface"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -69,9 +67,7 @@ func TestAccSakuraCloudVPCRouter_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.3412841145", "tag2-upd"),
 					resource.TestCheckResourceAttr(resourceName, "plan", "standard"),
 					resource.TestCheckResourceAttr(resourceName, "internet_connection", "false"),
-					resource.TestCheckResourceAttr(resourceName, "switch_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "vip", ""),
-					resource.TestCheckResourceAttr(resourceName, "ip_addresses.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "public_network_interface"),
 					resource.TestCheckResourceAttr(resourceName, "syslog_host", "192.168.0.2"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 				),
@@ -99,12 +95,12 @@ func TestAccSakuraCloudVPCRouter_Full(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudVPCRouterExists(resourceName, &vpcRouter),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
-					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "network_interface.0.vip", "192.168.11.1"),
-					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_addresses.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_addresses.0", "192.168.11.2"),
-					resource.TestCheckResourceAttr(resourceName, "network_interface.0.ip_addresses.1", "192.168.11.3"),
-					resource.TestCheckResourceAttr(resourceName, "network_interface.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.0.vip", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.0.ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.0.ip_addresses.0", "192.168.11.2"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.0.ip_addresses.1", "192.168.11.3"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.0.netmask", "24"),
 					resource.TestCheckResourceAttr(resourceName, "dhcp_server.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "dhcp_server.0.interface_index", "1"),
 					resource.TestCheckResourceAttr(resourceName, "dhcp_server.0.range_start", "192.168.11.11"),
@@ -171,7 +167,7 @@ func TestAccSakuraCloudVPCRouter_Full(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudVPCRouterExists(resourceName, &vpcRouter),
 					resource.TestCheckResourceAttr(resourceName, "name", rand+"-upd"),
-					resource.TestCheckNoResourceAttr(resourceName, "network_interface"),
+					resource.TestCheckNoResourceAttr(resourceName, "private_network_interface"),
 					resource.TestCheckNoResourceAttr(resourceName, "dhcp_server"),
 					resource.TestCheckNoResourceAttr(resourceName, "dhcp_static_mapping"),
 					resource.TestCheckNoResourceAttr(resourceName, "firewall"),
@@ -280,13 +276,15 @@ resource "sakuracloud_vpc_router" "foobar" {
 
   internet_connection = true
 
-  switch_id    = sakuracloud_internet.foobar.switch_id
-  vip          = sakuracloud_internet.foobar.ip_addresses[0]
-  ip_addresses = [sakuracloud_internet.foobar.ip_addresses[1], sakuracloud_internet.foobar.ip_addresses[2]]
-  aliases      = [sakuracloud_internet.foobar.ip_addresses[3]]
-  vrid         = 1
+  public_network_interface {
+    switch_id    = sakuracloud_internet.foobar.switch_id
+    vip          = sakuracloud_internet.foobar.ip_addresses[0]
+    ip_addresses = [sakuracloud_internet.foobar.ip_addresses[1], sakuracloud_internet.foobar.ip_addresses[2]]
+    aliases      = [sakuracloud_internet.foobar.ip_addresses[3]]
+    vrid         = 1
+  }
 
-  network_interface {
+  private_network_interface {
     index        = 1
     switch_id    = sakuracloud_switch.foobar.id
     vip          = "192.168.11.1"
@@ -394,10 +392,12 @@ resource "sakuracloud_vpc_router" "foobar" {
 
   internet_connection = true
 
-  switch_id    = sakuracloud_internet.foobar.switch_id
-  vip          = sakuracloud_internet.foobar.ip_addresses[0]
-  ip_addresses = [sakuracloud_internet.foobar.ip_addresses[1], sakuracloud_internet.foobar.ip_addresses[2]]
-  aliases      = [sakuracloud_internet.foobar.ip_addresses[3]]
-  vrid         = 1
+  public_network_interface {
+    switch_id    = sakuracloud_internet.foobar.switch_id
+    vip          = sakuracloud_internet.foobar.ip_addresses[0]
+    ip_addresses = [sakuracloud_internet.foobar.ip_addresses[1], sakuracloud_internet.foobar.ip_addresses[2]]
+    aliases      = [sakuracloud_internet.foobar.ip_addresses[3]]
+    vrid         = 1
+  }
 }
 `

--- a/sakuracloud/structure.go
+++ b/sakuracloud/structure.go
@@ -104,6 +104,16 @@ func getListFromResource(d resourceValueGettable, key string) ([]interface{}, bo
 	return nil, false
 }
 
+func mapFromFirstElement(d resourceValueGettable, key string) resourceValueGettable {
+	list, ok := getListFromResource(d, key)
+	if ok && len(list) > 0 {
+		if m, ok := list[0].(map[string]interface{}); ok {
+			return mapToResourceData(m)
+		}
+	}
+	return nil
+}
+
 func sakuraCloudClient(d resourceValueGettable, meta interface{}) (*APIClient, string, error) {
 	client := meta.(*APIClient)
 	zone := getZone(d, client)

--- a/website/docs/d/database.md
+++ b/website/docs/d/database.md
@@ -44,24 +44,36 @@ A `condition` block supports the following:
 ## Attribute Reference
 
 * `id` - The id of the Database.
-* `backup_time` - The time to take backup. This will be formatted with `HH:mm`.
-* `backup_weekdays` - The list of name of weekday that doing backup. This will be in [`sun`/`mon`/`tue`/`wed`/`thu`/`fri`/`sat`].
+* `backup` - A list of `backup` blocks as defined below.
 * `database_type` - The type of the database. This will be one of [`mariadb`/`postgres`].
 * `description` - The description of the Database.
-* `gateway` - The IP address of the gateway used by Database.
 * `icon_id` - The icon id attached to the Database.
-* `ip_address` - The IP address assigned to the Database.
 * `name` - The name of the Database.
-* `netmask` - The bit length of the subnet assigned to the Database.
+* `network_interface` - A list of `network_interface` blocks as defined below.
 * `password` - The password of default user on the database.
 * `plan` - The plan name of the Database. This will be one of [`10g`/`30g`/`90g`/`240g`/`500g`/`1t`].
 * `port` - The number of the listening port.
 * `replica_password` - The password of user that processing a replication.
 * `replica_user` - The name of user that processing a replication.
-* `source_ranges` - The range of source IP addresses that allow to access to the Database via network.
-* `switch_id` - The id of the switch connected from the Database.
 * `tags` - Any tags assigned to the Database.
 * `username` - The name of default user on the database.
 
+---
+
+A `backup` block exports the following:
+
+* `time` - The time to take backup. This will be formatted with `HH:mm`.
+* `weekdays` - The list of name of weekday that doing backup. This will be in [`sun`/`mon`/`tue`/`wed`/`thu`/`fri`/`sat`].
+
+---
+
+A `network_interface` block exports the following:
+
+* `gateway` - The IP address of the gateway used by Database.
+* `ip_address` - The IP address assigned to the Database.
+* `netmask` - The bit length of the subnet assigned to the Database.
+* `port` - The number of the listening port.
+* `source_ranges` - The range of source IP addresses that allow to access to the Database via network.
+* `switch_id` - The id of the switch connected from the Database.
 
 

--- a/website/docs/d/load_balancer.md
+++ b/website/docs/d/load_balancer.md
@@ -45,18 +45,22 @@ A `condition` block supports the following:
 
 * `id` - The id of the Load Balancer.
 * `description` - The description of the LoadBalancer.
-* `gateway` - The IP address of the gateway used by LoadBalancer.
-* `high_availability` - The flag to enable HA mode.
+* `network_interface` - A list of `network_interface` blocks as defined below.
 * `icon_id` - The icon id attached to the LoadBalancer.
-* `ip_addresses` - The list of IP address assigned to the LoadBalancer.
 * `name` - The name of the LoadBalancer.
-* `netmask` - The bit length of the subnet assigned to the LoadBalancer.
 * `plan` - The plan name of the LoadBalancer. This will be one of [`standard`/`highspec`].
-* `switch_id` - The id of the switch connected from the LoadBalancer.
 * `tags` - Any tags assigned to the LoadBalancer.
 * `vip` - A list of `vip` blocks as defined below.
-* `vrid` - The Virtual Router Identifier. This is only used when `high_availability` is set `true`.
 
+---
+
+A `network_interface` block exports the following:
+
+* `gateway` - The IP address of the gateway used by LoadBalancer.
+* `ip_addresses` - The list of IP address assigned to the LoadBalancer.
+* `netmask` - The bit length of the subnet assigned to the LoadBalancer.
+* `switch_id` - The id of the switch connected from the LoadBalancer.
+* `vrid` - The Virtual Router Identifier.
 
 ---
 

--- a/website/docs/d/nfs.md
+++ b/website/docs/d/nfs.md
@@ -45,15 +45,21 @@ A `condition` block supports the following:
 
 * `id` - The id of the NFS.
 * `description` - The description of the NFS.
-* `gateway` - The IP address of the gateway used by NFS.
 * `icon_id` - The icon id attached to the NFS.
-* `ip_address` - The IP address assigned to the NFS.
+* `network_interface` - A list of `network_interface` blocks as defined below.
 * `name` - The name of the NFS.
-* `netmask` - The bit length of the subnet assigned to the NFS.
 * `plan` - The plan name of the NFS. This will be one of [`hdd`/`ssd`].
 * `size` - The size of NFS in GiB.
-* `switch_id` - The id of the switch connected from the NFS.
 * `tags` - Any tags assigned to the NFS.
+
+---
+
+A `network_interface` block exports the following:
+
+* `gateway` - The IP address of the gateway used by NFS.
+* `ip_address` - The IP address assigned to the NFS.
+* `netmask` - The bit length of the subnet assigned to the NFS.
+* `switch_id` - The id of the switch connected from the NFS.
 
 
 

--- a/website/docs/d/vpc_router.md
+++ b/website/docs/d/vpc_router.md
@@ -44,31 +44,27 @@ A `condition` block supports the following:
 ## Attribute Reference
 
 * `id` - The id of the VPC Router.
-* `aliases` - A list of ip alias assigned to the VPC Router. This is only used when `plan` is not `standard`.
 * `description` - The description of the VPCRouter.
 * `dhcp_server` - A list of `dhcp_server` blocks as defined below.
 * `dhcp_static_mapping` - A list of `dhcp_static_mapping` blocks as defined below.
 * `firewall` - A list of `firewall` blocks as defined below.
 * `icon_id` - The icon id attached to the VPCRouter.
 * `internet_connection` - The flag to enable connecting to the Internet from the VPC Router.
-* `ip_addresses` - The list of the IP address assigned to the VPC Router. This will be only one value when `plan` is `standard`, two values otherwise.
 * `l2tp` - A list of `l2tp` blocks as defined below.
 * `name` - The id of the switch connected from the VPCRouter.
-* `network_interface` - A list of additional network interface setting. This doesn't include primary network interface setting.
 * `plan` - The plan name of the VPCRouter. This will be one of [`standard`/`premium`/`highspec`/`highspec4000`].
 * `port_forwarding` - A list of `port_forwarding` blocks as defined below. This represents a `Reverse NAT`.
 * `pptp` - A list of `pptp` blocks as defined below.
+* `private_network_interface` - A list of additional network interface setting. This doesn't include primary network interface setting.
 * `public_ip` - The public ip address of the VPC Router.
+* `public_netmask` - The bit length of the subnet to assign to the public network interface.
+* `public_network_interface` - A list of additional network interface setting. This doesn't include primary network interface setting.
 * `site_to_site_vpn` - A list of `site_to_site_vpn` blocks as defined below.
 * `static_nat` - A list of `static_nat` blocks as defined below. This represents a `1:1 NAT`, doing static mapping to both send/receive to/from the Internet. This is only used when `plan` is not `standard`.
 * `static_route` - A list of `static_route` blocks as defined below.
-* `switch_id` - The id of the switch connected from the VPCRouter.
 * `syslog_host` - The ip address of the syslog host to which the VPC Router sends logs.
 * `tags` - Any tags assigned to the VPCRouter.
 * `user` - A list of `user` blocks as defined below.
-* `vip` - The virtual IP address of the VPC Router. This is only used when `plan` is not `standard`.
-* `vrid` - The Virtual Router Identifier. This is only used when `plan` is not `standard`.
-
 
 ---
 
@@ -117,16 +113,6 @@ A `l2tp` block exports the following:
 
 ---
 
-A `network_interface` block exports the following:
-
-* `index` - The index of the network interface. This will be between `1`-`7`.
-* `ip_addresses` - A list of ip address assigned to the network interface. This will be only one value when `plan` is `standard`, two values otherwise.
-* `netmask` - The bit length of the subnet assigned to the network interface.
-* `switch_id` - The id of the connected switch.
-* `vip` - The virtual IP address assigned to the network interface. This is only used when `plan` is not `standard`.
-
----
-
 A `port_forwarding` block exports the following:
 
 * `description` - The description of the port forwarding.
@@ -141,6 +127,26 @@ A `pptp` block exports the following:
 
 * `range_start` - The start value of IP address range to assign to PPTP client.
 * `range_stop` - The end value of IP address range to assign to PPTP client.
+
+---
+
+A `private_network_interface` block exports the following:
+
+* `index` - The index of the network interface. This will be between `1`-`7`.
+* `ip_addresses` - A list of ip address assigned to the network interface. This will be only one value when `plan` is `standard`, two values otherwise.
+* `netmask` - The bit length of the subnet assigned to the network interface.
+* `switch_id` - The id of the connected switch.
+* `vip` - The virtual IP address assigned to the network interface. This is only used when `plan` is not `standard`.
+
+---
+
+A `public_network_interface` block exports the following:
+
+* `aliases` - A list of ip alias assigned to the VPC Router. This is only used when `plan` is not `standard`.
+* `ip_addresses` - The list of the IP address assigned to the VPC Router. This will be only one value when `plan` is `standard`, two values otherwise.
+* `switch_id` - The id of the switch connected from the VPCRouter.
+* `vip` - The virtual IP address of the VPC Router. This is only used when `plan` is not `standard`.
+* `vrid` - The Virtual Router Identifier. This is only used when `plan` is not `standard`.
 
 ---
 

--- a/website/docs/r/database.md
+++ b/website/docs/r/database.md
@@ -25,17 +25,19 @@ resource "sakuracloud_database" "foobar" {
 
   replica_password = var.replica_password
 
-  source_ranges = ["192.168.11.0/24", "192.168.12.0/24"]
+  network_interface {
+    switch_id     = sakuracloud_switch.foobar.id
+    ip_address    = "192.168.11.11"
+    netmask       = 24
+    gateway       = "192.168.11.1"
+    port          = 3306
+    source_ranges = ["192.168.11.0/24", "192.168.12.0/24"]
+  }
 
-  port = 3306
-
-  backup_time     = "00:00"
-  backup_weekdays = ["mon", "tue"]
-
-  switch_id    = sakuracloud_switch.foobar.id
-  ip_address   = "192.168.11.11"
-  netmask      = 24
-  gateway      = "192.168.11.1"
+  backup {
+    time     = "00:00"
+    weekdays = ["mon", "tue"]
+  }
 
   name        = "foobar"
   description = "description"
@@ -59,17 +61,31 @@ resource "sakuracloud_switch" "foobar" {
 * `password` - (Required) The password of default user on the database.
 
 #### Network
-* `switch_id` - (Required) The id of the switch to which the Database connects. Changing this forces a new resource to be created.
-* `gateway` - (Required) The IP address of the gateway used by Database. Changing this forces a new resource to be created.
-* `ip_address` - (Required) The IP address to assign to the Database. Changing this forces a new resource to be created.
-* `netmask` - (Required) The bit length of the subnet to assign to the Database. This must be in the range [`8`-`29`]. Changing this forces a new resource to be created.
-* `port` - (Optional) The number of the listening port. This must be in the range [`1024`-`65535`]. Default:`5432`.
+
+* `network_interface` - (Required) An `network_interface` block as defined below.
+
+---
+
+A `network_interface` block supports the following:
+
+* `gateway` - (Required) The IP address of the gateway used by Database.
+* `ip_address` - (Required) The IP address to assign to the Database.
+* `netmask` - (Required) The bit length of the subnet to assign to the Database. This must be in the range [`8`-`29`].
+* `switch_id` - (Required) The id of the switch to which the Database connects.
+* `port` - (Optional) The number of the listening port. This must be in the range [`1024`-`65535`].
 * `source_ranges` - (Optional) The range of source IP addresses that allow to access to the Database via network.
 
 #### Backup
 
-* `backup_time` - (Optional) The time to take backup. This must be formatted with `HH:mm`.
-* `backup_weekdays` - (Optional) A list of weekdays to backed up. The values in the list must be in [`sun`/`mon`/`tue`/`wed`/`thu`/`fri`/`sat`].
+* `backup` - (Optional) A `backup` block as defined below.
+
+---
+
+A `backup` block supports the following:
+
+* `time` - (Optional) The time to take backup. This must be formatted with `HH:mm`.
+* `weekdays` - (Optional) A list of weekdays to backed up. The values in the list must be in [`sun`/`mon`/`tue`/`wed`/`thu`/`fri`/`sat`].
+
 
 #### Replication
 

--- a/website/docs/r/database_read_replica.md
+++ b/website/docs/r/database_read_replica.md
@@ -15,7 +15,9 @@ Manages a SakuraCloud Database Read Replica.
 ```hcl
 resource "sakuracloud_database_read_replica" "foobar" {
   master_id    = data.sakuracloud_database.master.id
-  ip_address   = "192.168.11.111"
+  network_interface {
+    ip_address   = "192.168.11.111"
+  }
   name         = "foobar"
   description  = "description"
   tags         = ["tag1", "tag2"]
@@ -35,11 +37,18 @@ data sakuracloud_database "master" {
 
 #### Network
 
-* `ip_address` - (Required) The IP address to assign to the read-replica database. Changing this forces a new resource to be created.
-* `gateway` - (Optional) The IP address of the gateway used by read-replica database. If `gateway` isn't specified, it will be set to the same value of the master database. Changing this forces a new resource to be created.
-* `netmask` - (Optional) The bit length of the subnet to assign to the read-replica database. This must be in the range [`8`-`29`]. If `netmask` isn't specified, it will be set to the same value of the master database. Changing this forces a new resource to be created.
-* `switch_id` - (Optional) The id of the switch to which the read-replica database connects. If `switch_id` isn't specified, it will be set to the same value of the master database. Changing this forces a new resource to be created.
+* `network_interface` - (Required) An `network_interface` block as defined below.
+
+---
+
+A `network_interface` block supports the following:
+
+* `ip_address` - (Required) The IP address to assign to the read-replica database.
+* `gateway` - (Optional) The IP address of the gateway used by read-replica database. If `gateway` isn't specified, it will be set to the same value of the master database.
+* `netmask` - (Optional) The bit length of the subnet to assign to the read-replica database. This must be in the range [`8`-`29`]. If `netmask` isn't specified, it will be set to the same value of the master database.
 * `source_ranges` - (Optional) The range of source IP addresses that allow to access to the read-replica database via network.
+* `switch_id` - (Optional) The id of the switch to which the read-replica database connects. If `switch_id` isn't specified, it will be set to the same value of the master database.
+
 
 #### Common Arguments
 

--- a/website/docs/r/load_balancer.md
+++ b/website/docs/r/load_balancer.md
@@ -14,12 +14,16 @@ Manages a SakuraCloud Load Balancer.
 
 ```hcl
 resource "sakuracloud_load_balancer" "foobar" {
-  name         = "foobar"
-  switch_id    = sakuracloud_switch.foobar.id
-  vrid         = 1
-  ip_addresses = ["192.168.11.101"]
-  netmask      = 24
-  gateway      = "192.168.11.1"
+  name = "foobar"
+  plan = "standard"
+
+  network_interface {
+    switch_id    = sakuracloud_switch.foobar.id
+    vrid         = 1
+    ip_addresses = ["192.168.11.101"]
+    netmask      = 24
+    gateway      = "192.168.11.1"
+  }
 
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -54,24 +58,22 @@ resource "sakuracloud_switch" "foobar" {
 ## Argument Reference
 
 * `name` - (Required) The name of the LoadBalancer. The length of this value must be in the range [`1`-`64`].
-* `vrid` - (Required) The Virtual Router Identifier. This is only used when `high_availability` is set `true`. Changing this forces a new resource to be created.
-* `high_availability` - (Optional) The flag to enable HA mode. Changing this forces a new resource to be created.
 * `plan` - (Optional) The plan name of the LoadBalancer. This must be one of [`standard`/`highspec`]. Changing this forces a new resource to be created. Default:`standard`.
-* `vip` - (Optional) One or more `vip` blocks as defined below.
 
 #### Network
 
-* `ip_addresses` - (Required) A list of IP address to assign to the LoadBalancer. . Changing this forces a new resource to be created.
-* `netmask` - (Required) The bit length of the subnet assigned to the LoadBalancer. This must be in the range [`8`-`29`]. Changing this forces a new resource to be created.
-* `gateway` - (Optional) The IP address of the gateway used by LoadBalancer. Changing this forces a new resource to be created.
-* `switch_id` - (Required) The id of the switch to which the LoadBalancer connects. Changing this forces a new resource to be created.
+* `network_interface` - (Required) An `network_interface` block as defined below.
+* `vip` - (Optional) One or more `vip` blocks as defined below.
 
-#### Common Arguments
+---
 
-* `description` - (Optional) The description of the LoadBalancer. The length of this value must be in the range [`1`-`512`].
-* `icon_id` - (Optional) The icon id to attach to the LoadBalancer.
-* `tags` - (Optional) Any tags to assign to the LoadBalancer.
-* `zone` - (Optional) The name of zone that the LoadBalancer will be created. (e.g. `is1a`, `tk1a`). Changing this forces a new resource to be created.
+A `network_interface` block supports the following:
+
+* `gateway` - (Optional) The IP address of the gateway used by LoadBalancer.
+* `ip_addresses` - (Required) A list of IP address to assign to the LoadBalancer. .
+* `netmask` - (Required) The bit length of the subnet assigned to the LoadBalancer. This must be in the range [`8`-`29`].
+* `switch_id` - (Required) The id of the switch to which the LoadBalancer connects.
+* `vrid` - (Required) The Virtual Router Identifier.
 
 ---
 
@@ -94,6 +96,13 @@ A `server` block supports the following:
 * `path` - (Optional) The path used when checking by HTTP/HTTPS.
 * `status` - (Optional) The response code to expect when checking by HTTP/HTTPS.
 
+
+#### Common Arguments
+
+* `description` - (Optional) The description of the LoadBalancer. The length of this value must be in the range [`1`-`512`].
+* `icon_id` - (Optional) The icon id to attach to the LoadBalancer.
+* `tags` - (Optional) Any tags to assign to the LoadBalancer.
+* `zone` - (Optional) The name of zone that the LoadBalancer will be created. (e.g. `is1a`, `tk1a`). Changing this forces a new resource to be created.
 
 ### Timeouts
 

--- a/website/docs/r/nfs.md
+++ b/website/docs/r/nfs.md
@@ -14,16 +14,20 @@ Manages a SakuraCloud NFS.
 
 ```hcl
 resource "sakuracloud_nfs" "foobar" {
-  name        = "foobar"
-  switch_id   = sakuracloud_switch.foobar.id
-  plan        = "ssd"
-  size        = "500"
-  ip_address  = "192.168.11.101"
-  netmask     = 24
-  gateway     = "192.168.11.1"
+  name = "foobar"
+  plan = "ssd"
+  size = "500"
+
+  network_interface {
+    switch_id   = sakuracloud_switch.foobar.id
+    ip_address  = "192.168.11.101"
+    netmask     = 24
+    gateway     = "192.168.11.1"
+  }
+
   description = "description"
   tags        = ["tag1", "tag2"]
-}
+}}
 
 resource "sakuracloud_switch" "foobar" {
   name = "foobar"
@@ -38,10 +42,16 @@ resource "sakuracloud_switch" "foobar" {
 
 #### Network
 
-* `switch_id` - (Required) The id of the switch to which the NFS connects. Changing this forces a new resource to be created.
-* `ip_address` - (Required) The IP address to assign to the NFS. Changing this forces a new resource to be created.
-* `netmask` - (Required) The bit length of the subnet to assign to the NFS. This must be in the range [`8`-`29`]. Changing this forces a new resource to be created.
-* `gateway` - (Optional) The IP address of the gateway used by NFS. Changing this forces a new resource to be created.
+* `network_interface` - (Required) An `network_interface` block as defined below.
+
+---
+
+A `network_interface` block supports the following:
+
+* `ip_address` - (Required) The IP address to assign to the NFS.
+* `netmask` - (Required) The bit length of the subnet to assign to the NFS. This must be in the range [`8`-`29`].
+* `switch_id` - (Required) The id of the switch to which the NFS connects.
+* `gateway` - (Optional) The IP address of the gateway used by NFS.
 
 #### Common Arguments
 

--- a/website/docs/r/vpc_router.md
+++ b/website/docs/r/vpc_router.md
@@ -28,13 +28,15 @@ resource "sakuracloud_vpc_router" "premium" {
 
   internet_connection = true
 
-  switch_id    = sakuracloud_internet.foobar.switch_id
-  vip          = sakuracloud_internet.foobar.ip_addresses[0]
-  ip_addresses = [sakuracloud_internet.foobar.ip_addresses[1], sakuracloud_internet.foobar.ip_addresses[2]]
-  aliases      = [sakuracloud_internet.foobar.ip_addresses[3]]
-  vrid         = 1
+  public_network_interface {
+    switch_id    = sakuracloud_internet.foobar.switch_id
+    vip          = sakuracloud_internet.foobar.ip_addresses[0]
+    ip_addresses = [sakuracloud_internet.foobar.ip_addresses[1], sakuracloud_internet.foobar.ip_addresses[2]]
+    aliases      = [sakuracloud_internet.foobar.ip_addresses[3]]
+    vrid         = 1
+  }
 
-  network_interface {
+  private_network_interface {
     index        = 1
     switch_id    = sakuracloud_switch.foobar.id
     vip          = "192.168.11.1"
@@ -141,64 +143,50 @@ resource sakuracloud_switch "foobar" {
 * `internet_connection` - (Optional) The flag to enable connecting to the Internet from the VPC Router. Default:`true`.
 * `plan` - (Optional) The plan name of the VPCRouter. This must be one of [`standard`/`premium`/`highspec`/`highspec4000`]. Changing this forces a new resource to be created. Default:`standard`.
 * `syslog_host` - (Optional) The ip address of the syslog host to which the VPC Router sends logs.
-* `vrid` - (Optional) The Virtual Router Identifier. This is only required when `plan` is not `standard`. Changing this forces a new resource to be created.
 
 #### Network
 
+* `public_network_interface` - (Optional) An `public_network_interface` block as defined below. This block is required when `plan` is not `standard`.
+* `private_network_interface` - (Optional) A list of additional network interface setting. This doesn't include primary network interface setting.
+
+---
+
+A `public_network_interface` block supports the following:
+
 * `aliases` - (Optional) A list of ip alias to assign to the VPC Router. This can only be specified if `plan` is not `standard`.
-* `ip_addresses` - (Optional) The list of the IP address to assign to the VPC Router. This is required only one value when `plan` is `standard`, two values otherwise. Changing this forces a new resource to be created.
-* `network_interface` - (Optional) A list of additional network interface setting. This doesn't include primary network interface setting.
-* `switch_id` - (Optional) The id of the switch to connect. This is only required when when `plan` is not `standard`. Changing this forces a new resource to be created.
-* `vip` - (Optional) The virtual IP address of the VPC Router. This is only required when `plan` is not `standard`. Changing this forces a new resource to be created.
+* `ip_addresses` - (Optional) The list of the IP address to assign to the VPC Router. This is required only one value when `plan` is `standard`, two values otherwise.
+* `switch_id` - (Optional) The id of the switch to connect. This is only required when when `plan` is not `standard`.
+* `vip` - (Optional) The virtual IP address of the VPC Router. This is only required when `plan` is not `standard`.
+* `vrid` - (Optional) The Virtual Router Identifier. This is only required when `plan` is not `standard`.
+
+---
+
+A `private_network_interface` block supports the following:
+
+* `index` - (Required) The index of the network interface. This must be in the range [`1`-`7`].
+* `ip_addresses` - (Required) A list of ip address to assign to the network interface. This is required only one value when `plan` is `standard`, two values otherwise.
+* `netmask` - (Required) The bit length of the subnet to assign to the network interface.
+* `switch_id` - (Required) The id of the connected switch.
+* `vip` - (Optional) The virtual IP address to assign to the network interface. This is only required when `plan` is not `standard`.
+
+---
 
 #### Static Route
 
 * `static_route` - (Optional) One or more `static_route` blocks as defined below.
 
+---
+
+A `static_route` block supports the following:
+
+* `next_hop` - (Required) The IP address of the next hop.
+* `prefix` - (Required) The CIDR block of destination.
+
+---
+
 #### Firewall
 
 * `firewall` - (Optional) One or more `firewall` blocks as defined below.
-
-#### Site to Site VPN
-
-* `site_to_site_vpn` - (Optional) One or more `site_to_site_vpn` blocks as defined below.
-
-#### DHCP/NAT/Forwarding
-
-* `dhcp_server` - (Optional) One or more `dhcp_server` blocks as defined below.
-* `dhcp_static_mapping` - (Optional) One or more `dhcp_static_mapping` blocks as defined below.
-* `port_forwarding` - (Optional) One or more `port_forwarding` blocks as defined below.
-* `static_nat` - (Optional) One or more `static_nat` blocks as defined below.
-
-#### Remote Access
-
-* `l2tp` - (Optional) A `l2tp` block as defined below.
-* `pptp` - (Optional) A `pptp` block as defined below.
-* `user` - (Optional) One or more `user` blocks as defined below.
-
-#### Common Arguments
-
-* `description` - (Optional) The description of the VPCRouter. The length of this value must be in the range [`1`-`512`].
-* `icon_id` - (Optional) The icon id to attach to the VPCRouter.
-* `tags` - (Optional) Any tags to assign to the VPCRouter.
-* `zone` - (Optional) The name of zone that the VPCRouter will be created. (e.g. `is1a`, `tk1a`). Changing this forces a new resource to be created.
-
-
----
-
-A `dhcp_server` block supports the following:
-
-* `interface_index` - (Required) The index of the network interface on which to enable the DHCP service. This must be in the range [`1`-`7`].
-* `range_start` - (Required) The start value of IP address range to assign to DHCP client.
-* `range_stop` - (Required) The end value of IP address range to assign to DHCP client.
-* `dns_servers` - (Optional) A list of IP address of DNS server to assign to DHCP client.
-
----
-
-A `dhcp_static_mapping` block supports the following:
-
-* `ip_address` - (Required) The static IP address to assign to DHCP client.
-* `mac_address` - (Required) The source MAC address of static mapping.
 
 ---
 
@@ -223,38 +211,9 @@ A `expression` block supports the following:
 
 ---
 
-A `l2tp` block supports the following:
+#### Site to Site VPN
 
-* `pre_shared_secret` - (Required) The pre shared secret for L2TP/IPsec.
-* `range_start` - (Required) The start value of IP address range to assign to L2TP/IPsec client.
-* `range_stop` - (Required) The end value of IP address range to assign to L2TP/IPsec client.
-
----
-
-A `network_interface` block supports the following:
-
-* `index` - (Required) The index of the network interface. This must be in the range [`1`-`7`].
-* `ip_addresses` - (Required) A list of ip address to assign to the network interface. This is required only one value when `plan` is `standard`, two values otherwise.
-* `netmask` - (Required) The bit length of the subnet to assign to the network interface.
-* `switch_id` - (Required) The id of the connected switch.
-* `vip` - (Optional) The virtual IP address to assign to the network interface. This is only required when `plan` is not `standard`.
-
----
-
-A `port_forwarding` block supports the following:
-
-* `private_ip` - (Required) The destination ip address of the port forwarding.
-* `private_port` - (Required) The destination port number of the port forwarding. This will be a port number on a private network.
-* `protocol` - (Required) The protocol used for port forwarding. This must be one of [`tcp`/`udp`].
-* `public_port` - (Required) The source port number of the port forwarding. This must be a port number on a public network.
-* `description` - (Optional) The description of the port forwarding. The length of this value must be in the range [`0`-`512`].
-
----
-
-A `pptp` block supports the following:
-
-* `range_start` - (Required) The start value of IP address range to assign to PPTP client.
-* `range_stop` - (Required) The end value of IP address range to assign to PPTP client.
+* `site_to_site_vpn` - (Optional) One or more `site_to_site_vpn` blocks as defined below.
 
 ---
 
@@ -268,6 +227,41 @@ A `site_to_site_vpn` block supports the following:
 
 ---
 
+#### DHCP/NAT/Forwarding
+
+* `dhcp_server` - (Optional) One or more `dhcp_server` blocks as defined below.
+* `dhcp_static_mapping` - (Optional) One or more `dhcp_static_mapping` blocks as defined below.
+* `port_forwarding` - (Optional) One or more `port_forwarding` blocks as defined below.
+* `static_nat` - (Optional) One or more `static_nat` blocks as defined below.
+
+---
+
+A `dhcp_server` block supports the following:
+
+* `interface_index` - (Required) The index of the network interface on which to enable the DHCP service. This must be in the range [`1`-`7`].
+* `range_start` - (Required) The start value of IP address range to assign to DHCP client.
+* `range_stop` - (Required) The end value of IP address range to assign to DHCP client.
+* `dns_servers` - (Optional) A list of IP address of DNS server to assign to DHCP client.
+
+---
+
+A `dhcp_static_mapping` block supports the following:
+
+* `ip_address` - (Required) The static IP address to assign to DHCP client.
+* `mac_address` - (Required) The source MAC address of static mapping.
+
+---
+
+A `port_forwarding` block supports the following:
+
+* `private_ip` - (Required) The destination ip address of the port forwarding.
+* `private_port` - (Required) The destination port number of the port forwarding. This will be a port number on a private network.
+* `protocol` - (Required) The protocol used for port forwarding. This must be one of [`tcp`/`udp`].
+* `public_port` - (Required) The source port number of the port forwarding. This must be a port number on a public network.
+* `description` - (Optional) The description of the port forwarding. The length of this value must be in the range [`0`-`512`].
+
+---
+
 A `static_nat` block supports the following:
 
 * `private_ip` - (Required) The private IP address used for the static NAT.
@@ -276,10 +270,26 @@ A `static_nat` block supports the following:
 
 ---
 
-A `static_route` block supports the following:
+#### Remote Access
 
-* `next_hop` - (Required) The IP address of the next hop.
-* `prefix` - (Required) The CIDR block of destination.
+* `l2tp` - (Optional) A `l2tp` block as defined below.
+* `pptp` - (Optional) A `pptp` block as defined below.
+* `user` - (Optional) One or more `user` blocks as defined below.
+
+---
+
+A `l2tp` block supports the following:
+
+* `pre_shared_secret` - (Required) The pre shared secret for L2TP/IPsec.
+* `range_start` - (Required) The start value of IP address range to assign to L2TP/IPsec client.
+* `range_stop` - (Required) The end value of IP address range to assign to L2TP/IPsec client.
+
+---
+
+A `pptp` block supports the following:
+
+* `range_start` - (Required) The start value of IP address range to assign to PPTP client.
+* `range_stop` - (Required) The end value of IP address range to assign to PPTP client.
 
 ---
 
@@ -287,6 +297,15 @@ A `user` block supports the following:
 
 * `name` - (Required) The user name used to authenticate remote access.
 * `password` - (Required) The password used to authenticate remote access.
+
+---
+
+#### Common Arguments
+
+* `description` - (Optional) The description of the VPCRouter. The length of this value must be in the range [`1`-`512`].
+* `icon_id` - (Optional) The icon id to attach to the VPCRouter.
+* `tags` - (Optional) Any tags to assign to the VPCRouter.
+* `zone` - (Optional) The name of zone that the VPCRouter will be created. (e.g. `is1a`, `tk1a`). Changing this forces a new resource to be created.
 
 
 ### Timeouts
@@ -301,4 +320,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `id` - The id of the VPC Router.
 * `public_ip` - The public ip address of the VPC Router.
+* `public_netmask` - The bit length of the subnet to assign to the public network interface.
+
 


### PR DESCRIPTION
fixes #652 

- Database
  - `network_interface`ブロック
  - `backup`ブロック
- LoadBalancer
  - `network_interface`ブロック
  - `high_availability`の廃止
- NFS
  - `network_interface`ブロック
- VPCルータ
  - `public_network_interface`ブロック
  - `public_netmask`
  - リネーム:`network_interface` => `private_network_interface`

Note: VPCルータは共有セグメントに接続(IPアドレスは割り振り)パターンが存在するため、入力値として`public_network_interface`ブロックを、参照用として`public_ip`と`public_netmask`を提供する。