### PR TITLE
Skip local router tests in acceptance test

### DIFF
--- a/sakuracloud/data_source_sakuracloud_local_router_test.go
+++ b/sakuracloud/data_source_sakuracloud_local_router_test.go
@@ -21,6 +21,10 @@ import (
 )
 
 func TestAccSakuraCloudDataSourceLocalRouter_basic(t *testing.T) {
+	if !isFakeModeEnabled() {
+		t.Skip("This test only run if FAKE_MODE environment variable is set")
+	}
+
 	resourceName := "data.sakuracloud_local_router.foobar"
 	rand := randomName()
 

--- a/sakuracloud/resource_sakuracloud_local_router_test.go
+++ b/sakuracloud/resource_sakuracloud_local_router_test.go
@@ -27,6 +27,10 @@ import (
 )
 
 func TestAccSakuraCloudLocalRouter_basic(t *testing.T) {
+	if !isFakeModeEnabled() {
+		t.Skip("This test only run if FAKE_MODE environment variable is set")
+	}
+
 	resourceName := "sakuracloud_local_router.foobar"
 	rand := randomName()
 
@@ -156,6 +160,10 @@ func testCheckSakuraCloudLocalRouterDestroy(s *terraform.State) error {
 }
 
 func TestAccImportSakuraCloudLocalRouter_basic(t *testing.T) {
+	if !isFakeModeEnabled() {
+		t.Skip("This test only run if FAKE_MODE environment variable is set")
+	}
+
 	rand := randomName()
 
 	checkFn := func(s []*terraform.InstanceState) error {
@@ -275,6 +283,10 @@ resource "sakuracloud_local_router" "foobar" {
 `
 
 func TestAccSakuraCloudLocalRouter_peering(t *testing.T) {
+	if !isFakeModeEnabled() {
+		t.Skip("This test only run if FAKE_MODE environment variable is set")
+	}
+
 	resourceName1 := "sakuracloud_local_router.foobar1"
 	resourceName2 := "sakuracloud_local_router.foobar2"
 	rand := randomName()


### PR DESCRIPTION
from #826

#826 起因のエラーで日次CIの成功率が著しく悪化している。
このため受入テスト時はローカルルータ関連のテストをスキップするようにする。
この対応は一時的なもので、将来API側の問題が解決したら元に戻す。