### PR TITLE
Add user_ip_address/hostname attribute to sakuracloud_server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud/v2 v2.0.0-rc5
+	github.com/sacloud/libsacloud/v2 v2.0.0-rc6
 	github.com/stretchr/testify v1.4.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud/v2 v2.0.0-rc5 h1:qpNDv3AqKNEAudQCM7Nh5IAYSV8L8ducO7egb6oSTgQ=
-github.com/sacloud/libsacloud/v2 v2.0.0-rc5/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
+github.com/sacloud/libsacloud/v2 v2.0.0-rc6 h1:Q6OQ1G6Oo5erM2xH/xpdPk9kLkDFQOKZkSvSHTbNImg=
+github.com/sacloud/libsacloud/v2 v2.0.0-rc6/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=

--- a/sakuracloud/data_source_sakuracloud_server.go
+++ b/sakuracloud/data_source_sakuracloud_server.go
@@ -76,6 +76,11 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 								[]string{"shared", "disconnect", "<switch id>"},
 							),
 						},
+						"user_ip_address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The IP address for only display. This value doesn't affect actual NIC settings",
+						},
 						"packet_filter_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -115,6 +120,11 @@ func dataSourceSakuraCloudServer() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The network address which the `ip_address` belongs",
+			},
+			"hostname": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The hostname of the Server",
 			},
 			"dns_servers": {
 				Type:        schema.TypeList,

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -100,6 +100,13 @@ func resourceSakuraCloudServer() *schema.Resource {
 								[]string{"shared", "disconnect", "<switch id>"},
 							),
 						},
+						"user_ip_address": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.SingleIP(),
+							Description:  "The IP address for only display. This value doesn't affect actual NIC settings",
+						},
 						"packet_filter_id": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -226,6 +233,11 @@ func resourceSakuraCloudServer() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "A list of IP address of DNS server in the zone",
+			},
+			"hostname": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The hostname of the Server",
 			},
 			"force_shutdown": {
 				Type:        schema.TypeBool,
@@ -388,6 +400,7 @@ func setServerResourceData(ctx context.Context, d *schema.ResourceData, client *
 	d.Set("gateway", gateway)              // nolint
 	d.Set("network_address", nwAddress)    // nolint
 	d.Set("netmask", nwMaskLen)            // nolint
+	d.Set("hostname", data.HostName)       // nolint
 	if err := d.Set("dns_servers", data.Zone.Region.NameServers); err != nil {
 		return err
 	}

--- a/sakuracloud/resource_sakuracloud_server_test.go
+++ b/sakuracloud/resource_sakuracloud_server_test.go
@@ -60,6 +60,7 @@ func TestAccSakuraCloudServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.note_ids.0", "100000000000"),
 					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_interface.0.upstream", "shared"),
+					resource.TestCheckResourceAttr(resourceName, "hostname", rand),
 					resource.TestCheckResourceAttrSet(resourceName, "network_interface.0.mac_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
 					resource.TestCheckResourceAttrPair(
@@ -220,6 +221,8 @@ func TestAccSakuraCloudServer_switch(t *testing.T) {
 				Config: buildConfigWithArgs(testAccSakuraCloudServer_switch, rand),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudServerExists(resourceName, &server),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.0.user_ip_address", "192.168.0.2"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface.1.user_ip_address", "192.168.1.2"),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", "192.168.0.2"),
 					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
 					resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.0.1"),
@@ -541,7 +544,11 @@ resource "sakuracloud_disk" "foobar" {
   source_archive_id = data.sakuracloud_archive.ubuntu.id
 }
 
-resource "sakuracloud_switch" "foobar" {
+resource "sakuracloud_switch" "foobar1" {
+  name = "{{ .arg0 }}"
+}
+
+resource "sakuracloud_switch" "foobar2" {
   name = "{{ .arg0 }}"
 }
 
@@ -550,7 +557,11 @@ resource "sakuracloud_server" "foobar" {
   disks = [sakuracloud_disk.foobar.id]
 
   network_interface {
-    upstream = sakuracloud_switch.foobar.id
+    upstream = sakuracloud_switch.foobar1.id
+  }
+  network_interface {
+    upstream        = sakuracloud_switch.foobar2.id
+    user_ip_address = "192.168.1.2"
   }
   
   disk_edit_parameter {

--- a/sakuracloud/structure_server.go
+++ b/sakuracloud/structure_server.go
@@ -96,8 +96,9 @@ func expandServerNIC(d resourceValueGettable) serverBuilder.NICSettingHolder {
 		return &serverBuilder.DisconnectedNICSetting{}
 	default:
 		return &serverBuilder.ConnectedNICSetting{
-			SwitchID:       sakuraCloudID(upstream),
-			PacketFilterID: expandSakuraCloudID(d, "packet_filter_id"),
+			SwitchID:         sakuraCloudID(upstream),
+			PacketFilterID:   expandSakuraCloudID(d, "packet_filter_id"),
+			DisplayIPAddress: stringOrDefault(d, "user_ip_address"),
 		}
 	}
 }
@@ -121,8 +122,9 @@ func expandServerAdditionalNICs(d resourceValueGettable) []serverBuilder.Additio
 			results = append(results, &serverBuilder.DisconnectedNICSetting{})
 		default:
 			results = append(results, &serverBuilder.ConnectedNICSetting{
-				SwitchID:       sakuraCloudID(upstream),
-				PacketFilterID: expandSakuraCloudID(d, "packet_filter_id"),
+				SwitchID:         sakuraCloudID(upstream),
+				PacketFilterID:   expandSakuraCloudID(d, "packet_filter_id"),
+				DisplayIPAddress: stringOrDefault(d, "user_ip_address"),
 			})
 		}
 	}
@@ -145,6 +147,7 @@ func flattenServerNICs(server *sacloud.Server) []interface{} {
 			"upstream":         upstream,
 			"packet_filter_id": nic.PacketFilterID.String(),
 			"mac_address":      strings.ToLower(nic.MACAddress),
+			"user_ip_address":  nic.UserIPAddress,
 		})
 	}
 	return results

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/customize_envelope.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/customize_envelope.go
@@ -154,6 +154,16 @@ func (s sIMFindRequestEnvelope) MarshalJSON() ([]byte, error) {
 	return json.Marshal(tmp)
 }
 
+func (s localRouterFindRequestEnvelope) MarshalJSON() ([]byte, error) {
+	type alias localRouterFindRequestEnvelope
+	tmp := alias(s)
+	if tmp.Filter == nil {
+		tmp.Filter = search.Filter{}
+	}
+	tmp.Filter[search.Key("Provider.Class")] = "localrouter"
+	return json.Marshal(tmp)
+}
+
 func (s databaseFindRequestEnvelope) MarshalJSON() ([]byte, error) {
 	type alias databaseFindRequestEnvelope
 	tmp := alias(s)

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_disk.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_disk.go
@@ -113,6 +113,11 @@ func (o *DiskOp) Config(ctx context.Context, zone string, id types.ID, edit *sac
 		return err
 	}
 
+	if edit.HostName != "" {
+		server.HostName = edit.HostName
+		putServer(zone, server)
+	}
+
 	if len(server.Interfaces) > 0 {
 		nic := server.Interfaces[0]
 		if nic.SwitchScope == types.Scopes.Shared {

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_interface.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_interface.go
@@ -86,6 +86,19 @@ func (o *InterfaceOp) Update(ctx context.Context, zone string, id types.ID, para
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
 
+	serverOp := NewServerOp()
+	searched, err := serverOp.Find(ctx, zone, nil)
+	if err == nil {
+		for _, server := range searched.Servers {
+			for _, iface := range server.Interfaces {
+				if iface.ID == id {
+					iface.UserIPAddress = param.UserIPAddress
+					putServer(zone, server)
+				}
+			}
+		}
+	}
+
 	putInterface(zone, value)
 	return value, nil
 }

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
@@ -13383,7 +13383,7 @@ func (o *LocalRouterUpdateSettingsRequest) SetSettingsHash(v string) {
 
 // LocalRouterHealth represents API parameter/response structure
 type LocalRouterHealth struct {
-	Peers []*LocalRouterHealthPeer `mapconv:"LocalRouter.[]Peers,recursive"`
+	Peers []*LocalRouterHealthPeer `mapconv:"[]Peers,recursive"`
 }
 
 // Validate validates by field tags
@@ -13394,7 +13394,7 @@ func (o *LocalRouterHealth) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *LocalRouterHealth) setDefaults() interface{} {
 	return &struct {
-		Peers []*LocalRouterHealthPeer `mapconv:"LocalRouter.[]Peers,recursive"`
+		Peers []*LocalRouterHealthPeer `mapconv:"[]Peers,recursive"`
 	}{
 		Peers: o.GetPeers(),
 	}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/builder.go
@@ -437,12 +437,14 @@ func (b *Builder) collectInterfaceParameters() []*updateInterfaceRequest {
 		reqs = append(reqs, &updateInterfaceRequest{
 			index:          0,
 			packetFilterID: b.NIC.GetPacketFilterID(),
+			displayIP:      b.NIC.GetDisplayIPAddress(),
 		})
 	}
 	for i, nic := range b.AdditionalNICs {
 		reqs = append(reqs, &updateInterfaceRequest{
 			index:          i + 1,
 			packetFilterID: nic.GetPacketFilterID(),
+			displayIP:      nic.GetDisplayIPAddress(),
 		})
 	}
 	return reqs

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/nic.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/server/nic.go
@@ -33,6 +33,7 @@ type nicState struct {
 // NICSettingHolder NIC設定を保持するためのインターフェース
 type NICSettingHolder interface {
 	GetConnectedSwitchParam() *sacloud.ConnectedSwitch
+	GetDisplayIPAddress() string
 
 	GetPacketFilterID() types.ID
 	Validate(ctx context.Context, client *APIClient, zone string) error
@@ -74,6 +75,11 @@ func (c *SharedNICSetting) Validate(ctx context.Context, client *APIClient, zone
 		}
 	}
 	return nil
+}
+
+// GetDisplayIPAddress 表示用IPアドレスを返す
+func (c *SharedNICSetting) GetDisplayIPAddress() string {
+	return ""
 }
 
 func (c *SharedNICSetting) state() *nicState {

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/query/public_archive_info.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/query/public_archive_info.go
@@ -103,11 +103,6 @@ func getPublicArchiveFromAncestors(ctx context.Context, zone string, reader *Arc
 		return nil, nil
 	}
 
-	// vSrXであれば編集不可
-	if archive.HasTag("pkg-vsrx") {
-		return nil, nil
-	}
-
 	// SophosUTMであれば編集不可
 	if archive.HasTag("pkg-sophosutm") || isSophosUTM(archive) {
 		return nil, nil
@@ -118,6 +113,10 @@ func getPublicArchiveFromAncestors(ctx context.Context, zone string, reader *Arc
 	}
 	// Netwiser VEであれば編集不可
 	if archive.HasTag("pkg-netwiserve") {
+		return nil, nil
+	}
+	// Juniper vSRXであれば編集不可
+	if archive.HasTag("pkg-vsrx") {
 		return nil, nil
 	}
 

--- a/vendor/github.com/sacloud/libsacloud/v2/version.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/version.go
@@ -15,4 +15,4 @@
 package libsacloud
 
 // Version バージョン
-const Version = "2.0.0-rc5"
+const Version = "2.0.0-rc6"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/posener/complete/match
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud/v2 v2.0.0-rc5
+# github.com/sacloud/libsacloud/v2 v2.0.0-rc6
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/pkg/cidr
 github.com/sacloud/libsacloud/v2/pkg/mapconv

--- a/website/docs/d/server.md
+++ b/website/docs/d/server.md
@@ -51,6 +51,7 @@ A `condition` block supports the following:
 * `disks` - A list of disk id connected to the server.
 * `dns_servers` - A list of IP address of DNS server in the zone.
 * `gateway` - The IP address of the gateway used by Server.
+* `hostname` - The hostname of the Server.
 * `icon_id` - The icon id attached to the Server.
 * `interface_driver` - The driver name of network interface. This will be one of [`virtio`/`e1000`].
 * `ip_address` - The IP address assigned to the Server.
@@ -70,5 +71,7 @@ A `network_interface` block exports the following:
 * `mac_address` - The MAC address.
 * `packet_filter_id` - The id of the packet filter attached to the network interface.
 * `upstream` - The upstream type or upstream switch id. This will be one of [`shared`/`disconnect`/`<switch id>`].
+* `user_ip_address` - The IP address for only display. This value doesn't affect actual NIC settings.
+
 
 

--- a/website/docs/r/server.md
+++ b/website/docs/r/server.md
@@ -71,6 +71,9 @@ A `network_interface` block supports the following:
 
 * `upstream` - (Required) The upstream type or upstream switch id. This must be one of [`shared`/`disconnect`/`<switch id>`].
 * `packet_filter_id` - (Optional) The id of the packet filter to attach to the network interface.
+* `user_ip_address` - (Optional) The IP address for only display. This value doesn't affect actual NIC settings.
+
+
 
 #### Disks
 
@@ -112,6 +115,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 * `id` - The id of the Server.
 * `dns_servers` - A list of IP address of DNS server in the zone.
 * `gateway` - The IP address of the gateway used by Server.
+* `hostname` - The hostname of the Server.
 * `ip_address` - The IP address assigned to the Server.
 * `netmask` - The bit length of the subnet assigned to the Server.
 * `network_address` - The network address which the `ip_address` belongs.


### PR DESCRIPTION
`sakuracloud_server`リソースにいつかの属性を追加する。

- `network_interface.user_ip_address`: 表示用IPアドレス
- `hostname`: ホスト名

`network_interface.user_ip_address`はさくらのクラウドAPIから返される`Server.Interfaces[n].UserIPAddress`を表す。スイッチに接続した際のディスクの修正API経由で設定される(eth0のみ)ほか、`PUT interface/:id`で設定できる。
この値はサーバのNIC設定には影響しない表示用の項目となっている。
v1では`display_ipaddress`、または`additional_ipaddresses`だった項目。
`network_interface.upstream`にスイッチIDが指定されている場合のみ有効(以外は無視される)


`hostname`はさくらのクラウドAPIから返される`Server.HostName`を表す。
v1にも同様の項目があったが、v2では読み取り専用項目となった。  
(設定したい場合は`disk_edit_parameter`経由で設定可能)
