### PR TITLE
Add resource: sakuracloud_archive_share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES
 
+* Add sakuracloud_archive_share resource [GH-728] (@yamamoto-febc)
 * Supports transferred/shared archives [GH-727] (@yamamoto-febc)
     * libsacloud v2.4.1
 

--- a/examples/website/r/archive_share/archive_share.tf
+++ b/examples/website/r/archive_share/archive_share.tf
@@ -1,0 +1,9 @@
+resource "sakuracloud_archive" "source" {
+  name         = "foobar"
+  size         = 20
+  archive_file = "test/dummy.raw"
+}
+
+resource "sakuracloud_archive_share" "share_info" {
+  archive_id = sakuracloud_archive.source.id
+}

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -164,6 +164,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"sakuracloud_auto_backup":           resourceSakuraCloudAutoBackup(),
 			"sakuracloud_archive":               resourceSakuraCloudArchive(),
+			"sakuracloud_archive_share":         resourceSakuraCloudArchiveShare(),
 			"sakuracloud_bridge":                resourceSakuraCloudBridge(),
 			"sakuracloud_bucket_object":         resourceSakuraCloudBucketObject(),
 			"sakuracloud_cdrom":                 resourceSakuraCloudCDROM(),

--- a/sakuracloud/resource_sakuracloud_archive_share.go
+++ b/sakuracloud/resource_sakuracloud_archive_share.go
@@ -1,0 +1,146 @@
+// Copyright 2016-2020 terraform-provider-sakuracloud authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sakuracloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+func resourceSakuraCloudArchiveShare() *schema.Resource {
+	resourceName := "ArchiveShare"
+
+	return &schema.Resource{
+		Create: resourceSakuraCloudArchiveShareCreate,
+		Read:   resourceSakuraCloudArchiveShareRead,
+		Delete: resourceSakuraCloudArchiveShareDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"archive_id": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateSakuracloudIDType,
+				Description:  "The id of the archive",
+			},
+			"share_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The key to use sharing the Archive",
+			},
+			"zone": schemaResourceZone(resourceName),
+		},
+	}
+}
+
+func resourceSakuraCloudArchiveShareCreate(d *schema.ResourceData, meta interface{}) error {
+	client, zone, err := sakuraCloudClient(d, meta)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := operationContext(d, schema.TimeoutCreate)
+	defer cancel()
+
+	archiveOp := sacloud.NewArchiveOp(client)
+	archiveID := expandSakuraCloudID(d, "archive_id")
+
+	archive, err := archiveOp.Read(ctx, zone, archiveID)
+	if err != nil {
+		return fmt.Errorf("sharing SakuraCloud Archive is failed: %s", err)
+	}
+
+	// share
+	shareInfo, err := archiveOp.Share(ctx, zone, archiveID)
+	if err != nil {
+		return fmt.Errorf("sharing SakuraCloud Archive is failed: %s", err)
+	}
+
+	d.SetId(archive.ID.String())
+	d.Set("share_key", shareInfo.SharedKey)
+	d.Set("zone", zone)
+	return nil
+}
+
+func resourceSakuraCloudArchiveShareRead(d *schema.ResourceData, meta interface{}) error {
+	client, zone, err := sakuraCloudClient(d, meta)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := operationContext(d, schema.TimeoutRead)
+	defer cancel()
+
+	archiveOp := sacloud.NewArchiveOp(client)
+
+	archive, err := archiveOp.Read(ctx, zone, sakuraCloudID(d.Id()))
+	if err != nil {
+		if sacloud.IsNotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("could not read SakuraCloud Archive[%s]: %s", d.Id(), err)
+	}
+
+	if !archive.Availability.IsUploading() {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(archive.ID.String())
+	d.Set("share_key", d.Get("share_key").(string))
+	d.Set("zone", zone)
+	return nil
+}
+
+func resourceSakuraCloudArchiveShareDelete(d *schema.ResourceData, meta interface{}) error {
+	client, zone, err := sakuraCloudClient(d, meta)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := operationContext(d, schema.TimeoutDelete)
+	defer cancel()
+
+	archiveOp := sacloud.NewArchiveOp(client)
+
+	archive, err := archiveOp.Read(ctx, zone, sakuraCloudID(d.Id()))
+	if err != nil {
+		if sacloud.IsNotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("could not read SakuraCloud Archive[%s]: %s", d.Id(), err)
+	}
+
+	if !archive.Availability.IsUploading() {
+		d.SetId("")
+		return nil
+	}
+
+	if err := archiveOp.CloseFTP(ctx, zone, archive.ID); err != nil {
+		return fmt.Errorf("deleting SakuraCloud Archive Share[%s] is failed: %s", archive.ID, err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/sakuracloud/resource_sakuracloud_archive_share_test.go
+++ b/sakuracloud/resource_sakuracloud_archive_share_test.go
@@ -1,0 +1,87 @@
+// Copyright 2016-2020 terraform-provider-sakuracloud authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sakuracloud
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+func TestAccSakuraCloudArchiveShare_basic(t *testing.T) {
+	skipIfFakeModeEnabled(t)
+
+	resourceName := "sakuracloud_archive_share.foobar"
+	rand := randomName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraCloudArchiveDestroy,
+			testCheckSakuraCloudArchiveShareDestroy,
+			testCheckSakuraCloudIconDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: buildConfigWithArgs(testAccSakuraCloudArchiveShare_basic, rand),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "share_key"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckSakuraCloudArchiveShareDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*APIClient)
+	archiveOp := sacloud.NewArchiveOp(client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sakuracloud_archive" {
+			continue
+		}
+		if rs.Primary.ID == "" {
+			continue
+		}
+
+		zone := rs.Primary.Attributes["zone"]
+		archive, err := archiveOp.Read(context.Background(), zone, sakuraCloudID(rs.Primary.ID))
+		if err == nil && archive != nil && archive.Availability.IsUploading() {
+			return fmt.Errorf("archive[%s] still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+var testAccSakuraCloudArchiveShare_basic = `
+resource "sakuracloud_archive" "foobar" {
+  name        = "{{ .arg0 }}"
+  description = "description"
+  tags        = ["tag1", "tag2"]
+
+  size         = 20
+  archive_file = "test/dummy.raw"
+}
+
+resource "sakuracloud_archive_share" "foobar" {
+  archive_id = sakuracloud_archive.foobar.id
+}
+`

--- a/tools/tfdocgen/cmd/gen-sakuracloud-docs/main.go
+++ b/tools/tfdocgen/cmd/gen-sakuracloud-docs/main.go
@@ -100,6 +100,10 @@ var definitions = map[string]definition{
 		displayName: "Archive",
 		category:    CategoryStorage,
 	},
+	"sakuracloud_archive_share": {
+		displayName: "Archive",
+		category:    CategoryStorage,
+	},
 	"sakuracloud_auto_backup": {
 		displayName: "Auto Backup",
 		category:    CategoryAppliance,

--- a/website/docs/r/archive_share.md
+++ b/website/docs/r/archive_share.md
@@ -1,0 +1,43 @@
+---
+layout: "sakuracloud"
+page_title: "SakuraCloud: sakuracloud_archive_share"
+subcategory: "Storage"
+description: |-
+  Manages a SakuraCloud Archive Sharing.
+---
+
+# sakuracloud_archive_share
+
+Manages a SakuraCloud Archive Sharing.
+
+## Example Usage
+
+```hcl
+resource "sakuracloud_archive" "source" {
+  name         = "foobar"
+  size         = 20
+  archive_file = "test/dummy.raw"
+}
+
+resource "sakuracloud_archive_share" "share_info" {
+  archive_id = sakuracloud_archive.source.id
+}
+```
+## Argument Reference
+
+* `archive_id` - (Required) The id of the archive. Changing this forces a new resource to be created.
+* `zone` - (Optional) The name of zone that the ArchiveShare will be created (e.g. `is1a`, `tk1a`). Changing this forces a new resource to be created.
+
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 5 minutes) Used when creating the Archive
+* `update` - (Defaults to 5 minutes) Used when updating the Archive
+* `delete` - (Defaults to 5 minutes) Used when deleting Archive
+
+## Attribute Reference
+
+* `id` - The id of the Archive.
+* `share_key` - The key to use sharing the Archive.
+

--- a/website/sakuracloud.erb
+++ b/website/sakuracloud.erb
@@ -83,6 +83,9 @@
                   <a href="/docs/providers/sakuracloud/r/archive.html">sakuracloud_archive</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/sakuracloud/r/archive_share.html">sakuracloud_archive_share</a>
+                </li>
+                <li>
                   <a href="/docs/providers/sakuracloud/r/cdrom.html">sakuracloud_cdrom</a>
                 </li>
                 <li>


### PR DESCRIPTION
アーカイブ共有を有効化するためのリソース`sakuracloud_archive_share`を追加する。

```tf
resource "sakuracloud_archive_share" "share_info" {
  archive_id = sakuracloud_archive.source.id
}

output "shared_key" {
  value = sakuracloud_archive_share.share_info.share_key
}
```

このリソースはimport/updateをサポートしない。

またコントロールパネルなどから手動で再共有などを行なって共有キーが変化した場合については検知しない。この場合は必要に応じてtaintなどでリソース再作成で対応する。