### PR TITLE
各データソースのfilter.conditionで完全一致/部分一致のどちらで検索するか指定可能にする

### DIFF
--- a/sakuracloud/filter.go
+++ b/sakuracloud/filter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const filterAttrName = "filter"
@@ -36,6 +37,15 @@ var (
 		"filter.0.condition",
 	}
 	filterConfigKeysWithTags = append(filterConfigKeys, "filter.0.tags")
+	filteringOperators       = []string{
+		filteringOperatorPartialMatchAnd,
+		filteringOperatorExactMatchOr,
+	}
+)
+
+const (
+	filteringOperatorPartialMatchAnd = "partial_match_and"
+	filteringOperatorExactMatchOr    = "exact_match_or"
 )
 
 func filterSchema(opt *filterSchemaOption) *schema.Schema {
@@ -85,6 +95,16 @@ func filterSchema(opt *filterSchemaOption) *schema.Schema {
 						Required:    true,
 						Elem:        &schema.Schema{Type: schema.TypeString},
 						Description: "The values of the condition. If multiple values ​​are specified, they combined as AND condition",
+					},
+					"operator": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(filteringOperators, false)),
+						Default:          filteringOperatorPartialMatchAnd,
+						Description: descf(
+							"The filtering operator. This must be one of following:  \n%s",
+							filteringOperators,
+						),
 					},
 				},
 			},

--- a/sakuracloud/structure.go
+++ b/sakuracloud/structure.go
@@ -318,6 +318,8 @@ func expandSearchFilter(rawFilters interface{}) search.Filter {
 
 			keyName := mv["name"].(string)
 			values := mv["values"].([]interface{})
+			operator := mv["operator"].(string)
+
 			var conditions []string
 			for _, value := range values {
 				v := value.(string)
@@ -326,7 +328,15 @@ func expandSearchFilter(rawFilters interface{}) search.Filter {
 				}
 			}
 			if len(conditions) > 0 {
-				ret[search.Key(keyName)] = search.AndEqual(conditions...)
+				if operator == filteringOperatorExactMatchOr {
+					var vs []interface{}
+					for _, p := range conditions {
+						vs = append(vs, p)
+					}
+					ret[search.Key(keyName)] = search.OrEqual(vs...)
+				} else {
+					ret[search.Key(keyName)] = search.AndEqual(conditions...)
+				}
 			}
 		}
 	}

--- a/website/docs/d/archive.md
+++ b/website/docs/d/archive.md
@@ -44,7 +44,8 @@ A `filter` block supports the following:
 A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
-* `values` - (Required) The values of the condition. If multiple values are specified, they combined as AND condition.
+* `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/auto_scale.md
+++ b/website/docs/d/auto_scale.md
@@ -38,7 +38,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
-
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 ## Attribute Reference
 

--- a/website/docs/d/bridge.md
+++ b/website/docs/d/bridge.md
@@ -38,6 +38,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/cdrom.md
+++ b/website/docs/d/cdrom.md
@@ -42,6 +42,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/certificate_authority.md
+++ b/website/docs/d/certificate_authority.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 ---
 

--- a/website/docs/d/container_registry.md
+++ b/website/docs/d/container_registry.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/database.md
+++ b/website/docs/d/database.md
@@ -40,6 +40,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/disk.md
+++ b/website/docs/d/disk.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/dns.md
+++ b/website/docs/d/dns.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/enhanced_db.md
+++ b/website/docs/d/enhanced_db.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/esme.md
+++ b/website/docs/d/esme.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/gslb.md
+++ b/website/docs/d/gslb.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/icon.md
+++ b/website/docs/d/icon.md
@@ -39,7 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
-
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 ## Attribute Reference
 

--- a/website/docs/d/internet.md
+++ b/website/docs/d/internet.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/load_balancer.md
+++ b/website/docs/d/load_balancer.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/local_router.md
+++ b/website/docs/d/local_router.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/nfs.md
+++ b/website/docs/d/nfs.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/note.md
+++ b/website/docs/d/note.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/packet_filter.md
+++ b/website/docs/d/packet_filter.md
@@ -38,6 +38,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/private_host.md
+++ b/website/docs/d/private_host.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/proxylb.md
+++ b/website/docs/d/proxylb.md
@@ -38,6 +38,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/server.md
+++ b/website/docs/d/server.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/simple_monitor.md
+++ b/website/docs/d/simple_monitor.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/ssh_key.md
+++ b/website/docs/d/ssh_key.md
@@ -38,6 +38,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/switch.md
+++ b/website/docs/d/switch.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference

--- a/website/docs/d/vpc_router.md
+++ b/website/docs/d/vpc_router.md
@@ -39,6 +39,7 @@ A `condition` block supports the following:
 
 * `name` - (Required) The name of the target field. This value is case-sensitive.
 * `values` - (Required) The values of the condition. If multiple values ​​are specified, they combined as AND condition.
+* `operator` - (Optional) The filtering operator. This must be one of following: `partial_match_and`/`exact_match_or`. Default: `partial_match_and`
 
 
 ## Attribute Reference


### PR DESCRIPTION
closes #899

稀にnamesだけではリソースを特定できないケースがある。

例: Windowsアーカイブ
- Windows Server 2022 for RDS
- Windows Server 2022 for RDS(MS Office2021付)

このケースに対応するためにfilter.conditionにoperatorフィールドを追加し、完全一致 or 部分一致を指定可能にする。

指定可能な値:
- `partial_match_and`(デフォルト): 部分一致、複数指定した場合はAND結合
- `exact_match_or`: 完全一致、複数指定した場合はOR結合

使用例:

```tf
data "sakuracloud_archive" "foobar" {
  filter {
    condition {
      name     = "Name"
      values   = ["Windows Server 2022 for RDS"]
      operator = "exact_match_or"
    }
  }
}
```