### PR TITLE
Moved default size setting from the schema definition section

### DIFF
--- a/sakuracloud/data_source_sakuracloud_archive_test.go
+++ b/sakuracloud/data_source_sakuracloud_archive_test.go
@@ -20,31 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccSakuraCloudDataSourceArchive_basic(t *testing.T) {
-	resourceName := "data.sakuracloud_archive.foobar"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSakuraCloudDataSourceArchive_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckSakuraCloudDataSourceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", "Ubuntu Server 16.04.6 LTS 64bit"),
-					resource.TestCheckResourceAttr(resourceName, "size", "20"),
-					resource.TestCheckResourceAttr(resourceName, "tags.#", "6"),
-					resource.TestCheckResourceAttr(resourceName, "tags.0", "@size-extendable"),
-					resource.TestCheckResourceAttr(resourceName, "tags.1", "arch-64bit"),
-					resource.TestCheckResourceAttr(resourceName, "tags.2", "distro-ubuntu"),
-					resource.TestCheckResourceAttr(resourceName, "tags.3", "distro-ver-16.04.5"),
-					resource.TestCheckResourceAttr(resourceName, "tags.4", "os-linux"),
-					resource.TestCheckResourceAttr(resourceName, "tags.5", "ubuntu-16.04-latest"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccSakuraCloudDataSourceArchive_osType(t *testing.T) {
 	resourceName := "data.sakuracloud_archive.foobar"
 	resource.ParallelTest(t, resource.TestCase{
@@ -76,13 +51,6 @@ func TestAccSakuraCloudDataSourceArchive_withTag(t *testing.T) {
 		},
 	})
 }
-
-var testAccSakuraCloudDataSourceArchive_basic = `
-data "sakuracloud_archive" "foobar" {
-  filter {
-    names = ["Ubuntu Server 16"]
-  }
-}`
 
 var testAccCheckSakuraCloudDataSourceArchive_withTag = `
 data "sakuracloud_archive" "foobar" {

--- a/sakuracloud/resource_sakuracloud_archive.go
+++ b/sakuracloud/resource_sakuracloud_archive.go
@@ -53,7 +53,7 @@ func resourceSakuraCloudArchive() *schema.Resource {
 				Type:             schema.TypeInt,
 				Optional:         true,
 				ForceNew:         true,
-				Default:          20,
+				Computed:         true,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.IntInSlice(types.ArchiveSizes)),
 				Description:      descf("The size of %s in GiB. This must be one of [%s]", resourceName, types.ArchiveSizes),
 				ConflictsWith:    []string{"source_disk_id", "source_archive_id", "source_shared_key", "source_archive_zone"},

--- a/sakuracloud/resource_sakuracloud_archive_test.go
+++ b/sakuracloud/resource_sakuracloud_archive_test.go
@@ -72,6 +72,30 @@ func TestAccSakuraCloudArchive_basic(t *testing.T) {
 	})
 }
 
+func TestAccSakuraCloudArchive_defaultSize(t *testing.T) {
+	skipIfFakeModeEnabled(t)
+
+	resourceName := "sakuracloud_archive.foobar"
+	rand := randomName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraCloudArchiveDestroy,
+			testCheckSakuraCloudDiskDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: buildConfigWithArgs(testAccSakuraCloudArchive_defaultSize, rand),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "size", "40"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSakuraCloudArchive_transfer(t *testing.T) {
 	skipIfFakeModeEnabled(t)
 
@@ -258,6 +282,19 @@ resource "sakuracloud_archive" "foobar" {
 resource "sakuracloud_icon" "foobar" {
   name          = "{{ .arg0 }}"
   base64content = "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAACdBJREFUWMPNmHtw1NUVx8+5v9/+9rfJPpJNNslisgmIiCCgDQZR5GWnilUDPlpUqjOB2mp4qGM7tVOn/yCWh4AOVUprHRVB2+lMa0l88Kq10iYpNYPWkdeAmFjyEJPN7v5+v83ec/rH3Q1J2A2Z1hnYvz755ZzzvXPPveeee/GbC24FJmZGIYD5QgPpTBIAAICJLgJAwUQMAIDMfOEBUQchgJmAEC8CINLPThpfFCAG5orhogCBQiAAEyF8PQCATEQyxQzMzFIi4Ojdv86UEVF/f38ymezv7yciANR0zXAZhuHSdR0RRxNHZyJEBERmQvhfAAABIJlMJhIJt9t9TXX11GlTffleQGhvbz/4YeuRw4c13ZWfnycQR9ACQEShAyIxAxEKMXoAIVQ6VCzHcSzLmj937qqVK8aNrYKhv4bGxue3bvu8rc3n9+ualisyMzOltMjYccBqWanKdD5gBgAppZNMJhKJvlgs1heLxWL3fPfutU8/VVhYoGx7e3uJyOVyAcCEyy6bN2d266FDbW3thsuFI0gA4qy589PTOJC7EYEBbNu2ElYg4J9e/Y3p1dWBgN+l67csWKBC/mrbth07dnafOSMQp0y58pEVK2tm1ABAW9vn93zvgYRl5+XlAXMuCbxh3o3MDMyIguE8wADRaJ/H7Vp873119y8JBALDsrN8xcpXX3utoKDQNE1iiEV7ieSzmzYuXrwYAH7z4m83bNocDAZ1Tc8hQThrzjwYxY8BmCjaF/P78n+xZs0Ns64f+Ndnn53yevOLioo2btq8bsOGsvAYn9eHAoFZStnR0aFpWsObfxw/fvzp06fvXnyvZVmmx4M5hHQa3S4DwIRlm4Zr7dNPz7r+OgDo6el5bsuWtxrf6u7u9njygsHC9i/+U1Ia9ubnMzATA7MQIlRS8tnJk3/e1fDoI6vKysoqK8pbP/q323RDdi2hq/0ysHGyAwopU4lEfNXKlWo0Hx069MDSZcePHy8MBk3Tk0ylTnd1+wsKTNMERLUGlLtA1A3jyNEjagIKgsFk0gEM5NCSOst0+wEjAEvHtktKSuoeWAIAX3311f11Szs7OydcPtFwGYDp0sagWhoa7K4G5/f71TfHskEVdHXMn6M16CzLDcRkWfaM6dWm6QGAjZs2t7W1X1JeYRgGMzERMxOnNYa5O8mkrmkzr50JAKlUqq29Le2VQ0sACmYmIvU1OwAmLKt6ejUAyJTcu3dfQTCoaZqUkgEoY0ODvKRMSWbLsjo6O2fPmbuw9nYAOHjw4KdHjhqGoRqgLFpS6oNOE84JRDLVX1FeDgBd3V0pIrfLxZn5GGLMrE40y7YTCcula7W3167++c+UzfNbtzGRK+ObxR1RZyJARPUpNxBzPBYDAE3ThCYkETMjIPMQdwCwbNttGItqb6uqrJo2deqMGTVK8qWXX969+92SsjAi5hRF1BkQKJ3REUDXtE+PHL3ppptCoVBpcXFXVzdJqerFWWNmKaVt2T9YWldf//Dg6rL52efWrV/vCxQYLhdJmV2LmaUUkEkZZGbvXGBm0+P563vvqT/vW7LEcRwnmUxv7wFjZiYyDJdabQCQSsnt27d/6+YFT61Z4/UHBvZadi1mQBRERMwEMAIwkdttNh/8V2trKwB85647a2tv7+npTfb3y6HGKLREIvHKK6+my66ubd/x+p69+0KlZf5AQKV+BC0G0MaURwZGlxMAiam9vf3YsWNL7rsXAL694Oa2tvZPPvnEZRiozBABAIE1XfvggwMfffzxnXcsAoBrZ8zYs3+/pmm6ECNJIKrto4UvueQ8pxiRZduxWKympuauRQsnT56saRoAlIRCbzbsYmYhxGB7TdPcHk9LS3O4LHz1VVcFg8HmpubjJ0643W44/w8FS6kqW1YgKROW5VjWivr6P/3h93V1dYZhKNeD/2zp7elVjfAQLyKP2+0PFG5/NZ242XNm25bNRCNrKUjfy5gIzwXE/mQyEYs98dMnHnrw+yr6hx+2/qOp6djRo43vvGu4XJquZ3X3mO7OL8+cOnUqEolURSpUx53LeDDolDlE+ByQRNG+vlmzZ6vROI69fMWqN954Ix5PBAoLC4PBfK+XMqfSEHdEQJRS2ratyl1KSmLG3FoDoKcXFCIQDQOZTCLAQ8uWKtNlD/5w546dkaqqKq8XERDFQIkb7g6QSqUK/f5wOAwA0WgUiM+u/WxaChBRJxSgzsXhK5+sZDISiVxTUwMAjY2Nu3Y1RMZd6vXmAzCAIOB0uHP2SyqVisViCxcu9Pl8ANDc0oK6xswkxMg7mon0dGHMUqkg6Tjh0lLTdAPABwf+niKZ5zFRtRmQ8RrqyACyv783Gi0vL390eb0qqm+/szvPNNMzNGIFRnUvA0SAzOwNAiLJmU4zHo8DCgAgZgAETtswyX4pk8lkehP0pywrUTV27JaNGyqrKgHgha1bT548WRYOMwDk1hrIna46gbTAUBBCUwcqAFw6frwuRCqV0nUdmFB1MCRtx9E0bWwkEresRDzu9/nm3Th/Vf3DoVAIAJqbmtauXZfv9WpCpBd7Dq00EOGkKdNylCi0EgkhxP4971ZUVJw8ceK2RXd0dX9ZUFCgCaFyYTtOrC/22CMrf/LjH3V0dvX1RSsjEVemUDU3NS1d9uAXHR2lpaVqV4+iMIJWXFKKiEpgCCAKxI6OjuLioutmziwoLBxTFn7r7Xei0WhKSsdxYvF4PJ649Zabn1m/DhC93vxgMKiKuGUlntm46bHHHz/T0xsqKdEEZpYKZ9caJIpXTJmWfuVDofpPBcAMKKLRXoHwl727x106HgAOHDiw5ZcvHD5ymBiCwcJFtbXLM21GQ0ODZVm90ej77/9t3779XV2dBcEifyCgIcLQyCMBMU6cNCX3wQIkqbOzY+LlE373+s6KSER97untdSy7tKx0wHD16tVPPvkkAIDQvV6fz+fNz/emXzyAYVS5yqSsqLh4UM8GwwAFmqZ54sSJXY2NJSUlkyZNAgDTNL1er/Jvb29/uL7+1y++VFQcKg2PCYVCfr/XND1C01QnnytydkDECVdcqdpqtXGGgcqulHTmy+54PH71VdNunD+/sqoSEaPRaEtzy569exO2UxQM5nm9ynpQgrIEPA8w42UTJ6dLEkNWUI0KMTu2E4v3xftiSccGAKHpnrw8v8/vyfPoug4Zv1xxRgOIoDNJQAEMmfo9HNT9DxFN03QbRrCwCNQjHAp1gVc2mQKbM86oAFCA0GDQnSEXqMcGwPQjmND1zGgEAFBmNOeNMzIQSZ0GXvJHuJedPXRkLhiN+2hAVxUdz77yXWDQUdMGFUa40DC4Y/ya5vz/BMEkmVm9dl94QPwvNJB+oilXgHEAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTYtMDItMTBUMjE6MDg6MzMtMDg6MDB4P0OtAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTAyLTEwVDIxOjA4OjMzLTA4OjAwCWL7EQAAAABJRU5ErkJggg=="
+}
+`
+
+var testAccSakuraCloudArchive_defaultSize = `
+resource sakuracloud_disk "disk" {
+  name = "{{ .arg0 }}"
+  size = 40
+}
+
+resource "sakuracloud_archive" "foobar" {
+  name        = "{{ .arg0 }}"
+
+  source_disk_id = sakuracloud_disk.disk.id
 }
 `
 

--- a/sakuracloud/structure_archive.go
+++ b/sakuracloud/structure_archive.go
@@ -50,13 +50,19 @@ func expandArchiveBuilder(d *schema.ResourceData, zone string, client *APIClient
 			sourceArchiveZone = ""
 		}
 	}
+	sizeGB := intOrDefault(d, "size")
+	if sizeGB == 0 {
+		sizeGB = 20
+	}
 
+	// Note: APIとしてはディスクやアーカイブをソースとした場合Sizeの指定はできないが、
+	//       archiveUtil.Director側でAPIに渡すパラメータを制御しているためここでは常に渡して問題ない
 	director := &archiveUtil.Director{
 		Name:              d.Get("name").(string),
 		Description:       d.Get("description").(string),
 		Tags:              expandTags(d),
 		IconID:            expandSakuraCloudID(d, "icon_id"),
-		SizeGB:            intOrDefault(d, "size"),
+		SizeGB:            sizeGB,
 		SourceReader:      reader,
 		SourceDiskID:      expandSakuraCloudID(d, "source_disk_id"),
 		SourceArchiveID:   expandSakuraCloudID(d, "source_archive_id"),


### PR DESCRIPTION
from #841 

アーカイブの`size`デフォルト値設定をスキーマ上ではなくAPIパラメータ組み立て処理部に移動する。  
加えて`Computed: true`に変更し`size`が指定されないケースに対応する。  

### 背景

アーカイブは以下の仕様となっている。

- ブランクアーカイブを作成する際はサイズ指定が必要
- 以外の場合はソースのサイズを引き継ぐ

このとき、スキーマ上で`size`にデフォルト値が設定されていると後者のケースで`size`に差分が発生する。  
このためスキーマ上のデフォルト値は空にした上で`Computed: true`にすることでこの問題を解消する。

デフォルト値はAPIパラメータ組み立て時にこれまでと同様の値を設定する。