### PR TITLE
vpc_router: dns_forwarding

### DIFF
--- a/examples/website/r/vpc_router/vpc_router.tf
+++ b/examples/website/r/vpc_router/vpc_router.tf
@@ -42,6 +42,11 @@ resource "sakuracloud_vpc_router" "premium" {
     mac_address = "aa:bb:cc:aa:bb:cc"
   }
 
+  dns_forwarding {
+    interface_index = 1
+    dns_servers = ["133.242.0.3", "133.242.0.4"]
+  }
+
   firewall {
     interface_index = 1
 

--- a/sakuracloud/data_source_sakuracloud_vpc_router.go
+++ b/sakuracloud/data_source_sakuracloud_vpc_router.go
@@ -174,6 +174,25 @@ func dataSourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
+			"dns_forwarding": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"interface_index": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The index of the network interface on which to enable the DNS forwarding service",
+						},
+						"dns_servers": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "A list of IP address of DNS server to forward to",
+						},
+					},
+				},
+			},
 			"firewall": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -203,6 +203,30 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 					},
 				},
 			},
+			"dns_forwarding": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"interface_index": {
+							Type:             schema.TypeInt,
+							Required:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 7)),
+							Description: descf(
+								"The index of the network interface on which to enable the DNS forwarding service. %s",
+								descRange(1, 7),
+							),
+						},
+						"dns_servers": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "A list of IP address of DNS server to forward to",
+						},
+					},
+				},
+			},
 			"firewall": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -675,6 +699,9 @@ func setVPCRouterResourceData(ctx context.Context, d *schema.ResourceData, zone 
 		return diag.FromErr(err)
 	}
 	if err := d.Set("dhcp_static_mapping", flattenVPCRouterDHCPStaticMappings(data)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("dns_forwarding", flattenVPCRouterDNSForwarding(data)); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("firewall", flattenVPCRouterFirewalls(data)); err != nil {

--- a/sakuracloud/resource_sakuracloud_vpc_router_test.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_test.go
@@ -119,6 +119,11 @@ func TestAccSakuraCloudVPCRouter_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "dhcp_static_mapping.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "dhcp_static_mapping.0.ip_address", "192.168.11.10"),
 					resource.TestCheckResourceAttr(resourceName, "dhcp_static_mapping.0.mac_address", "aa:bb:cc:aa:bb:cc"),
+					resource.TestCheckResourceAttr(resourceName, "dns_forwarding.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_forwarding.0.interface_index", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_forwarding.0.dns_servers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "dns_forwarding.0.dns_servers.0", "133.242.0.3"),
+					resource.TestCheckResourceAttr(resourceName, "dns_forwarding.0.dns_servers.1", "133.242.0.4"),
 					resource.TestCheckResourceAttr(resourceName, "firewall.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "firewall.0.interface_index", "1"),
 					resource.TestCheckResourceAttr(resourceName, "firewall.0.direction", "send"),
@@ -320,6 +325,12 @@ resource "sakuracloud_vpc_router" "foobar" {
     ip_address  = "192.168.11.10"
     mac_address = "aa:bb:cc:aa:bb:cc"
   }
+
+  dns_forwarding {
+    interface_index = 1
+    dns_servers = ["133.242.0.3", "133.242.0.4"]
+  }
+
 
   firewall {
     interface_index = 1

--- a/sakuracloud/structure_vpc_router.go
+++ b/sakuracloud/structure_vpc_router.go
@@ -227,6 +227,7 @@ func expandVPCRouterSettings(d resourceValueGettable) *vpcrouter.RouterSetting {
 		Firewall:                  expandVPCRouterFirewallList(d),
 		DHCPServer:                expandVPCRouterDHCPServerList(d),
 		DHCPStaticMapping:         expandVPCRouterDHCPStaticMappingList(d),
+		DNSForwarding:             expandVPCRouterDNSForwarding(d),
 		PPTPServer:                expandVPCRouterPPTP(d),
 		L2TPIPsecServer:           expandVPCRouterL2TP(d),
 		RemoteAccessUsers:         expandVPCRouterUserList(d),
@@ -340,6 +341,31 @@ func flattenVPCRouterDHCPStaticMappings(vpcRouter *sacloud.VPCRouter) []interfac
 		})
 	}
 	return staticMappings
+}
+
+func expandVPCRouterDNSForwarding(d resourceValueGettable) *sacloud.VPCRouterDNSForwarding {
+	if values, ok := getListFromResource(d, "dns_forwarding"); ok && len(values) > 0 {
+		raw := values[0]
+		d := mapToResourceData(raw.(map[string]interface{}))
+		return &sacloud.VPCRouterDNSForwarding{
+			Interface:  fmt.Sprintf("eth%d", d.Get("interface_index").(int)),
+			DNSServers: expandStringList(d.Get("dns_servers").([]interface{})),
+		}
+	}
+	return nil
+}
+
+func flattenVPCRouterDNSForwarding(vpcRouter *sacloud.VPCRouter) []interface{} {
+	v := vpcRouter.Settings.DNSForwarding
+	if v != nil {
+		return []interface{}{
+			map[string]interface{}{
+				"interface_index": vpcRouterInterfaceNameToIndex(v.Interface),
+				"dns_servers":     v.DNSServers,
+			},
+		}
+	}
+	return nil
 }
 
 func expandVPCRouterFirewallList(d resourceValueGettable) []*sacloud.VPCRouterFirewall {

--- a/website/docs/d/vpc_router.md
+++ b/website/docs/d/vpc_router.md
@@ -47,6 +47,7 @@ A `condition` block supports the following:
 * `description` - The description of the VPCRouter.
 * `dhcp_server` - A list of `dhcp_server` blocks as defined below.
 * `dhcp_static_mapping` - A list of `dhcp_static_mapping` blocks as defined below.
+* `dns_forwarding` - A list of `dns_forwarding` blocks as defined below.
 * `firewall` - A list of `firewall` blocks as defined below.
 * `icon_id` - The icon id attached to the VPCRouter.
 * `internet_connection` - The flag to enable connecting to the Internet from the VPC Router.
@@ -84,6 +85,13 @@ A `dhcp_static_mapping` block exports the following:
 
 * `ip_address` - The static IP address to assign to DHCP client.
 * `mac_address` - The source MAC address of static mapping.
+
+---
+
+A `dns_forwarding` block exports the following:
+
+* `dns_servers` - A list of IP address of DNS server to forward to.
+* `interface_index` - The index of the network interface on which to enable the DNS forwarding service.
 
 ---
 

--- a/website/docs/r/vpc_router.md
+++ b/website/docs/r/vpc_router.md
@@ -57,6 +57,11 @@ resource "sakuracloud_vpc_router" "premium" {
     mac_address = "aa:bb:cc:aa:bb:cc"
   }
 
+  dns_forwarding {
+    interface_index = 1
+    dns_servers = ["133.242.0.3", "133.242.0.4"]
+  }
+
   firewall {
     interface_index = 1
 
@@ -241,6 +246,7 @@ A `site_to_site_vpn` block supports the following:
 
 * `dhcp_server` - (Optional) One or more `dhcp_server` blocks as defined below.
 * `dhcp_static_mapping` - (Optional) One or more `dhcp_static_mapping` blocks as defined below.
+* `dns_forwarding` - (Optional) A `dns_forwarding` block as defined below.
 * `port_forwarding` - (Optional) One or more `port_forwarding` blocks as defined below.
 * `static_nat` - (Optional) One or more `static_nat` blocks as defined below.
 
@@ -259,6 +265,13 @@ A `dhcp_static_mapping` block supports the following:
 
 * `ip_address` - (Required) The static IP address to assign to DHCP client.
 * `mac_address` - (Required) The source MAC address of static mapping.
+* 
+---
+
+A `dns_forwarding` block supports the following:
+
+* `dns_servers` - (Optional) A list of IP address of DNS server to forward to.
+* `interface_index` - (Required) The index of the network interface on which to enable the DNS forwarding service. This must be in the range [`1`-`7`].
 
 ---
 


### PR DESCRIPTION
VPCルータで`dns_forwarding`を指定可能にする。

例:
```tf
resource "sakuracloud_vpc_router" "foobar" {
  name        = "foobar"

  dns_forwarding {
    interface_index = 1
    dns_servers     = ["133.242.0.3", "133.242.0.4"]
  }

  # ...
}
```