### PR TITLE
sakuracloud_cdrom: 20GB対応

### DIFF
--- a/sakuracloud/resource_sakuracloud_cdrom.go
+++ b/sakuracloud/resource_sakuracloud_cdrom.go
@@ -54,7 +54,7 @@ func resourceSakuraCloudCDROM() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": schemaResourceName(resourceName),
-			"size": schemaResourceSize(resourceName, 5, []int{5, 10}...),
+			"size": schemaResourceSize(resourceName, 5, []int{5, 10, 20}...),
 			"iso_image_file": {
 				Type:          schema.TypeString,
 				Optional:      true,

--- a/sakuracloud/resource_sakuracloud_cdrom_test.go
+++ b/sakuracloud/resource_sakuracloud_cdrom_test.go
@@ -46,7 +46,7 @@ func TestAccSakuraCloudCDROM_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudCDROMExists(resourceName, &cdrom),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
-					resource.TestCheckResourceAttr(resourceName, "size", "5"),
+					resource.TestCheckResourceAttr(resourceName, "size", "20"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "icon_id",
 						"sakuracloud_icon.foobar", "id",
@@ -61,7 +61,7 @@ func TestAccSakuraCloudCDROM_basic(t *testing.T) {
 				Config: buildConfigWithArgs(testAccSakuraCloudCDROM_update, rand),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rand+"-upd"),
-					resource.TestCheckResourceAttr(resourceName, "size", "5"),
+					resource.TestCheckResourceAttr(resourceName, "size", "20"),
 					resource.TestCheckResourceAttr(resourceName, "icon_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "iso_image_file", "test/dummy-upd.iso"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description-upd"),
@@ -165,7 +165,7 @@ func TestAccImportSakuraCloudCDROM_basic(t *testing.T) {
 		}
 		expects := map[string]string{
 			"name":        rand,
-			"size":        "5",
+			"size":        "20",
 			"description": "description",
 			"tags.0":      "tag1",
 			"tags.1":      "tag2",
@@ -210,7 +210,7 @@ func TestAccImportSakuraCloudCDROM_basic(t *testing.T) {
 var testAccSakuraCloudCDROM_basic = `
 resource "sakuracloud_cdrom" "foobar" {
   name           = "{{ .arg0 }}"
-  size           = 5
+  size           = 20
   iso_image_file = "test/dummy.iso"
   description    = "description"
   tags           = ["tag1", "tag2"]
@@ -226,7 +226,7 @@ resource "sakuracloud_icon" "foobar" {
 var testAccSakuraCloudCDROM_update = `
 resource "sakuracloud_cdrom" "foobar" {
   name           = "{{ .arg0 }}-upd"
-  size           = 5
+  size           = 20
   iso_image_file = "test/dummy-upd.iso"
   description    = "description-upd"
   tags           = ["tag1-upd", "tag2-upd"]

--- a/website/docs/r/cdrom.md
+++ b/website/docs/r/cdrom.md
@@ -29,7 +29,7 @@ resource "sakuracloud_cdrom" "foobar" {
 * `content_file_name` - (Optional) The name of content file to upload to as the CD-ROM. This is only used when `content` is specified. This conflicts with [`iso_image_file`]. Default:`config`.
 * `iso_image_file` - (Optional) The file path to upload to as the CD-ROM. This conflicts with [`content`].
 * `hash` - (Optional) The md5 checksum calculated from the base64 encoded file body.
-* `size` - (Optional) The size of CD-ROM in GiB. This must be one of [`5`/`10`]. Changing this forces a new resource to be created. Default:`5`.
+* `size` - (Optional) The size of CD-ROM in GiB. This must be one of [`5`/`10`/`20`]. Changing this forces a new resource to be created. Default:`5`.
 
 #### Common Arguments
 


### PR DESCRIPTION
closes #1124 

20GBのISOイメージを作成可能に


テスト結果

```
$ TESTARGS="-run=CDROM" make testacc
running 'go test' with TESTACC=1...
TF_ACC=1 SAKURACLOUD_APPEND_USER_AGENT="(Acceptance Test)" go test -v -run=CDROM -timeout 240m ./...
?   	github.com/sacloud/terraform-provider-sakuracloud	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/internal/defaults	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/internal/desc	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/internal/ftps	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/tools/hash	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/tools/tfdocgen/cmd/gen-sakuracloud-docs	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/version	[no test files]
=== RUN   TestAccSakuraCloudDataSourceCDROM_basic
=== PAUSE TestAccSakuraCloudDataSourceCDROM_basic
=== RUN   TestAccSakuraCloudCDROM_basic
=== PAUSE TestAccSakuraCloudCDROM_basic
=== RUN   TestAccSakuraCloudCDROM_textContent
=== PAUSE TestAccSakuraCloudCDROM_textContent
=== RUN   TestAccImportSakuraCloudCDROM_basic
=== PAUSE TestAccImportSakuraCloudCDROM_basic
=== CONT  TestAccSakuraCloudDataSourceCDROM_basic
=== CONT  TestAccSakuraCloudCDROM_textContent
=== CONT  TestAccImportSakuraCloudCDROM_basic
=== CONT  TestAccSakuraCloudCDROM_basic
--- PASS: TestAccSakuraCloudDataSourceCDROM_basic (16.45s)
--- PASS: TestAccImportSakuraCloudCDROM_basic (16.66s)
--- PASS: TestAccSakuraCloudCDROM_textContent (17.99s)
--- PASS: TestAccSakuraCloudCDROM_basic (21.05s)
PASS
ok  	github.com/sacloud/terraform-provider-sakuracloud/sakuracloud	21.387s

```