### PR TITLE
sakuracloud_disk: encryption_algorithmにデフォルト値を指定

### DIFF
--- a/sakuracloud/resource_sakuracloud_disk.go
+++ b/sakuracloud/resource_sakuracloud_disk.go
@@ -99,6 +99,7 @@ func resourceSakuraCloudDisk() *schema.Resource {
 				Type:             schema.TypeString,
 				ForceNew:         true,
 				Optional:         true,
+				Default:          types.DiskEncryptionAlgorithms.None,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(types.DiskEncryptionAlgorithmStrings, false)),
 				Description: desc.Sprintf(
 					"The disk encryption algorithm. This must be one of [%s]",


### PR DESCRIPTION
#1161 と #1165 のフォローアップ

さくらのクラウドAPIでのDisk.EncryptionAlgorithmを省略した場合 `none` が設定される。
現在のプロバイダーのスキーマではこの挙動が反映されておらず、encryption_algorithmを未指定の場合に2回目以降のapplyで差分が発生する。

この問題への対応のためにプロバイダー側のスキーマでもデフォルト値を指定する。