### PR TITLE
sakuracloud_dns: upgrade MaxItems to 2000

### DIFF
--- a/sakuracloud/resource_sakuracloud_dns.go
+++ b/sakuracloud/resource_sakuracloud_dns.go
@@ -59,7 +59,7 @@ func resourceSakuraCloudDNS() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
-				MaxItems: 1000,
+				MaxItems: 2000,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": schemaResourceName("DNS Record"),


### PR DESCRIPTION
closes #888 

レコード数上限を2000に引き上げ