### PR TITLE
Update release scripts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,34 +1,39 @@
 name: Release
+
 on:
   push:
     tags: 'v[0-9]+.[0-9]+.[0-9]+'
+
 env:
   GOPROXY: https://proxy.golang.org
+
 jobs:
-  build:
-    name: build
-    runs-on: ubuntu-18.04
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  goreleaser:
+    runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.14
 
-      - name: Set up Go environemnt variables
-        run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v1
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: Setup tools
-        run: make tools
-
-      - name: make build-x
-        run: make build-x
-
-      - name: make release
-        run: make release
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,51 +3,6 @@ on: [push, pull_request]
 env:
   GOPROXY: https://proxy.golang.org
 jobs:
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-
-      - name: Set up Go environemnt variables
-        run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
-        shell: bash
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: Setup tools
-        run: make tools
-
-      - name: make lint
-        run: make lint
-  tflint:
-    name: tflint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-
-      - name: Set up Go environemnt variables
-        run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: Setup tools
-        run: make tools
-
-      - name: make tflint
-        run: make tflint
   test:
     name: test
     runs-on: ${{ matrix.os }}
@@ -55,18 +10,16 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-18.04]
     steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13
-
-      - name: Set up Go environemnt variables
-        run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+          go-version: 1.14
 
       - name: Setup tools
         run: make tools

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -27,7 +27,7 @@ export GO111MODULE=on
 default: fmt goimports set-license lint tflint docscheck
 
 clean:
-	rm -Rf $(CURDIR)/bin/*
+	rm -f $(CURDIR)/terraform-provider-sakuracloud
 
 .PHONY: tools
 tools:
@@ -35,10 +35,10 @@ tools:
 	GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 	GO111MODULE=off go get github.com/sacloud/addlicense
 	GO111MODULE=off go get github.com/tcnksm/ghr
-	GO111MODULE=on go install github.com/bflad/tfproviderdocs
-	GO111MODULE=on go install github.com/bflad/tfproviderlint/cmd/tfproviderlint
-	GO111MODULE=on go install github.com/client9/misspell/cmd/misspell
-	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint
+	GO111MODULE=off go get github.com/bflad/tfproviderdocs
+	GO111MODULE=off go get github.com/bflad/tfproviderlint/cmd/tfproviderlintx
+	GO111MODULE=off go get github.com/client9/misspell/cmd/misspell
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.24.0
 
 
 .PHONY: build-envs
@@ -50,45 +50,15 @@ build-envs:
 
 .PHONY: build
 build: build-envs
-	OS=$${OS:-"`go env GOOS`"} ARCH=$${ARCH:-"`go env GOARCH`"} BUILD_LDFLAGS=$(BUILD_LDFLAGS) CURRENT_VERSION=$(CURRENT_VERSION) sh -c "'$(CURDIR)/scripts/build.sh'"
-
-.PHONY: build-x
-build-x: build-envs build-darwin build-windows build-linux shasum
-
-.PHONY: build-darwin
-build-darwin: build-envs bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_darwin-386.zip bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_darwin-amd64.zip
-
-.PHONY: build-windows
-build-windows: build-envs bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_windows-386.zip bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_windows-amd64.zip
-
-.PHONY: build-linux
-build-linux: build-envs bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_linux-386.zip bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_linux-amd64.zip
-
-bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_darwin-386.zip: build-envs
-	OS="darwin"  ARCH="386"   ARCHIVE=1 BUILD_LDFLAGS=$(BUILD_LDFLAGS) CURRENT_VERSION=$(CURRENT_VERSION) sh -c "'$(CURDIR)/scripts/build.sh'"
-
-bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_darwin-amd64.zip: build-envs
-	OS="darwin"  ARCH="amd64" ARCHIVE=1 BUILD_LDFLAGS=$(BUILD_LDFLAGS) CURRENT_VERSION=$(CURRENT_VERSION) sh -c "'$(CURDIR)/scripts/build.sh'"
-
-bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_windows-386.zip: build-envs
-	OS="windows" ARCH="386"   ARCHIVE=1 BUILD_LDFLAGS=$(BUILD_LDFLAGS) CURRENT_VERSION=$(CURRENT_VERSION) sh -c "'$(CURDIR)/scripts/build.sh'"
-
-bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_windows-amd64.zip: build-envs
-	OS="windows" ARCH="amd64" ARCHIVE=1 BUILD_LDFLAGS=$(BUILD_LDFLAGS) CURRENT_VERSION=$(CURRENT_VERSION) sh -c "'$(CURDIR)/scripts/build.sh'"
-
-bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_linux-386.zip: build-envs
-	OS="linux"   ARCH="386"   ARCHIVE=1 BUILD_LDFLAGS=$(BUILD_LDFLAGS) CURRENT_VERSION=$(CURRENT_VERSION) sh -c "'$(CURDIR)/scripts/build.sh'"
-
-bin/terraform-provider-sakuracloud_$(CURRENT_VERSION)_linux-amd64.zip: build-envs
-	OS="linux"   ARCH="amd64" ARCHIVE=1 BUILD_LDFLAGS=$(BUILD_LDFLAGS) CURRENT_VERSION=$(CURRENT_VERSION) sh -c "'$(CURDIR)/scripts/build.sh'"
+	GOOS=$${OS:-"`go env GOOS`"} GOARCH=$${ARCH:-"`go env GOARCH`"} CGO_ENABLED=0 go build -ldflags=$(BUILD_LDFLAGS)
 
 .PHONY: shasum
 shasum:
 	(cd bin/; shasum -a 256 * > terraform-provider-sakuracloud_$(CURRENT_VERSION)_SHA256SUMS)
 
-.PHONY: release
-release: build-envs
-	ghr v${CURRENT_VERSION} bin/
+# .PHONY: release
+# release: build-envs
+# 	goreleaser release --rm-dist
 
 .PHONY: test
 test:


### PR DESCRIPTION
v1のリリーススクリプトを更新し、Terraform Registryへ公開可能にする。

Note: 

- v1はドキュメント類がTerraform Registryに対応していない。必要に応じて別途対応する。
- v1では今のところCI時のlint/tflintを行わない。v1のメンテナンス期間が延びるようであれば(要望が多いようであれば)再検討する。