### PR TITLE
yamlencodeからjsonencodeへ変更

### DIFF
--- a/examples/website/r/auto_scale/auto_scale.tf
+++ b/examples/website/r/auto_scale/auto_scale.tf
@@ -11,7 +11,7 @@ resource "sakuracloud_auto_scale" "foobar" {
   zones = [local.zone]
 
   # 設定ファイル
-  config = yamlencode({
+  config = jsonencode({
     resources : [{
       type : "Server",
       selector : {

--- a/website/docs/r/auto_scale.md
+++ b/website/docs/r/auto_scale.md
@@ -23,7 +23,7 @@ resource "sakuracloud_auto_scale" "foobar" {
   name  = "example"
   zones = [local.zone]
 
-  config = yamlencode({
+  config = jsonencode({
     resources : [{
       type : "Server",
       selector : {


### PR DESCRIPTION
autoscaler向けのyamlをyamlencode()で生成するとautoscaler側でエラーが出る場合があるためjsonencodeを利用するようにコード例などを修正する