### PR TITLE
Fix zone name attribute of DNS

### DIFF
--- a/sakuracloud/resource_sakuracloud_dns.go
+++ b/sakuracloud/resource_sakuracloud_dns.go
@@ -181,7 +181,7 @@ func resourceSakuraCloudDNSDelete(ctx context.Context, d *schema.ResourceData, m
 }
 
 func setDNSResourceData(ctx context.Context, d *schema.ResourceData, client *APIClient, data *sacloud.DNS) diag.Diagnostics {
-	d.Set("zone", data.Name)               // nolint
+	d.Set("zone", data.DNSZone)            // nolint
 	d.Set("icon_id", data.IconID.String()) // nolint
 	d.Set("description", data.Description) // nolint
 	if err := d.Set("dns_servers", data.DNSNameServers); err != nil {


### PR DESCRIPTION
`Name` is truncated when the zone name is long.
This changes use `Status.Zone` instead of `Name`.
