### PR TITLE
Use libsacloud v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.0.1 (Unreleased)
 
-*
+IMPROVEMENT
+
+* Use libsacloud v2.0.1 [GH-696] @yamamoto-febc
 
 ## 2.0.0 (2020-01-31)
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud/v2 v2.0.0
+	github.com/sacloud/libsacloud/v2 v2.0.1
 	github.com/stretchr/testify v1.4.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud/v2 v2.0.0 h1:LuaGjj1DVDyNUT8XNeB7ihxZgV2LNM2txGp6TGNSo5U=
-github.com/sacloud/libsacloud/v2 v2.0.0/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
+github.com/sacloud/libsacloud/v2 v2.0.1 h1:YR7Q8qBTTUsBGEXgSrbmaA9J954X523bvS3D0zFXIMs=
+github.com/sacloud/libsacloud/v2 v2.0.1/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/customize_envelope.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/customize_envelope.go
@@ -104,6 +104,16 @@ func (s autoBackupFindRequestEnvelope) MarshalJSON() ([]byte, error) {
 	return json.Marshal(tmp)
 }
 
+func (s containerRegistryFindRequestEnvelope) MarshalJSON() ([]byte, error) {
+	type alias containerRegistryFindRequestEnvelope
+	tmp := alias(s)
+	if tmp.Filter == nil {
+		tmp.Filter = search.Filter{}
+	}
+	tmp.Filter[search.Key("Provider.Class")] = "containerregistry"
+	return json.Marshal(tmp)
+}
+
 func (s dNSFindRequestEnvelope) MarshalJSON() ([]byte, error) {
 	type alias dNSFindRequestEnvelope
 	tmp := alias(s)

--- a/vendor/github.com/sacloud/libsacloud/v2/version.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/version.go
@@ -15,4 +15,4 @@
 package libsacloud
 
 // Version バージョン
-const Version = "2.0.0"
+const Version = "2.0.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/posener/complete/match
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud/v2 v2.0.0
+# github.com/sacloud/libsacloud/v2 v2.0.1
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/pkg/cidr
 github.com/sacloud/libsacloud/v2/pkg/mapconv


### PR DESCRIPTION
related: https://github.com/sacloud/libsacloud/issues/498

`sakuracloud_container_registry`データソースで`filter`の値次第でエラーとなるケースがある。
この対応がされたlibsacloud v2.0.1へアップデートする。