### PR TITLE
Remove centos8 from examples / docs

### DIFF
--- a/examples/website/d/archive/archive.tf
+++ b/examples/website/d/archive/archive.tf
@@ -1,3 +1,3 @@
 data "sakuracloud_archive" "foobar" {
-  os_type = "centos8"
+  os_type = "centos"
 }

--- a/website/docs/d/archive.md
+++ b/website/docs/d/archive.md
@@ -14,7 +14,7 @@ Get information about an existing Archive.
 
 ```hcl
 data "sakuracloud_archive" "foobar" {
-  os_type = "centos8"
+  os_type = "centos"
 }
 ```
 ## Argument Reference


### PR DESCRIPTION
examplesやドキュメントから`centos8`を除去