### PR TITLE
Added support for parameters blocks in sakuracloud_database

### DIFF
--- a/examples/website/r/database/database.tf
+++ b/examples/website/r/database/database.tf
@@ -25,6 +25,10 @@ resource "sakuracloud_database" "foobar" {
     weekdays = ["mon", "tue"]
   }
 
+  parameters = {
+    max_connections = 100
+  }
+
   name        = "foobar"
   description = "description"
   tags        = ["tag1", "tag2"]

--- a/sakuracloud/data_source_sakuracloud_database.go
+++ b/sakuracloud/data_source_sakuracloud_database.go
@@ -99,6 +99,14 @@ func dataSourceSakuraCloudDatabase() *schema.Resource {
 					},
 				},
 			},
+			"parameters": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed:    true,
+				Description: "The map for setting RDMBS-specific parameters. Valid keys can be found with the `usacloud database list-parameters` command",
+			},
 			"icon_id":     schemaDataSourceIconID(resourceName),
 			"description": schemaDataSourceDescription(resourceName),
 			"tags":        schemaDataSourceTags(resourceName),
@@ -132,5 +140,5 @@ func dataSourceSakuraCloudDatabaseRead(d *schema.ResourceData, meta interface{})
 
 	targets := res.Databases
 	d.SetId(targets[0].ID.String())
-	return setDatabaseResourceData(ctx, d, client, targets[0])
+	return setDatabaseResourceData(ctx, d, client, targets[0], zone)
 }

--- a/sakuracloud/data_source_sakuracloud_database.go
+++ b/sakuracloud/data_source_sakuracloud_database.go
@@ -105,7 +105,7 @@ func dataSourceSakuraCloudDatabase() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Computed:    true,
-				Description: "The map for setting RDMBS-specific parameters. Valid keys can be found with the `usacloud database list-parameters` command",
+				Description: "The map for setting RDBMS-specific parameters. Valid keys can be found with the `usacloud database list-parameters` command",
 			},
 			"icon_id":     schemaDataSourceIconID(resourceName),
 			"description": schemaDataSourceDescription(resourceName),

--- a/sakuracloud/resource_sakuracloud_database.go
+++ b/sakuracloud/resource_sakuracloud_database.go
@@ -167,7 +167,7 @@ func resourceSakuraCloudDatabase() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Optional:    true,
-				Description: "The map for setting RDMBS-specific parameters. Valid keys can be found with the `usacloud database list-parameters` command",
+				Description: "The map for setting RDBMS-specific parameters. Valid keys can be found with the `usacloud database list-parameters` command",
 			},
 			"icon_id":     schemaResourceIconID(resourceName),
 			"description": schemaResourceDescription(resourceName),

--- a/sakuracloud/resource_sakuracloud_database_test.go
+++ b/sakuracloud/resource_sakuracloud_database_test.go
@@ -68,6 +68,9 @@ func TestAccSakuraCloudDatabase_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "backup.0.weekdays.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "backup.0.weekdays.4146182742", "mon"),
 					resource.TestCheckResourceAttr(resourceName, "backup.0.weekdays.3274244602", "tue"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.max_connections", "100"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.event_scheduler", "ON"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -99,6 +102,8 @@ func TestAccSakuraCloudDatabase_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "backup.0.weekdays.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "backup.0.weekdays.1370803959", "sun"),
 					resource.TestCheckResourceAttr(resourceName, "backup.0.weekdays.2188959960", "sat"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.max_connections", "200"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 				),
 			},
@@ -262,6 +267,11 @@ resource "sakuracloud_database" "foobar" {
     weekdays = ["mon", "tue"]
   }
 
+  parameters = {
+    max_connections = 100
+    event_scheduler = "ON"
+  }
+
   name        = "{{ .arg0 }}"
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -298,6 +308,11 @@ resource "sakuracloud_database" "foobar" {
     time     = "00:30"
     weekdays = ["sun", "sat"]
   }
+
+  parameters = {
+    max_connections = 200
+  }
+
 
   name        = "{{ .arg0 }}-upd"
   description = "description-upd"

--- a/sakuracloud/structure_database.go
+++ b/sakuracloud/structure_database.go
@@ -61,13 +61,13 @@ func expandDatabaseBuilder(d *schema.ResourceData, client *APIClient) *databaseB
 			ReplicaUser:     replicaUser,
 			ReplicaPassword: replicaPassword,
 		},
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		Tags:        expandTags(d),
-		IconID:      expandSakuraCloudID(d, "icon_id"),
-		Client:      databaseBuilder.NewAPIClient(client),
-		// 後で設定する
+		Name:               d.Get("name").(string),
+		Description:        d.Get("description").(string),
+		Tags:               expandTags(d),
+		IconID:             expandSakuraCloudID(d, "icon_id"),
+		Client:             databaseBuilder.NewAPIClient(client),
 		BackupSetting:      expandDatabaseBackupSetting(d),
+		Parameters:         d.Get("parameters").(map[string]interface{}),
 		ReplicationSetting: &sacloud.DatabaseReplicationSetting{},
 	}
 

--- a/website/docs/d/database.md
+++ b/website/docs/d/database.md
@@ -22,7 +22,8 @@ data "sakuracloud_database" "foobar" {
 ## Argument Reference
 
 * `filter` - (Optional) One or more values used for filtering, as defined below.
-* `zone` - The name of zone that the Database is in (e.g. `is1a`, `tk1a`).
+* `zone` - (Optional) The name of zone that the Database is in (e.g. `is1a`, `tk1a`). Changing this forces a new resource to be created.
+
 
 ---
 
@@ -50,6 +51,7 @@ A `condition` block supports the following:
 * `icon_id` - The icon id attached to the Database.
 * `name` - The name of the Database.
 * `network_interface` - A list of `network_interface` blocks as defined below.
+* `parameters` - The map for setting RDBMS-specific parameters. Valid keys can be found with the `usacloud database list-parameters` command.
 * `password` - The password of default user on the database.
 * `plan` - The plan name of the Database. This will be one of [`10g`/`30g`/`90g`/`240g`/`500g`/`1t`].
 * `port` - The number of the listening port.

--- a/website/docs/r/database.md
+++ b/website/docs/r/database.md
@@ -40,6 +40,10 @@ resource "sakuracloud_database" "foobar" {
     weekdays = ["mon", "tue"]
   }
 
+  parameters = {
+    max_connections = 100
+  }
+
   name        = "foobar"
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -55,6 +59,7 @@ resource "sakuracloud_switch" "foobar" {
 * `name` - (Required) The name of the Database. The length of this value must be in the range [`1`-`64`].
 * `database_type` - (Optional) The type of the database. This must be one of [`mariadb`/`postgres`]. Changing this forces a new resource to be created. Default:`postgres`.
 * `plan` - (Optional) The plan name of the Database. This must be one of [`10g`/`30g`/`90g`/`240g`/`500g`/`1t`]. Changing this forces a new resource to be created. Default:`10g`.
+* `password` - (Required) The password of default user on the database.
 
 #### User
 
@@ -87,6 +92,9 @@ A `backup` block supports the following:
 * `time` - (Optional) The time to take backup. This must be formatted with `HH:mm`.
 * `weekdays` - (Optional) A list of weekdays to backed up. The values in the list must be in [`sun`/`mon`/`tue`/`wed`/`thu`/`fri`/`sat`].
 
+#### RDBMS Parameters
+
+* `parameters` - (Optional) The map for setting RDBMS-specific parameters. Valid keys can be found with the `usacloud database list-parameters` command.
 
 #### Replication
 


### PR DESCRIPTION
`sakuracloud_database`リソース/データソースで`parameters`ブロックを利用可能にする。

例:
```hcl
resource "sakuracloud_database" "foobar" {
  # ...中略...
  parameters = {
    max_connections = 100
  }
}
```

- `parameters`ブロックはmap型(schema.TypeMap)として定義
   -> `parameters =`のように`=`を記述する必要がある点に注意
- 利用可能なキーは`usacloud database list-parameters <ID or Name or Tags>`で確認可能(コンパネでも確認可)
  -> usacloud v1.1以降で利用可能