### PR TITLE
tfproviderlintx

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,7 +36,7 @@ tools:
 	GO111MODULE=off go get github.com/sacloud/addlicense
 	GO111MODULE=off go get github.com/tcnksm/ghr
 	GO111MODULE=on go install github.com/bflad/tfproviderdocs
-	GO111MODULE=on go install github.com/bflad/tfproviderlint/cmd/tfproviderlint
+	GO111MODULE=on go install github.com/bflad/tfproviderlint/cmd/tfproviderlintx
 	GO111MODULE=on go install github.com/client9/misspell/cmd/misspell
 	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint
 
@@ -108,11 +108,12 @@ lint:
 
 .PHONY: tflint
 tflint:
-	tfproviderlint \
+	tfproviderlintx \
         -AT001 -AT002 -AT003 -AT004 -AT005 -AT006 -AT007 \
         -R001 -R002 -R004 -R005 -R006 \
         -S001 -S002 -S003 -S004 -S005 -S006 -S007 -S008 -S009 -S010 -S011 -S012 -S013 -S014 -S015 -S016 -S017 -S018 -S019 -S020 -S021 -S022 -S023\
         -V001 \
+        -XR001 -XR004 \
         ./$(PKG_NAME)
 
 .PHONY: goimports

--- a/sakuracloud/resource_sakuracloud_mobile_gateway.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway.go
@@ -353,7 +353,9 @@ func setMobileGatewayResourceData(ctx context.Context, d *schema.ResourceData, c
 	if err := d.Set("traffic_control", flattenMobileGatewayTrafficConfigs(tc)); err != nil {
 		return err
 	}
-	d.Set("dns_servers", []string{resolver.DNS1, resolver.DNS2}) // nolint
+	if err := d.Set("dns_servers", []string{resolver.DNS1, resolver.DNS2}); err != nil {
+		return err
+	}
 	if err := d.Set("static_route", flattenMobileGatewayStaticRoutes(data.Settings.StaticRoute)); err != nil {
 		return err
 	}

--- a/sakuracloud/resource_sakuracloud_proxylb.go
+++ b/sakuracloud/resource_sakuracloud_proxylb.go
@@ -482,9 +482,11 @@ func setProxyLBResourceData(ctx context.Context, d *schema.ResourceData, client 
 	d.Set("region", data.Region.String())                      // nolint
 	d.Set("fqdn", data.FQDN)                                   // nolint
 	d.Set("vip", health.CurrentVIP)                            // nolint
-	d.Set("proxy_networks", data.ProxyNetworks)                // nolint
-	d.Set("icon_id", data.IconID.String())                     // nolint
-	d.Set("description", data.Description)                     // nolint
+	if err := d.Set("proxy_networks", data.ProxyNetworks); err != nil {
+		return err
+	}
+	d.Set("icon_id", data.IconID.String()) // nolint
+	d.Set("description", data.Description) // nolint
 	if err := d.Set("bind_port", flattenProxyLBBindPorts(data)); err != nil {
 		return err
 	}

--- a/sakuracloud/resource_sakuracloud_subnet.go
+++ b/sakuracloud/resource_sakuracloud_subnet.go
@@ -229,7 +229,9 @@ func setSubnetResourceData(_ context.Context, d *schema.ResourceData, client *AP
 	d.Set("network_address", data.NetworkAddress)                                // nolint
 	d.Set("min_ip_address", data.IPAddresses[0].IPAddress)                       // nolint
 	d.Set("max_ip_address", data.IPAddresses[len(data.IPAddresses)-1].IPAddress) // nolint
-	d.Set("ip_addresses", addrs)                                                 // nolint
-	d.Set("zone", getZone(d, client))                                            // nolint
+	if err := d.Set("ip_addresses", addrs); err != nil {
+		return err
+	}
+	d.Set("zone", getZone(d, client)) // nolint
 	return nil
 }


### PR DESCRIPTION
tfproviderlintの代わりにtfproviderlintxを利用する。

https://github.com/bflad/tfproviderlint#extra-lint-checks

### 有効にしたlint

- XR001 | check for usage of ResourceData.GetOkExists() calls
- XR004 | check for ResourceData.Set() calls that should implement error checking with complex values

### 有効にしなかったlint

- XR002 | check for Resource that should implement Importer: importを実装しないリソースがあるため
- XR003 | check for Resource that should implement Timeouts: オブジェクトストレージがTimeoutsを実装していないため(要検討)
- XS001 | check for map[string]*Schema that Description is configured: リスト項目はDescriptionを指定していないため


