### PR TITLE
Add default_zone to provider config

### DIFF
--- a/sakuracloud/config.go
+++ b/sakuracloud/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	AccessTokenSecret   string
 	Zone                string
 	Zones               []string
+	DefaultZone         string
 	TraceMode           string
 	FakeMode            string
 	FakeStorePath       string
@@ -117,6 +118,9 @@ func (c *Config) loadFromProfile() error {
 	sort.Strings(pcv.Zones)
 	if reflect.DeepEqual(defaultZones, c.Zones) && !reflect.DeepEqual(c.Zones, pcv.Zones) && len(pcv.Zones) > 0 {
 		c.Zones = pcv.Zones
+	}
+	if c.DefaultZone != "" {
+		sacloud.APIDefaultZone = c.DefaultZone
 	}
 	if c.TraceMode == "" {
 		c.TraceMode = pcv.TraceMode

--- a/sakuracloud/provider.go
+++ b/sakuracloud/provider.go
@@ -65,6 +65,12 @@ func Provider() terraform.ResourceProvider {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "A list of available SakuraCloud zone name. It can also be sourced via a shared credentials file if `profile` is specified. Default:[`is1a`, `is1b`, `tk1a`, `tk1v`]",
 			},
+			"default_zone": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SAKURACLOUD_DEFAULT_ZONE"}, nil),
+				Description: "The name of zone to use as default for global resources. It must be provided, but it can also be sourced from the `SAKURACLOUD_DEFAULT_ZONE` environment variables, or via a shared credentials file if `profile` is specified",
+			},
 			"accept_language": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -220,6 +226,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		AccessTokenSecret:   d.Get("secret").(string),
 		Zone:                d.Get("zone").(string),
 		Zones:               expandStringList(d.Get("zones").([]interface{})),
+		DefaultZone:         d.Get("default_zone").(string),
 		TraceMode:           d.Get("trace").(string),
 		APIRootURL:          d.Get("api_root_url").(string),
 		RetryMax:            d.Get("retry_max").(int),


### PR DESCRIPTION
グローバルリソースなどで利用される、libsacloudの `sacloud.APIDefaultZone` をprovider設定(`default_zone`)または環境変数(`SAKURACLOUD_DEFAULT_ZONE`)で変更できるようにしました。

libsacloudの `sacloud.APIDefaultZone`: https://github.com/sacloud/libsacloud/blob/1b60a85db3c5dad6ab84287daaa1529c267041ac/v2/sacloud/client.go#L42-L43