### PR TITLE
sakuracloud_server: ssh_keys

### DIFF
--- a/examples/website/r/server/server.tf
+++ b/examples/website/r/server/server.tf
@@ -14,7 +14,8 @@ resource "sakuracloud_server" "foobar" {
     password = "password"
     disable_pw_auth = true
 
-    # ssh_key_ids     = ["<ID>", "<ID>"]
+    # ssh_keys    = ["ssh-rsa xxxxx"]
+    # ssh_key_ids = ["<ID>", "<ID>"]
     # note {
     #  id         = "<ID>"
     #  api_key_id = "<ID>"

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -168,6 +168,12 @@ func resourceSakuraCloudServer() *schema.Resource {
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: "A list of the SSHKey id",
 						},
+						"ssh_keys": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "A list of the SSHKey text",
+						},
 						"disable_pw_auth": {
 							Type:        schema.TypeBool,
 							Optional:    true,

--- a/sakuracloud/resource_sakuracloud_server_test.go
+++ b/sakuracloud/resource_sakuracloud_server_test.go
@@ -53,6 +53,8 @@ func TestAccSakuraCloudServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.1852302624", "tag2"),
 					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.hostname", rand),
 					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.password", password),
+					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.ssh_keys.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.ssh_keys.0", "ssh-rsa xxxxx"),
 					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.ssh_key_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.ssh_key_ids.0", "100000000000"),
 					resource.TestCheckResourceAttr(resourceName, "disk_edit_parameter.0.disable_pw_auth", "true"),
@@ -392,6 +394,7 @@ resource "sakuracloud_server" "foobar" {
   disk_edit_parameter {
     hostname        = "{{ .arg0 }}"
     password        = "{{ .arg1 }}"
+    ssh_keys        = ["ssh-rsa xxxxx"]
     ssh_key_ids     = ["100000000000", "200000000000"]
     disable_pw_auth = true
     note {

--- a/sakuracloud/structure_server.go
+++ b/sakuracloud/structure_server.go
@@ -85,6 +85,7 @@ func expandServerDisks(ctx context.Context, zone string, d *schema.ResourceData,
 					IPAddress:           stringOrDefault(v, "ip_address"),
 					NetworkMaskLen:      intOrDefault(v, "netmask"),
 					DefaultRoute:        stringOrDefault(v, "gateway"),
+					SSHKeys:             stringListOrDefault(v, "ssh_keys"),
 					SSHKeyIDs:           expandSakuraCloudIDs(v, "ssh_key_ids"),
 					Notes:               expandDiskEditNotes(v),
 				}

--- a/website/docs/r/server.md
+++ b/website/docs/r/server.md
@@ -29,7 +29,8 @@ resource "sakuracloud_server" "foobar" {
     password        = "password"
     disable_pw_auth = true
 
-    # ssh_key_ids     = ["<ID>", "<ID>"]
+    # ssh_keys    = ["ssh-rsa xxxxx"]
+    # ssh_key_ids = ["<ID>", "<ID>"]
     # note {
     #  id         = "<ID>"
     #  api_key_id = "<ID>"
@@ -102,6 +103,7 @@ A `disk_edit_parameter` block supports the following:
 Note: **The `note_ids` will be removed in a future version. Please use the `note` instead**
 * `password` - (Optional) The password of default user. The length of this value must be in the range [`8`-`64`].
 * `ssh_key_ids` - (Optional) A list of the SSHKey id.
+* `ssh_keys` - (Optional) A list of the SSHKey text.
 
 ---
 


### PR DESCRIPTION
closes #784 

sakuracloud_serverで公開鍵のテキストを指定可能にする。

```tf
resource "sakuracloud_server" "example" {
  name        = "example"

  network_interface {
    upstream = "shared"
  }

  disk_edit_parameter {
    ssh_keys = [file("~/.ssh/gitlab.pub")] # 公開鍵を文字列で指定
    ssh_key_ids = [sakuracloud_ssh_key.foobar.id] # 公開鍵をリソースIDで指定
  }
}
```

バリデーションは追加していないので#784 の問題の直接解決にはなっていないがこの機能で十分カバーできると判断している。