### PR TITLE
Increase router+switch timeout from 100s to 300s

### DIFF
--- a/sakuracloud/resource_sakuracloud_internet.go
+++ b/sakuracloud/resource_sakuracloud_internet.go
@@ -156,7 +156,7 @@ func resourceSakuraCloudInternetCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Failed to create SakuraCloud Internet resource: %s", err)
 	}
 
-	err = client.Internet.RetrySleepWhileCreating(internet.ID, client.DefaultTimeoutDuration, 20)
+	err = client.Internet.RetrySleepWhileCreating(internet.ID, client.DefaultTimeoutDuration, 60)
 
 	if err != nil {
 		return fmt.Errorf("Failed to create SakuraCloud Internet resource: %s", err)


### PR DESCRIPTION
Router+Switchの作成でタイムアウトが起きており、その対応のためタイムアウト時間を100秒から300秒まで増加。