### PR TITLE
VPCルータ作成直後に値が参照できない問題を修正

### DIFF
--- a/sakuracloud/config.go
+++ b/sakuracloud/config.go
@@ -45,7 +45,7 @@ var (
 	deletionWaiterTimeout            = 30 * time.Minute
 	deletionWaiterPollingInterval    = 5 * time.Second
 	databaseWaitAfterCreateDuration  = 1 * time.Minute
-	vpcRouterWaitAfterCreateDuration = 1 * time.Minute
+	vpcRouterWaitAfterCreateDuration = 2 * time.Minute
 )
 
 // Config type of SakuraCloud Config


### PR DESCRIPTION
作成直後だとWireGuardの公開鍵などの項目が空になるケースがある
元々作成直後だと値が取れないケースがあり待ち時間を設定していたが、それでもこの問題が発生することがあるため待ち時間を伸ばして対応する