### PR TITLE
Set ID to state even if got error from builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.3 (Unreleased)
 
+* Set ID to state even if got error from builders [GH-726] (@yamamoto-febc)
 * libsacloud v2.3.0 - MariaDB 10.4 [GH-724]
 
 ## 2.1.2 (2020-03-10)

--- a/sakuracloud/resource_sakuracloud_container_registry.go
+++ b/sakuracloud/resource_sakuracloud_container_registry.go
@@ -117,11 +117,13 @@ func resourceSakuraCloudContainerRegistryCreate(d *schema.ResourceData, meta int
 
 	builder := expandContainerRegistryBuilder(d, client, "")
 	reg, err := builder.Build(ctx)
+	if reg != nil {
+		d.SetId(reg.ID.String())
+	}
 	if err != nil {
 		return fmt.Errorf("creating SakuraCloud ContainerRegistry is failed: %s", err)
 	}
 
-	d.SetId(reg.ID.String())
 	return resourceSakuraCloudContainerRegistryRead(d, meta)
 }
 

--- a/sakuracloud/resource_sakuracloud_database.go
+++ b/sakuracloud/resource_sakuracloud_database.go
@@ -183,6 +183,9 @@ func resourceSakuraCloudDatabaseCreate(d *schema.ResourceData, meta interface{})
 
 	dbBuilder := expandDatabaseBuilder(d, client)
 	db, err := dbBuilder.Build(ctx, zone)
+	if db != nil {
+		d.SetId(db.ID.String())
+	}
 	if err != nil {
 		return fmt.Errorf("creating SakuraCloud Database is failed: %s", err)
 	}
@@ -191,7 +194,6 @@ func resourceSakuraCloudDatabaseCreate(d *schema.ResourceData, meta interface{})
 	// この挙動はテストなどで問題となる。このためここで少しsleepすることで対応する。
 	time.Sleep(client.databaseWaitAfterCreateDuration)
 
-	d.SetId(db.ID.String())
 	return resourceSakuraCloudDatabaseRead(d, meta)
 }
 

--- a/sakuracloud/resource_sakuracloud_database_read_replica.go
+++ b/sakuracloud/resource_sakuracloud_database_read_replica.go
@@ -126,6 +126,9 @@ func resourceSakuraCloudDatabaseReadReplicaCreate(d *schema.ResourceData, meta i
 	}
 
 	db, err := builder.Build(ctx, zone)
+	if db != nil {
+		d.SetId(db.ID.String())
+	}
 	if err != nil {
 		return fmt.Errorf("creating SakuraCloud Database ReadReplica is failed: %s", err)
 	}
@@ -134,7 +137,6 @@ func resourceSakuraCloudDatabaseReadReplicaCreate(d *schema.ResourceData, meta i
 	// この挙動はテストなどで問題となる。このためここで少しsleepすることで対応する。
 	time.Sleep(client.databaseWaitAfterCreateDuration)
 
-	d.SetId(db.ID.String())
 	return setDatabaseReadReplicaResourceData(ctx, d, client, db)
 }
 

--- a/sakuracloud/resource_sakuracloud_internet.go
+++ b/sakuracloud/resource_sakuracloud_internet.go
@@ -143,11 +143,13 @@ func resourceSakuraCloudInternetCreate(d *schema.ResourceData, meta interface{})
 	builder := expandInternetBuilder(d, client)
 
 	internet, err := builder.Build(ctx, zone)
+	if internet != nil {
+		d.SetId(internet.ID.String())
+	}
 	if err != nil {
 		return fmt.Errorf("creating SakuraCloud Internet is failed: %s", err)
 	}
 
-	d.SetId(internet.ID.String())
 	return resourceSakuraCloudInternetRead(d, meta)
 }
 

--- a/sakuracloud/resource_sakuracloud_local_router.go
+++ b/sakuracloud/resource_sakuracloud_local_router.go
@@ -181,10 +181,13 @@ func resourceSakuraCloudLocalRouterCreate(d *schema.ResourceData, meta interface
 	}
 
 	localRouter, err := builder.Build(ctx)
+	if localRouter != nil {
+		d.SetId(localRouter.ID.String())
+	}
 	if err != nil {
 		return fmt.Errorf("creating SakuraCloud LocalRouter is failed: %s", err)
 	}
-	d.SetId(localRouter.ID.String())
+
 	return resourceSakuraCloudLocalRouterRead(d, meta)
 }
 

--- a/sakuracloud/resource_sakuracloud_mobile_gateway.go
+++ b/sakuracloud/resource_sakuracloud_mobile_gateway.go
@@ -230,11 +230,13 @@ func resourceSakuraCloudMobileGatewayCreate(d *schema.ResourceData, meta interfa
 	}
 
 	mgw, err := builder.Build(ctx, zone)
+	if mgw != nil {
+		d.SetId(mgw.ID.String())
+	}
 	if err != nil {
 		return fmt.Errorf("creating SakuraCloud MobileGateway is failed: %s", err)
 	}
 
-	d.SetId(mgw.ID.String())
 	return resourceSakuraCloudMobileGatewayRead(d, meta)
 }
 

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -503,10 +503,12 @@ func resourceSakuraCloudVPCRouterCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	vpcRouter, err := builder.Build(ctx, zone)
+	if vpcRouter != nil {
+		d.SetId(vpcRouter.ID.String())
+	}
 	if err != nil {
 		return fmt.Errorf("creating SakuraCloud VPCRouter is failed: %s", err)
 	}
-	d.SetId(vpcRouter.ID.String())
 	return resourceSakuraCloudVPCRouterRead(d, meta)
 }
 


### PR DESCRIPTION
related: https://github.com/sacloud/libsacloud/pull/520

builderがエラーを返した場合でも作成済みリソースが存在する時はSetIdを呼びstateにIDを保存する。