### PR TITLE
sakuracloud_packet_filter_rulesのimportができないバグを修正

### DIFF
--- a/sakuracloud/resource_sakuracloud_packet_filter_rules.go
+++ b/sakuracloud/resource_sakuracloud_packet_filter_rules.go
@@ -115,7 +115,7 @@ func resourceSakuraCloudPacketFilterRulesRead(ctx context.Context, d *schema.Res
 	}
 
 	pfOp := iaas.NewPacketFilterOp(client)
-	pfID := d.Get("packet_filter_id").(string)
+	pfID := d.Id()
 
 	pf, err := pfOp.Read(ctx, zone, sakuraCloudID(pfID))
 	if err != nil {


### PR DESCRIPTION
https://github.com/sacloud/terraform-provider-sakuracloud/pull/1174 と同様の理由で `sakuracloud_packet_filter_rules` のimportができないバグを修正しました。