### PR TITLE
Set sakuracloud_proxylb.vip value from Health API result

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,17 @@
+# Copyright 2016-2020 terraform-provider-sakuracloud authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 PKG_NAME     ?= sakuracloud
 WEBSITE_REPO  = github.com/hashicorp/terraform-website
 

--- a/sakuracloud/resource_sakuracloud_proxylb.go
+++ b/sakuracloud/resource_sakuracloud_proxylb.go
@@ -469,6 +469,10 @@ func setProxyLBResourceData(ctx context.Context, d *schema.ResourceData, client 
 		// even if certificate is deleted, it will not result in an error
 		return err
 	}
+	health, err := proxyLBOp.HealthStatus(ctx, data.ID)
+	if err != nil {
+		return err
+	}
 
 	d.Set("name", data.Name)                                   // nolint
 	d.Set("plan", data.Plan.Int())                             // nolint
@@ -477,7 +481,7 @@ func setProxyLBResourceData(ctx context.Context, d *schema.ResourceData, client 
 	d.Set("timeout", flattenProxyLBTimeout(data))              // nolint
 	d.Set("region", data.Region.String())                      // nolint
 	d.Set("fqdn", data.FQDN)                                   // nolint
-	d.Set("vip", data.VirtualIPAddress)                        // nolint
+	d.Set("vip", health.CurrentVIP)                            // nolint
 	d.Set("proxy_networks", data.ProxyNetworks)                // nolint
 	d.Set("icon_id", data.IconID.String())                     // nolint
 	d.Set("description", data.Description)                     // nolint

--- a/sakuracloud/resource_sakuracloud_proxylb_test.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_test.go
@@ -79,6 +79,7 @@ func TestAccSakuraCloudProxyLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rule.0.host", "usacloud.jp"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.path", "/path"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.group", "group1"),
+					resource.TestCheckResourceAttrSet(resourceName, "vip"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "server.0.ip_address",
 						"sakuracloud_server.foobar", "ip_address",
@@ -113,6 +114,7 @@ func TestAccSakuraCloudProxyLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rule.0.host", "upd.usacloud.jp"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.path", "/path-upd"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.group", "group2"),
+					resource.TestCheckResourceAttrSet(resourceName, "vip"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "server.0.ip_address",
 						"sakuracloud_server.foobar", "ip_address",


### PR DESCRIPTION
VIPフェイルオーバが有効な場合は`CommonServiceItem.Status.VirtualIPAddress`に値が入っておらず、API `GET commonserviceitem/:id/health`から値を取得する必要がある。

このため、`sakuracloud_proxylb`でStateに値をセットする際にこのAPIを利用するようにする。