### PR TITLE
sakuracloud_archive: アーカイブ作成方法の多様化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 2.1.3 (Unreleased)
+## 2.2.0 (Unreleased)
+
+FEATURES
+
+* Supports transferred/shared archives [GH-727] (@yamamoto-febc)
+    * libsacloud v2.4.1
+
+IMPROVEMENTS
 
 * Set ID to state even if got error from builders [GH-726] (@yamamoto-febc)
 * libsacloud v2.3.0 - MariaDB 10.4 [GH-724]

--- a/examples/website/r/archive/archive.tf
+++ b/examples/website/r/archive/archive.tf
@@ -1,3 +1,25 @@
+# from archive/disk
+resource "sakuracloud_archive" "from-archive-or-disk" {
+  name         = "foobar"
+  description  = "description"
+  tags         = ["tag1", "tag2"]
+
+  source_archive_id   = 123456789012
+  source_archive_zone = "tk1a"
+  # source_disk_id    = 123456789012
+}
+
+# from shared archive
+resource "sakuracloud_archive" "from-shared-archive" {
+  name         = "foobar"
+  description  = "description"
+  tags         = ["tag1", "tag2"]
+
+  source_shared_key = "is1a:123456789012:xxx"
+}
+
+
+# from local file
 resource "sakuracloud_archive" "foobar" {
   name         = "foobar"
   description  = "description"

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/goamz v0.0.0-20150317174335-caaaea8b30ee
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect
-	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
+	github.com/sacloud/ftps v1.0.0
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud/v2 v2.3.0
+	github.com/sacloud/libsacloud/v2 v2.4.1
 	github.com/stretchr/testify v1.4.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,12 +200,12 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.1 h1:LrvDIY//XNo65Lq84G/akBuMGlawHvGBABv8f/ZN6DI=
 github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=
-github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht3QdNJ13Stey0hR6asicabuEqU=
-github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
+github.com/sacloud/ftps v1.0.0 h1:RFIOwGby8ZDqdSccA7Tm9kJdm9QVAxADvxmMINBGLZw=
+github.com/sacloud/ftps v1.0.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud/v2 v2.3.0 h1:ryRa9U87ZwhcCqWhqww8d1klPdg5J2iAfAV4VTGt0zM=
-github.com/sacloud/libsacloud/v2 v2.3.0/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
+github.com/sacloud/libsacloud/v2 v2.4.1 h1:E1b94d/lngTSbrTeNIyKsWs6AHQUPx0Lt3jJZWdDaQQ=
+github.com/sacloud/libsacloud/v2 v2.4.1/go.mod h1:83Mv5rKrD39QtKyarsFC2mVl9NKXWyGlL2XtnnqGKVk=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=

--- a/sakuracloud/resource_sakuracloud_archive_test.go
+++ b/sakuracloud/resource_sakuracloud_archive_test.go
@@ -18,12 +18,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 )
+
+const envSourceSharedArchiveKey = "SAKURACLOUD_SOURCE_SHARED_ARCHIVE_KEY"
 
 func TestAccSakuraCloudArchive_basic(t *testing.T) {
 	skipIfFakeModeEnabled(t)
@@ -66,6 +69,77 @@ func TestAccSakuraCloudArchive_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "description-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.2362157161", "tag1-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.3412841145", "tag2-upd"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSakuraCloudArchive_transfer(t *testing.T) {
+	skipIfFakeModeEnabled(t)
+
+	resourceName := "sakuracloud_archive.foobar"
+	rand := randomName()
+
+	var archive sacloud.Archive
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraCloudArchiveDestroy,
+			testCheckSakuraCloudIconDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: buildConfigWithArgs(testAccSakuraCloudArchive_transfer, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraCloudArchiveExists(resourceName, &archive),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "tags.4151227546", "tag1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
+					resource.TestCheckResourceAttrPair(
+						resourceName, "source_archive_id",
+						"sakuracloud_archive.source", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						resourceName, "source_archive_zone",
+						"sakuracloud_archive.source", "zone",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSakuraCloudArchive_fromShared(t *testing.T) {
+	skipIfFakeModeEnabled(t)
+	skipIfEnvIsNotSet(t, envSourceSharedArchiveKey)
+
+	resourceName := "sakuracloud_archive.foobar"
+	rand := randomName()
+	sharedKey := os.Getenv(envSourceSharedArchiveKey)
+
+	var archive sacloud.Archive
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraCloudArchiveDestroy,
+			testCheckSakuraCloudIconDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: buildConfigWithArgs(testAccSakuraCloudArchive_fromShared, rand, sharedKey),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraCloudArchiveExists(resourceName, &archive),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "tags.4151227546", "tag1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
+					resource.TestCheckResourceAttr(resourceName, "source_shared_key", sharedKey),
 				),
 			},
 		},
@@ -188,5 +262,36 @@ resource "sakuracloud_archive" "foobar" {
 resource "sakuracloud_icon" "foobar" {
   name          = "{{ .arg0 }}"
   base64content = "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAACdBJREFUWMPNmHtw1NUVx8+5v9/+9rfJPpJNNslisgmIiCCgDQZR5GWnilUDPlpUqjOB2mp4qGM7tVOn/yCWh4AOVUprHRVB2+lMa0l88Kq10iYpNYPWkdeAmFjyEJPN7v5+v83ec/rH3Q1J2A2Z1hnYvz755ZzzvXPPveeee/GbC24FJmZGIYD5QgPpTBIAAICJLgJAwUQMAIDMfOEBUQchgJmAEC8CINLPThpfFCAG5orhogCBQiAAEyF8PQCATEQyxQzMzFIi4Ojdv86UEVF/f38ymezv7yciANR0zXAZhuHSdR0RRxNHZyJEBERmQvhfAAABIJlMJhIJt9t9TXX11GlTffleQGhvbz/4YeuRw4c13ZWfnycQR9ACQEShAyIxAxEKMXoAIVQ6VCzHcSzLmj937qqVK8aNrYKhv4bGxue3bvu8rc3n9+ualisyMzOltMjYccBqWanKdD5gBgAppZNMJhKJvlgs1heLxWL3fPfutU8/VVhYoGx7e3uJyOVyAcCEyy6bN2d266FDbW3thsuFI0gA4qy589PTOJC7EYEBbNu2ElYg4J9e/Y3p1dWBgN+l67csWKBC/mrbth07dnafOSMQp0y58pEVK2tm1ABAW9vn93zvgYRl5+XlAXMuCbxh3o3MDMyIguE8wADRaJ/H7Vp873119y8JBALDsrN8xcpXX3utoKDQNE1iiEV7ieSzmzYuXrwYAH7z4m83bNocDAZ1Tc8hQThrzjwYxY8BmCjaF/P78n+xZs0Ns64f+Ndnn53yevOLioo2btq8bsOGsvAYn9eHAoFZStnR0aFpWsObfxw/fvzp06fvXnyvZVmmx4M5hHQa3S4DwIRlm4Zr7dNPz7r+OgDo6el5bsuWtxrf6u7u9njygsHC9i/+U1Ia9ubnMzATA7MQIlRS8tnJk3/e1fDoI6vKysoqK8pbP/q323RDdi2hq/0ysHGyAwopU4lEfNXKlWo0Hx069MDSZcePHy8MBk3Tk0ylTnd1+wsKTNMERLUGlLtA1A3jyNEjagIKgsFk0gEM5NCSOst0+wEjAEvHtktKSuoeWAIAX3311f11Szs7OydcPtFwGYDp0sagWhoa7K4G5/f71TfHskEVdHXMn6M16CzLDcRkWfaM6dWm6QGAjZs2t7W1X1JeYRgGMzERMxOnNYa5O8mkrmkzr50JAKlUqq29Le2VQ0sACmYmIvU1OwAmLKt6ejUAyJTcu3dfQTCoaZqUkgEoY0ODvKRMSWbLsjo6O2fPmbuw9nYAOHjw4KdHjhqGoRqgLFpS6oNOE84JRDLVX1FeDgBd3V0pIrfLxZn5GGLMrE40y7YTCcula7W3167++c+UzfNbtzGRK+ObxR1RZyJARPUpNxBzPBYDAE3ThCYkETMjIPMQdwCwbNttGItqb6uqrJo2deqMGTVK8qWXX969+92SsjAi5hRF1BkQKJ3REUDXtE+PHL3ppptCoVBpcXFXVzdJqerFWWNmKaVt2T9YWldf//Dg6rL52efWrV/vCxQYLhdJmV2LmaUUkEkZZGbvXGBm0+P563vvqT/vW7LEcRwnmUxv7wFjZiYyDJdabQCQSsnt27d/6+YFT61Z4/UHBvZadi1mQBRERMwEMAIwkdttNh/8V2trKwB85647a2tv7+npTfb3y6HGKLREIvHKK6+my66ubd/x+p69+0KlZf5AQKV+BC0G0MaURwZGlxMAiam9vf3YsWNL7rsXAL694Oa2tvZPPvnEZRiozBABAIE1XfvggwMfffzxnXcsAoBrZ8zYs3+/pmm6ECNJIKrto4UvueQ8pxiRZduxWKympuauRQsnT56saRoAlIRCbzbsYmYhxGB7TdPcHk9LS3O4LHz1VVcFg8HmpubjJ0643W44/w8FS6kqW1YgKROW5VjWivr6P/3h93V1dYZhKNeD/2zp7elVjfAQLyKP2+0PFG5/NZ242XNm25bNRCNrKUjfy5gIzwXE/mQyEYs98dMnHnrw+yr6hx+2/qOp6djRo43vvGu4XJquZ3X3mO7OL8+cOnUqEolURSpUx53LeDDolDlE+ByQRNG+vlmzZ6vROI69fMWqN954Ix5PBAoLC4PBfK+XMqfSEHdEQJRS2ratyl1KSmLG3FoDoKcXFCIQDQOZTCLAQ8uWKtNlD/5w546dkaqqKq8XERDFQIkb7g6QSqUK/f5wOAwA0WgUiM+u/WxaChBRJxSgzsXhK5+sZDISiVxTUwMAjY2Nu3Y1RMZd6vXmAzCAIOB0uHP2SyqVisViCxcu9Pl8ANDc0oK6xswkxMg7mon0dGHMUqkg6Tjh0lLTdAPABwf+niKZ5zFRtRmQ8RrqyACyv783Gi0vL390eb0qqm+/szvPNNMzNGIFRnUvA0SAzOwNAiLJmU4zHo8DCgAgZgAETtswyX4pk8lkehP0pywrUTV27JaNGyqrKgHgha1bT548WRYOMwDk1hrIna46gbTAUBBCUwcqAFw6frwuRCqV0nUdmFB1MCRtx9E0bWwkEresRDzu9/nm3Th/Vf3DoVAIAJqbmtauXZfv9WpCpBd7Dq00EOGkKdNylCi0EgkhxP4971ZUVJw8ceK2RXd0dX9ZUFCgCaFyYTtOrC/22CMrf/LjH3V0dvX1RSsjEVemUDU3NS1d9uAXHR2lpaVqV4+iMIJWXFKKiEpgCCAKxI6OjuLioutmziwoLBxTFn7r7Xei0WhKSsdxYvF4PJ649Zabn1m/DhC93vxgMKiKuGUlntm46bHHHz/T0xsqKdEEZpYKZ9caJIpXTJmWfuVDofpPBcAMKKLRXoHwl727x106HgAOHDiw5ZcvHD5ymBiCwcJFtbXLM21GQ0ODZVm90ej77/9t3779XV2dBcEifyCgIcLQyCMBMU6cNCX3wQIkqbOzY+LlE373+s6KSER97untdSy7tKx0wHD16tVPPvkkAIDQvV6fz+fNz/emXzyAYVS5yqSsqLh4UM8GwwAFmqZ54sSJXY2NJSUlkyZNAgDTNL1er/Jvb29/uL7+1y++VFQcKg2PCYVCfr/XND1C01QnnytydkDECVdcqdpqtXGGgcqulHTmy+54PH71VdNunD+/sqoSEaPRaEtzy569exO2UxQM5nm9ynpQgrIEPA8w42UTJ6dLEkNWUI0KMTu2E4v3xftiSccGAKHpnrw8v8/vyfPoug4Zv1xxRgOIoDNJQAEMmfo9HNT9DxFN03QbRrCwCNQjHAp1gVc2mQKbM86oAFCA0GDQnSEXqMcGwPQjmND1zGgEAFBmNOeNMzIQSZ0GXvJHuJedPXRkLhiN+2hAVxUdz77yXWDQUdMGFUa40DC4Y/ya5vz/BMEkmVm9dl94QPwvNJB+oilXgHEAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTYtMDItMTBUMjE6MDg6MzMtMDg6MDB4P0OtAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTAyLTEwVDIxOjA4OjMzLTA4OjAwCWL7EQAAAABJRU5ErkJggg=="
+}
+`
+
+var testAccSakuraCloudArchive_transfer = `
+resource "sakuracloud_archive" "source" {
+  name         = "{{ .arg0 }}"
+  size         = 20
+  archive_file = "test/dummy.raw"
+
+  zone = "is1a"
+}
+
+resource "sakuracloud_archive" "foobar" {
+  name        = "{{ .arg0 }}"
+  description = "description"
+  tags        = ["tag1", "tag2"]
+
+  source_archive_zone = sakuracloud_archive.source.zone
+  source_archive_id   = sakuracloud_archive.source.id 
+
+  zone = "is1b"
+}
+`
+
+var testAccSakuraCloudArchive_fromShared = `
+resource "sakuracloud_archive" "foobar" {
+  name        = "{{ .arg0 }}"
+  description = "description"
+  tags        = ["tag1", "tag2"]
+
+  source_shared_key = "{{ .arg1 }}"
 }
 `

--- a/sakuracloud/validators.go
+++ b/sakuracloud/validators.go
@@ -142,3 +142,18 @@ func validateCarrier(d resourceValueGettable) error {
 
 	return nil
 }
+
+func validateSourceSharedKey(v interface{}, k string) ([]string, []error) {
+	var ws []string
+	var errors []error
+
+	value := v.(string)
+	if value == "" {
+		return ws, errors
+	}
+	key := types.ArchiveShareKey(value)
+	if !key.ValidFormat() {
+		errors = append(errors, fmt.Errorf("%q must be formatted in '<ZONE>:<ID>:<TOKEN>'", k))
+	}
+	return ws, errors
+}

--- a/vendor/github.com/sacloud/ftps/client.go
+++ b/vendor/github.com/sacloud/ftps/client.go
@@ -3,6 +3,7 @@ package ftps
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,6 +39,11 @@ func (c *Client) Upload(filePath string) error {
 
 // UploadFile file to Server
 func (c *Client) UploadFile(remoteFilepath string, file *os.File) error {
+	return c.UploadReader(remoteFilepath, file)
+}
+
+// UploadFile file to Server
+func (c *Client) UploadReader(remoteFilepath string, source io.Reader) error {
 	rawClient := &FTPS{}
 	rawClient.TLSConfig.InsecureSkipVerify = true
 
@@ -51,7 +57,7 @@ func (c *Client) UploadFile(remoteFilepath string, file *os.File) error {
 		return fmt.Errorf("Auth FTP failed: %#v", err)
 	}
 
-	err = rawClient.StoreFile(remoteFilepath, file)
+	err = rawClient.StoreReader(remoteFilepath, source)
 	if err != nil {
 		return fmt.Errorf("Storefile FTP failed: %#v", err)
 	}

--- a/vendor/github.com/sacloud/ftps/ftps.go
+++ b/vendor/github.com/sacloud/ftps/ftps.go
@@ -299,6 +299,10 @@ func (ftps *FTPS) parseEntryLine(line string) (entry *Entry, err error) {
 }
 
 func (ftps *FTPS) StoreFile(remoteFilepath string, f *os.File) (err error) {
+	return ftps.StoreReader(remoteFilepath, f)
+}
+
+func (ftps *FTPS) StoreReader(remoteFilepath string, r io.Reader) (err error) {
 
 	dataConn, err := ftps.requestDataConn(fmt.Sprintf("STOR %s", remoteFilepath), 150)
 	if err != nil {
@@ -306,7 +310,7 @@ func (ftps *FTPS) StoreFile(remoteFilepath string, f *os.File) (err error) {
 	}
 	defer dataConn.Close()
 
-	_, err = io.Copy(dataConn, f)
+	_, err = io.Copy(dataConn, r)
 	if err != nil {
 		return
 	}
@@ -324,6 +328,10 @@ func (ftps *FTPS) StoreFile(remoteFilepath string, f *os.File) (err error) {
 }
 
 func (ftps *FTPS) RetrieveFile(remoteFilepath string, file *os.File) (err error) {
+	return ftps.RetrieveWriter(remoteFilepath, file)
+}
+
+func (ftps *FTPS) RetrieveWriter(remoteFilepath string, w io.Writer) (err error) {
 
 	dataConn, err := ftps.requestDataConn(fmt.Sprintf("RETR %s", remoteFilepath), 150)
 	if err != nil {
@@ -331,7 +339,7 @@ func (ftps *FTPS) RetrieveFile(remoteFilepath string, file *os.File) (err error)
 	}
 	defer dataConn.Close()
 
-	_, err = io.Copy(file, dataConn)
+	_, err = io.Copy(w, dataConn)
 	if err != nil {
 		return
 	}

--- a/vendor/github.com/sacloud/ftps/go.mod
+++ b/vendor/github.com/sacloud/ftps/go.mod
@@ -1,0 +1,3 @@
+module github.com/sacloud/ftps
+
+go 1.14

--- a/vendor/github.com/sacloud/libsacloud/v2/go.mod
+++ b/vendor/github.com/sacloud/libsacloud/v2/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/sacloud/ftps v1.0.0
 	github.com/stretchr/testify v1.2.2
 	github.com/uber-go/atomic v1.4.0 // indirect
 	go.uber.org/atomic v1.4.0 // indirect

--- a/vendor/github.com/sacloud/libsacloud/v2/go.sum
+++ b/vendor/github.com/sacloud/libsacloud/v2/go.sum
@@ -28,6 +28,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sacloud/ftps v1.0.0 h1:RFIOwGby8ZDqdSccA7Tm9kJdm9QVAxADvxmMINBGLZw=
+github.com/sacloud/ftps v1.0.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/uber-go/atomic v1.4.0 h1:yOuPqEq4ovnhEjpHmfFwsqBXDYbQeT6Nb0bwD6XnD5o=

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/api_client.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/api_client.go
@@ -12,7 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package libsacloud
+package archive
 
-// Version バージョン
-const Version = "2.4.1"
+import "github.com/sacloud/libsacloud/v2/sacloud"
+
+// APIClient builderが利用するAPIクライアント
+type APIClient struct {
+	Archive sacloud.ArchiveAPI
+	Zone    sacloud.ZoneAPI
+}
+
+// NewAPIClient builderが利用するAPIクライアントを返す
+func NewAPIClient(caller sacloud.APICaller) *APIClient {
+	return &APIClient{
+		Archive: sacloud.NewArchiveOp(caller),
+		Zone:    sacloud.NewZoneOp(caller),
+	}
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/blank_archive_builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/blank_archive_builder.go
@@ -1,0 +1,87 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/sacloud/ftps"
+	"github.com/sacloud/libsacloud/v2/pkg/size"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// BlankArchiveBuilder ブランクアーカイブの作成〜FTPSでのファイルアップロードを行う
+type BlankArchiveBuilder struct {
+	Name         string
+	Description  string
+	Tags         types.Tags
+	IconID       types.ID
+	SizeGB       int
+	SourceReader io.Reader
+
+	Client *APIClient
+}
+
+// Validate 設定値の検証
+func (b *BlankArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	requiredValues := map[string]bool{
+		"Name":         b.Name == "",
+		"SizeGB":       b.SizeGB == 0,
+		"SourceReader": b.SourceReader == nil,
+	}
+	for key, empty := range requiredValues {
+		if empty {
+			return fmt.Errorf("%s is required", key)
+		}
+	}
+	return nil
+}
+
+// Build ブランクアーカイブの作成〜FTPSでのファイルアップロードを行う
+func (b *BlankArchiveBuilder) Build(ctx context.Context, zone string) (*sacloud.Archive, error) {
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	archive, ftpServer, err := b.Client.Archive.CreateBlank(ctx, zone,
+		&sacloud.ArchiveCreateBlankRequest{
+			Name:        b.Name,
+			Description: b.Description,
+			Tags:        b.Tags,
+			IconID:      b.IconID,
+			SizeMB:      b.SizeGB * size.GiB,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	// upload sources via FTPS
+	ftpsClient := ftps.NewClient(ftpServer.User, ftpServer.Password, ftpServer.HostName)
+
+	if err := ftpsClient.UploadReader("data.raw", b.SourceReader); err != nil {
+		return archive, fmt.Errorf("uploading file via FTPS is failed: %s", err)
+	}
+
+	// close FTP
+	if err := b.Client.Archive.CloseFTP(ctx, zone, archive.ID); err != nil {
+		return archive, err
+	}
+
+	// reload
+	return b.Client.Archive.Read(ctx, zone, archive.ID)
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/director.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/director.go
@@ -1,0 +1,106 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"io"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// Builder アーカイブビルダーが持つ共通インターフェース
+type Builder interface {
+	Build(ctx context.Context, zone string) (*sacloud.Archive, error)
+	Validate(ctx context.Context, zone string) error
+}
+
+// Director パラメータに応じて適切なアーカイブビルダーを返す
+type Director struct {
+	Name        string
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+	SizeGB      int
+
+	// for blank builder
+	SourceReader io.Reader
+
+	// for standard builder
+	SourceDiskID    types.ID
+	SourceArchiveID types.ID
+
+	// transfer archive builder
+	SourceArchiveZone string
+
+	// for shared archive builder
+	SourceSharedKey types.ArchiveShareKey
+
+	Client *APIClient
+}
+
+// パラメータに応じて適切なアーカイブビルダーを返す
+//
+// Note: 他ゾーンからの転送の場合、転送元/先でゾーンが同一でもエラーとならない。
+// このためDirectorでは転送元/先ゾーンを意識せずにSourceArchiveZoneが指定されていた場合は
+// 一律でTransferArchiveBuilderを返す。
+//
+// もしこの挙動で問題が発生する場合は呼び出し側で適切にビルダーを切り替える実装を行う必要がある。
+func (d *Director) Builder() Builder {
+	if d.SourceReader != nil {
+		return &BlankArchiveBuilder{
+			Name:         d.Name,
+			Description:  d.Description,
+			Tags:         d.Tags,
+			IconID:       d.IconID,
+			SizeGB:       d.SizeGB,
+			SourceReader: d.SourceReader,
+			Client:       d.Client,
+		}
+	}
+	if d.SourceSharedKey.String() != "" {
+		return &FromSharedArchiveBuilder{
+			Name:            d.Name,
+			Description:     d.Description,
+			Tags:            d.Tags,
+			IconID:          d.IconID,
+			SourceSharedKey: d.SourceSharedKey,
+			Client:          d.Client,
+		}
+	}
+
+	if d.SourceArchiveZone != "" {
+		return &TransferArchiveBuilder{
+			Name:              d.Name,
+			Description:       d.Description,
+			Tags:              d.Tags,
+			IconID:            d.IconID,
+			SourceArchiveID:   d.SourceArchiveID,
+			SourceArchiveZone: d.SourceArchiveZone,
+			Client:            d.Client,
+		}
+	}
+
+	return &StandardArchiveBuilder{
+		Name:            d.Name,
+		Description:     d.Description,
+		Tags:            d.Tags,
+		IconID:          d.IconID,
+		SourceDiskID:    d.SourceDiskID,
+		SourceArchiveID: d.SourceArchiveID,
+		Client:          d.Client,
+	}
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/from_shared_archive_builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/from_shared_archive_builder.go
@@ -1,0 +1,86 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// FromSharedArchiveBuilder 共有アーカイブからアーカイブの作成を行う
+type FromSharedArchiveBuilder struct {
+	Name            string
+	Description     string
+	Tags            types.Tags
+	IconID          types.ID
+	SourceSharedKey types.ArchiveShareKey
+
+	Client *APIClient
+}
+
+// Validate 設定値の検証
+func (b *FromSharedArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	requiredValues := map[string]bool{
+		"Name":            b.Name == "",
+		"SourceSharedKey": b.SourceSharedKey == "",
+	}
+	for key, empty := range requiredValues {
+		if empty {
+			return fmt.Errorf("%s is required", key)
+		}
+	}
+	if !b.SourceSharedKey.ValidFormat() {
+		return fmt.Errorf("archive shared key is invalid format: key:%q", b.SourceSharedKey)
+	}
+	return nil
+}
+
+// Build 共有アーカイブからアーカイブの作成を行う
+func (b *FromSharedArchiveBuilder) Build(ctx context.Context, zone string) (*sacloud.Archive, error) {
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	zoneID, err := query.ZoneIDFromName(ctx, b.Client.Zone, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	archive, err := b.Client.Archive.CreateFromShared(ctx, b.SourceSharedKey.Zone(), b.SourceSharedKey.SourceArchiveID(), zoneID,
+		&sacloud.ArchiveCreateRequestFromShared{
+			Name:            b.Name,
+			Description:     b.Description,
+			Tags:            b.Tags,
+			IconID:          b.IconID,
+			SourceSharedKey: b.SourceSharedKey,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	lastState, err := sacloud.WaiterForReady(func() (interface{}, error) {
+		return b.Client.Archive.Read(ctx, zone, archive.ID)
+	}).WaitForState(ctx)
+
+	var ret *sacloud.Archive
+	if lastState != nil {
+		ret = lastState.(*sacloud.Archive)
+	}
+	return ret, err
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/standard_archive_builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/standard_archive_builder.go
@@ -1,0 +1,79 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// StandardArchiveBuilder 同一アカウント/同一ゾーンのディスク/アーカイブからアーカイブの作成を行う
+type StandardArchiveBuilder struct {
+	Name            string
+	Description     string
+	Tags            types.Tags
+	IconID          types.ID
+	SourceDiskID    types.ID
+	SourceArchiveID types.ID
+
+	Client *APIClient
+}
+
+// Validate 設定値の検証
+func (b *StandardArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	requiredValues := map[string]bool{
+		"Name":                            b.Name == "",
+		"SourceDiskID or SourceArchiveID": b.SourceArchiveID.IsEmpty() && b.SourceDiskID.IsEmpty(),
+	}
+	for key, empty := range requiredValues {
+		if empty {
+			return fmt.Errorf("%s is required", key)
+		}
+	}
+	return nil
+}
+
+// Build 同一アカウント/同一ゾーンのディスク/アーカイブからアーカイブの作成を行う
+func (b *StandardArchiveBuilder) Build(ctx context.Context, zone string) (*sacloud.Archive, error) {
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	archive, err := b.Client.Archive.Create(ctx, zone,
+		&sacloud.ArchiveCreateRequest{
+			Name:            b.Name,
+			Description:     b.Description,
+			Tags:            b.Tags,
+			IconID:          b.IconID,
+			SourceDiskID:    b.SourceDiskID,
+			SourceArchiveID: b.SourceArchiveID,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	lastState, err := sacloud.WaiterForReady(func() (interface{}, error) {
+		return b.Client.Archive.Read(ctx, zone, archive.ID)
+	}).WaitForState(ctx)
+
+	var ret *sacloud.Archive
+	if lastState != nil {
+		ret = lastState.(*sacloud.Archive)
+	}
+	return ret, err
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/transfer_archive_builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/transfer_archive_builder.go
@@ -1,0 +1,91 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// TransferArchiveBuilder 共有アーカイブからアーカイブの作成を行う
+type TransferArchiveBuilder struct {
+	Name        string
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+
+	SourceArchiveID   types.ID
+	SourceArchiveZone string
+
+	Client *APIClient
+}
+
+// Validate 設定値の検証
+func (b *TransferArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	requiredValues := map[string]bool{
+		"Name":              b.Name == "",
+		"SourceArchiveID":   b.SourceArchiveID.IsEmpty(),
+		"SourceArchiveZone": b.SourceArchiveZone == "",
+	}
+	for key, empty := range requiredValues {
+		if empty {
+			return fmt.Errorf("%s is required", key)
+		}
+	}
+	return nil
+}
+
+// Build 他ゾーンのアーカイブからアーカイブの作成を行う
+func (b *TransferArchiveBuilder) Build(ctx context.Context, zone string) (*sacloud.Archive, error) {
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	zoneID, err := query.ZoneIDFromName(ctx, b.Client.Zone, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceInfo, err := b.Client.Archive.Read(ctx, b.SourceArchiveZone, b.SourceArchiveID)
+	if err != nil {
+		return nil, err
+	}
+
+	archive, err := b.Client.Archive.Transfer(ctx, b.SourceArchiveZone, b.SourceArchiveID, zoneID,
+		&sacloud.ArchiveTransferRequest{
+			Name:        b.Name,
+			Description: b.Description,
+			Tags:        b.Tags,
+			IconID:      b.IconID,
+			SizeMB:      sourceInfo.SizeMB,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	lastState, err := sacloud.WaiterForReady(func() (interface{}, error) {
+		return b.Client.Archive.Read(ctx, zone, archive.ID)
+	}).WaitForState(ctx)
+
+	var ret *sacloud.Archive
+	if lastState != nil {
+		ret = lastState.(*sacloud.Archive)
+	}
+	return ret, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -238,13 +238,13 @@ github.com/posener/complete
 github.com/posener/complete/cmd
 github.com/posener/complete/cmd/install
 github.com/posener/complete/match
-# github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
+# github.com/sacloud/ftps v1.0.0
 ## explicit
 github.com/sacloud/ftps
 # github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 ## explicit
 github.com/sacloud/iso9660wrap
-# github.com/sacloud/libsacloud/v2 v2.3.0
+# github.com/sacloud/libsacloud/v2 v2.4.1
 ## explicit
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/pkg/cidr
@@ -262,6 +262,7 @@ github.com/sacloud/libsacloud/v2/sacloud/search/keys
 github.com/sacloud/libsacloud/v2/sacloud/trace
 github.com/sacloud/libsacloud/v2/sacloud/types
 github.com/sacloud/libsacloud/v2/utils/builder
+github.com/sacloud/libsacloud/v2/utils/builder/archive
 github.com/sacloud/libsacloud/v2/utils/builder/database
 github.com/sacloud/libsacloud/v2/utils/builder/disk
 github.com/sacloud/libsacloud/v2/utils/builder/internet

--- a/website/docs/r/archive.md
+++ b/website/docs/r/archive.md
@@ -13,6 +13,28 @@ Manages a SakuraCloud Archive.
 ## Example Usage
 
 ```hcl
+# from archive/disk
+resource "sakuracloud_archive" "from-archive-or-disk" {
+  name         = "foobar"
+  description  = "description"
+  tags         = ["tag1", "tag2"]
+
+  source_archive_id   = 123456789012
+  source_archive_zone = "tk1a"
+  # source_disk_id    = 123456789012
+}
+
+# from shared archive
+resource "sakuracloud_archive" "from-shared-archive" {
+  name         = "foobar"
+  description  = "description"
+  tags         = ["tag1", "tag2"]
+
+  source_shared_key = "is1a:123456789012:xxx"
+}
+
+
+# from local file
 resource "sakuracloud_archive" "foobar" {
   name         = "foobar"
   description  = "description"
@@ -25,10 +47,14 @@ resource "sakuracloud_archive" "foobar" {
 ## Argument Reference
 
 * `name` - (Required) The name of the archive. The length of this value must be in the range [`1`-`64`].
-* `archive_file` - (Required) The file path to upload to the SakuraCloud.
+* `archive_file` - (Optional) The file path to upload to the SakuraCloud.
 * `description` - (Optional) The description of the archive. The length of this value must be in the range [`1`-`512`].
-* `hash` - (Optional) The md5 checksum calculated from the base64 encoded file body.
+* `hash` - (Optional) The md5 checksum calculated from the base64 encoded file body. Changing this forces a new resource to be created.
 * `size` - (Optional) The size of archive in GiB. This must be one of [`20`/`40`/`60`/`80`/`100`/`250`/`500`/`750`/`1024`]. Changing this forces a new resource to be created. Default:`20`.
+* `source_archive_id` - (Optional) The id of the source archive. This conflicts with [`source_disk_id`]. Changing this forces a new resource to be created.
+* `source_archive_zone` - (Optional) The share key of source shared archive. Changing this forces a new resource to be created.
+* `source_disk_id` - (Optional) The id of the source disk. This conflicts with [`source_archive_id`]. Changing this forces a new resource to be created.
+* `source_shared_key` - (Optional) The share key of source shared archive. Changing this forces a new resource to be created.
 
 #### Common Arguments
 


### PR DESCRIPTION
sakuracloud_archiveリソースではローカルファイルのアップロードによるアーカイブ作成のみをサポートしていたが、このPRで以下3つの方法でのアーカイブ作成もサポートする。

- 同一アカウント/同一ゾーンのディスク/アーカイブからの作成
- 他ゾーンからの転送作成
- アーカイブ共有からの作成

#### 同一アカウント/同一ゾーンのディスク/アーカイブからの作成

```hcl
resource "sakuracloud_archive" "from-transferred-archive" {
  name = "foobar"

  source_archive_id   = 123456789012 # コピー元アーカイブのID

  # または
  # source_disk_id = 123456789012
}

```

#### 他ゾーンからの転送

```hcl
resource "sakuracloud_archive" "from-transferred-archive" {
  name = "foobar"

  source_archive_id   = 123456789012 # コピー元アーカイブのID
  source_archive_zone = "tk1a"       # コピー元アーカイブの属するゾーン名   
}
```

#### アーカイブ共有キーを指定して作成

```hcl
resource "sakuracloud_archive" "from-shared-archive" {
  name = "foobar"

  source_shared_key = "is1a:123456789012:xxx" # アーカイブ共有キー
}

```