### PR TITLE
simple_monitor: verify_sni

### DIFF
--- a/examples/website/r/simple_monitor/simple_monitor.tf
+++ b/examples/website/r/simple_monitor/simple_monitor.tf
@@ -12,6 +12,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
     status          = "200"
     host_header     = "example.com"
     sni             = true
+    verify_sni      = true
     http2           = true
     # username    = "username"
     # password    = "password"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sacloud/ftps v1.1.0
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
-	github.com/sacloud/libsacloud/v2 v2.28.1-0.20211206013343-22cec9b427cb
+	github.com/sacloud/libsacloud/v2 v2.29.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/sacloud/go-http v0.0.4 h1:+vgx/uCctcGiHMe8jE+qirMKd3+d73MNZXK7nrUo0po
 github.com/sacloud/go-http v0.0.4/go.mod h1:aYTXNuAnPmD6Ar3ktDaR1gPxJCPv2CqpppcYciy1hmo=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
-github.com/sacloud/libsacloud/v2 v2.28.1-0.20211206013343-22cec9b427cb h1:fV/nNaRuyAM8jLqcJNXVGbh0RX43OfcoZnoPK48MsgA=
-github.com/sacloud/libsacloud/v2 v2.28.1-0.20211206013343-22cec9b427cb/go.mod h1:QDsX+iHidP+o/AfOHvl44oeQew3cdfgoswqP2dQy2tk=
+github.com/sacloud/libsacloud/v2 v2.29.0 h1:/Bnz6dgwd4mefiHGc+cE6fQ6XTRsBrlov33Iyec5Mtc=
+github.com/sacloud/libsacloud/v2 v2.29.0/go.mod h1:QDsX+iHidP+o/AfOHvl44oeQew3cdfgoswqP2dQy2tk=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/sakuracloud/data_source_sakuracloud_simple_monitor.go
+++ b/sakuracloud/data_source_sakuracloud_simple_monitor.go
@@ -141,6 +141,11 @@ func dataSourceSakuraCloudSimpleMonitor() *schema.Resource {
 								types.SimpleMonitorFTPSStrings,
 							),
 						},
+						"verify_sni": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "The flag to enable hostname verification for SNI",
+						},
 					},
 				},
 			},

--- a/sakuracloud/resource_sakuracloud_simple_monitor.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor.go
@@ -180,6 +180,11 @@ func resourceSakuraCloudSimpleMonitor() *schema.Resource {
 								types.SimpleMonitorFTPSStrings,
 							),
 						},
+						"verify_sni": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "The flag to enable hostname verification for SNI",
+						},
 					},
 				},
 			},

--- a/sakuracloud/resource_sakuracloud_simple_monitor_test.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor_test.go
@@ -46,6 +46,7 @@ func TestAccSakuraCloudSimpleMonitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8443"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.contains_string", "ok"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.sni", "true"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.verify_sni", "true"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.username", "foo"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.password", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.http2", "true"),
@@ -198,6 +199,7 @@ resource "sakuracloud_simple_monitor" "foobar" {
     username        = "foo"
     password        = "bar"
     http2           = true
+    verify_sni      = true
   }
   description          = "description"
   tags                 = ["tag1", "tag2"]

--- a/sakuracloud/structure_simple_monitor.go
+++ b/sakuracloud/structure_simple_monitor.go
@@ -90,6 +90,7 @@ func flattenSimpleMonitorHealthCheck(simpleMonitor *sacloud.SimpleMonitor) []int
 		healthCheck["username"] = hc.BasicAuthUsername
 		healthCheck["password"] = hc.BasicAuthPassword
 		healthCheck["http2"] = hc.HTTP2
+		healthCheck["verify_sni"] = hc.VerifySNI
 	case types.SimpleMonitorProtocols.TCP, types.SimpleMonitorProtocols.SSH, types.SimpleMonitorProtocols.SMTP, types.SimpleMonitorProtocols.POP3:
 		healthCheck["port"] = hc.Port.Int()
 	case types.SimpleMonitorProtocols.SNMP:
@@ -149,6 +150,7 @@ func expandSimpleMonitorHealthCheck(d resourceValueGettable) *sacloud.SimpleMoni
 			BasicAuthUsername: forceString(conf["username"]),
 			BasicAuthPassword: forceString(conf["password"]),
 			HTTP2:             types.StringFlag(forceBool(conf["http2"])),
+			VerifySNI:         types.StringFlag(forceBool(conf["verify_sni"])),
 		}
 
 	case "dns":

--- a/website/docs/d/simple_monitor.md
+++ b/website/docs/d/simple_monitor.md
@@ -79,5 +79,5 @@ A `health_check` block exports the following:
 * `snmp_version` - The SNMP version used when checking by SNMP.
 * `status` - The response-code to expect when checking by HTTP/HTTPS.
 * `username` - The user name for basic auth used when checking by HTTP/HTTPS.
-
+* `verify_sni` - The flag to enable hostname verification for SNI.
 

--- a/website/docs/r/simple_monitor.md
+++ b/website/docs/r/simple_monitor.md
@@ -70,6 +70,7 @@ A `health_check` block supports the following:
 * `username` - (Optional) The user name for basic auth used when checking by HTTP/HTTPS.
 * `path` - (Optional) The path used when checking by HTTP/HTTPS.
 * `sni` - (Optional) The flag to enable SNI when checking by HTTP/HTTPS.
+* `verify_sni` - (Optional) The flag to enable hostname verification for SNI.
 * `http2` - (Optional) The flag to enable HTTP/2 when checking by HTTPS.
 * `status` - (Optional) The response-code to expect when checking by HTTP/HTTPS.
 * `contains_string` - (Optional) The string that should be included in the response body when checking for HTTP/HTTPS.


### PR DESCRIPTION
シンプル監視でSNIホスト名検証を有効にするためのフィールドを追加

利用例: 
```tf
resource "sakuracloud_simple_monitor" "foobar" {
  target = "www.example.com"

  health_check {
    protocol        = "https"
    port            = 8443
    path            = "/"
    status          = "200"
    host_header     = "example.com"
    sni             = true
    verify_sni      = true
  }

  # ...
}
```