### PR TITLE
validate disk_edit_parameter.hostname

### DIFF
--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -165,7 +165,7 @@ func resourceSakuraCloudServer() *schema.Resource {
 						"hostname": {
 							Type:             schema.TypeString,
 							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 64)),
+							ValidateDiagFunc: validateHostName(),
 							Description:      desc.Sprintf("The hostname of the %s. %s", resourceName, desc.Length(1, 64)),
 						},
 						"password": {

--- a/sakuracloud/validators_test.go
+++ b/sakuracloud/validators_test.go
@@ -1,0 +1,80 @@
+// Copyright 2016-2023 The sacloud/terraform-provider-sakuracloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sakuracloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isValidHostName(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     bool
+	}{
+		{
+			name:     "empty",
+			hostname: "",
+			want:     true,
+		},
+		{
+			name:     "starts with dash",
+			hostname: "-example.com",
+			want:     false,
+		},
+		{
+			name:     "ends with dash",
+			hostname: "example-.com",
+			want:     false,
+		},
+		{
+			name:     "with dash",
+			hostname: "exa-mple.com",
+			want:     true,
+		},
+		{
+			name:     "with multiple dash",
+			hostname: "exa-m-ple.com",
+			want:     true,
+		},
+		{
+			name:     "with consecutive dashes",
+			hostname: "exa--mple.com",
+			want:     false,
+		},
+		{
+			name:     "ends with under bar",
+			hostname: "example_.com",
+			want:     false,
+		},
+		{
+			name:     "dot+dot",
+			hostname: "example..com",
+			want:     false,
+		},
+		{
+			name:     "starts with dot",
+			hostname: ".example.com",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, isValidHostName(tt.hostname), "isValidHostName(%v)", tt.hostname)
+		})
+	}
+}


### PR DESCRIPTION
ディスクの修正でのホスト名パラメータがRFC952/RFC1123に準拠しているかのバリデーションを行う。
従来アンダーバーなどの利用できない文字でも`terraform validate`で許容してしまっていた問題を修正する。

validateの実行例:
```
$ terraform validate
╷
│ Error: invalid hostname: invalid_host_name
│ 
│   with sakuracloud_server.foobar,
│   on init.tf line 26, in resource "sakuracloud_server" "foobar":
│   26:     hostname        = "invalid_host_name"
│ 
╵

```