### PR TITLE
Rename flag from -debuggable to -debug

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 func main() {
 	var debugMode bool
 
-	flag.BoolVar(&debugMode, "debuggable", false, "set to true to run the provider with support for debuggers like delve")
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
 	if debugMode {


### PR DESCRIPTION
closes #842 

Terraformドキュメントに合わせフラグ名を`-debuggable`から`-debug`に変更する。

```console
$ ./terraform-provider-sakuracloud -h

Usage of ./terraform-provider-sakuracloud:
  -debug
    	set to true to run the provider with support for debuggers like delve
  -sweep string
    	List of Regions to run available Sweepers
  -sweep-allow-failures
    	Enable to allow Sweeper Tests to continue after failures
  -sweep-run string
    	Comma seperated list of Sweeper Tests to run

```