### PR TITLE
Bump to v1.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.21.2 (Unreleased)
+## 1.21.3 (Unreleased)
+
+## 1.21.2 (2020-01-28)
 
 * Use libsacloud v1.35.1 #672 (@yamamoto-febc)
 


### PR DESCRIPTION
v1.21.3のリリース用PR

現在v1/v2両方に対応したリリースプロセスへの移行の過渡期のため、今回は手作業でPRを作成して対応する。