### PR TITLE
Modify how to determine whether to pass disk_edit_parameter to ServerBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.3.1 (Unreleased)
 
+FIXES
+
+* Modify how to determine whether to pass disk_edit_parameter to ServerBuilder [GH-737] (@yamamoto-febc)
+
 MISC
 
 * Fix broken CI - install golangci-lint via install script [GH-735] (@yamamoto-febc)

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -439,7 +439,3 @@ func setServerResourceData(ctx context.Context, d *schema.ResourceData, client *
 	d.Set("zone", zone) // nolint
 	return d.Set("tags", flattenTags(data.Tags))
 }
-
-func isServerDiskConfigChanged(d *schema.ResourceData) bool {
-	return d.HasChanges("disks", "network_interface", "disk_edit_parameter")
-}

--- a/sakuracloud/structure.go
+++ b/sakuracloud/structure.go
@@ -33,6 +33,11 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
+type resourceValueChangeHandler interface {
+	HasChanges(keys ...string) bool
+	GetChange(key string) (interface{}, interface{})
+}
+
 type resourceValueGettable interface {
 	Get(key string) interface{}
 	GetOk(key string) (interface{}, bool)

--- a/sakuracloud/structure_server_test.go
+++ b/sakuracloud/structure_server_test.go
@@ -1,0 +1,346 @@
+// Copyright 2016-2020 terraform-provider-sakuracloud authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sakuracloud
+
+import (
+	"reflect"
+	"testing"
+)
+
+type dummyResourceValueChangeHandler struct {
+	oldState resourceValueGettable
+	newState resourceValueGettable
+}
+
+func (d *dummyResourceValueChangeHandler) HasChanges(keys ...string) bool {
+	for _, key := range keys {
+		old := d.oldState.Get(key)
+		new := d.newState.Get(key)
+		if !reflect.DeepEqual(old, new) {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *dummyResourceValueChangeHandler) GetChange(key string) (interface{}, interface{}) {
+	return d.oldState.Get(key), d.newState.Get(key)
+}
+
+func TestStructureServer_isDiskEditParameterChanged(t *testing.T) {
+	cases := []struct {
+		msg    string
+		in     *dummyResourceValueChangeHandler
+		expect bool
+	}{
+		{
+			msg: "nil",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{},
+				newState: &resourceMapValue{},
+			},
+			expect: false,
+		},
+		{
+			msg: "added: disks",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{},
+				newState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			msg: "added: disk_edit_parameter",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{},
+				newState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{},
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			msg: "added: network_interface",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{},
+				newState: &resourceMapValue{
+					value: map[string]interface{}{
+						"network_interface": []interface{}{
+							map[string]interface{}{},
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			msg: "updated: no changes",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{
+								"password": "password",
+							},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "shared",
+							},
+						},
+					},
+				},
+				newState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{
+								"password": "password",
+							},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "shared",
+							},
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			msg: "updated: disks",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{
+								"password": "password",
+							},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "shared",
+							},
+						},
+					},
+				},
+				newState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"2"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{
+								"password": "password",
+							},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "shared",
+							},
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			msg: "updated: disk_edit_parameter",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{
+								"password": "password",
+							},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "shared",
+							},
+						},
+					},
+				},
+				newState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{
+								"password": "password-upd",
+							},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "shared",
+							},
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			msg: "updated: network_interface.upstream",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{
+								"password": "password",
+							},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "1",
+							},
+						},
+					},
+				},
+				newState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{
+								"password": "password",
+							},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "2",
+							},
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			msg: "updated: network_interface.other",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{
+								"password": "password",
+							},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream":         "1",
+								"user_ip_address":  "192.168.0.1",
+								"packet_filter_id": "1",
+							},
+						},
+					},
+				},
+				newState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{
+								"password": "password",
+							},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream":         "1",
+								"user_ip_address":  "192.168.0.2",
+								"packet_filter_id": "2",
+							},
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			msg: "deleted: disks",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "shared",
+							},
+						},
+					},
+				},
+				newState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "shared",
+							},
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			msg: "deleted: network_interface",
+			in: &dummyResourceValueChangeHandler{
+				oldState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{},
+						},
+						"network_interface": []interface{}{
+							map[string]interface{}{
+								"upstream": "shared",
+							},
+						},
+					},
+				},
+				newState: &resourceMapValue{
+					value: map[string]interface{}{
+						"disks": []interface{}{"1"},
+						"disk_edit_parameter": []interface{}{
+							map[string]interface{}{},
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+	}
+
+	for _, tc := range cases {
+		got := isDiskEditParameterChanged(tc.in)
+		if got != tc.expect {
+			t.Fatalf("got unexpected state: pattern: %s expected: %t actual: %t", tc.msg, tc.expect, got)
+		}
+	}
+}


### PR DESCRIPTION
closes #736 

sakuracloud_serverでのUpdate時に以下がtrueを返した場合にディスクの修正パラメータをlibsacloudのServerBuilderに渡していた。

```go
func isServerDiskConfigChanged(d *schema.ResourceData) bool {		
	return d.HasChanges("disks", "network_interface", "disk_edit_parameter")		
}
```

しかし、libsacloudのServerBuilderでは更新時にディスクの修正パラメータを受け取ると一旦シャットダウンする実装となっているため、呼び出し側で変更に応じて渡す/渡さないを判定する必要があった。

このため既存の実装では`network_interface.user_ip_address`や`network_interface.packet_filter_id`などの再起動が不要な項目の変更でも再起動されてしまっていた。
このPRでは上記の判定部分を修正し、~ディスクの修正パラメータ `disk_edit_parameter`が変更された場合にのみパラメータをServerBuilderに渡すようにする。~

** UPDATE** 以下の場合にパラメータをServerBuilderに渡すようにする。

- `disks`が変更された場合
- `network_interface`が追加/削除された場合
- `network_interface`の`upstream`が変更された場合
- `disk_edit_parameter`が変更された場合

この場合、`disk_edit_parameter`が削除された場合にもパラメータが渡されてしまうが、現実的ではないケースなため考慮しない。