### PR TITLE
sakuracloud_proxylb: プラン変更で再作成される問題を修正

### DIFF
--- a/sakuracloud/resource_sakuracloud_proxylb.go
+++ b/sakuracloud/resource_sakuracloud_proxylb.go
@@ -47,7 +47,13 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": schemaResourceName(resourceName),
-			"plan": schemaResourceIntPlan(resourceName, types.ProxyLBPlans.CPS100.Int(), types.ProxyLBPlanValues),
+			"plan": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          types.ProxyLBPlans.CPS100.Int(),
+				Description:      desc.ResourcePlan(resourceName, types.ProxyLBPlanValues),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IntInSlice(types.ProxyLBPlanValues)),
+			},
 			"vip_failover": {
 				Type:        schema.TypeBool,
 				Optional:    true,

--- a/sakuracloud/schema.go
+++ b/sakuracloud/schema.go
@@ -233,20 +233,6 @@ func schemaDataSourceIntPlan(resourceName string, plans []int) *schema.Schema {
 	}
 }
 
-func schemaResourceIntPlan(resourceName string, defaultValue int, plans []int) *schema.Schema {
-	s := &schema.Schema{
-		Type:             schema.TypeInt,
-		Optional:         true,
-		ForceNew:         true,
-		Description:      desc.ResourcePlan(resourceName, plans),
-		ValidateDiagFunc: validation.ToDiagFunc(validation.IntInSlice(plans)),
-	}
-	if defaultValue > 0 {
-		s.Default = defaultValue
-	}
-	return s
-}
-
 func schemaDataSourceClass(resourceName string, classes []string) *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeString,


### PR DESCRIPTION
#741 のデグレを修正

動作確認:
```
$ terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # sakuracloud_proxylb.foobar will be updated in-place
  ~ resource "sakuracloud_proxylb" "foobar" {
        id                      = "..."
        name                    = "terraform-test"
      ~ plan                    = 100 -> 500
        tags                    = [
            "tag1",
            "tag2",
        ]
        # (12 unchanged attributes hidden)

        # (7 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```