### PR TITLE
sakuracloud_sim: Sentitive:true

### DIFF
--- a/sakuracloud/resource_sakuracloud_sim.go
+++ b/sakuracloud/resource_sakuracloud_sim.go
@@ -56,6 +56,7 @@ func resourceSakuraCloudSIM() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
+				Sensitive:   true,
 				Description: "The passcord to authenticate the SIM",
 			},
 			"imei": {


### PR DESCRIPTION
closes #782 

パスコードを`Sensitive: true`にする。
この変更を既存のリソースに適用する際に`terraform init -upgrade`が必要となるが、リソースの再作成は不要。