### PR TITLE
ELBのACME証明書自動更新が無効になる不具合修正

### DIFF
--- a/sakuracloud/data_source_sakuracloud_proxylb.go
+++ b/sakuracloud/data_source_sakuracloud_proxylb.go
@@ -373,6 +373,31 @@ func dataSourceSakuraCloudProxyLB() *schema.Resource {
 					},
 				},
 			},
+			"letsencrypt": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "The flag to accept the current Let's Encrypt terms of service(see: https://letsencrypt.org/repository/). This must be set `true` explicitly",
+						},
+						"common_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The common name of the certificate",
+						},
+						"subject_alt_names": {
+							Type:        schema.TypeSet,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         schema.HashString,
+							Computed:    true,
+							Description: "The subject alternative names of the certificate",
+						},
+					},
+				},
+			},
 			"icon_id":     schemaDataSourceIconID(resourceName),
 			"description": schemaDataSourceDescription(resourceName),
 			"tags":        schemaDataSourceTags(resourceName),

--- a/sakuracloud/resource_sakuracloud_proxylb_test.go
+++ b/sakuracloud/resource_sakuracloud_proxylb_test.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/sacloud/iaas-api-go"
@@ -38,6 +39,8 @@ func TestAccSakuraCloudProxyLB_basic(t *testing.T) {
 	resourceName := "sakuracloud_proxylb.foobar"
 	rand := randomName()
 	ip := os.Getenv(envProxyLBRealServerIP0)
+	subDomain := "acme-acctest1" + acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	proxyLBDomain = os.Getenv(envProxyLBACMEDomain)
 
 	var proxylb, proxylbUpd iaas.ProxyLB
 	resource.Test(t, resource.TestCase{
@@ -98,6 +101,13 @@ func TestAccSakuraCloudProxyLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rule.0.request_header_value_ignore_case", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.request_header_value_not_match", "true"),
 
+					resource.TestCheckResourceAttr(resourceName, "certificate.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.0.common_name", subDomain+"."+proxyLBDomain),
+					resource.TestCheckResourceAttr(resourceName,
+						"certificate.0.subject_alt_names",
+						fmt.Sprintf("%s.%s, acme-acctest2.%s, acme-acctest3.%s", subDomain, proxyLBDomain, proxyLBDomain, proxyLBDomain),
+					),
+
 					resource.TestCheckResourceAttrSet(resourceName, "vip"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "server.0.ip_address",
@@ -152,6 +162,12 @@ func TestAccSakuraCloudProxyLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rule.0.fixed_message_body", ""),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.redirect_status_code", "301"),
 					resource.TestCheckResourceAttr(resourceName, "rule.0.redirect_location", "https://redirect.usacloud.jp"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.0.common_name", subDomain+"."+proxyLBDomain),
+					resource.TestCheckResourceAttr(resourceName,
+						"certificate.0.subject_alt_names",
+						fmt.Sprintf("%s.%s, acme-acctest2.%s, acme-acctest3.%s", subDomain, proxyLBDomain, proxyLBDomain, proxyLBDomain),
+					),
 					resource.TestCheckResourceAttrSet(resourceName, "vip"),
 					resource.TestCheckResourceAttrPair(
 						resourceName, "server.0.ip_address",
@@ -354,6 +370,16 @@ resource sakuracloud_server "foobar" {
   }
 
   force_shutdown = true
+}
+
+resource sakuracloud_proxylb_acme "foobar" {
+  proxylb_id        = sakuracloud_proxylb.foobar.id
+  accept_tos        = true
+  common_name       = "{{ .arg2 }}.{{ .arg1 }}"
+  subject_alt_names = ["acme-acctest2.{{ .arg1 }}", "acme-acctest3.{{ .arg1 }}"]
+
+  update_delay_sec             = 120
+  get_certificates_timeout_sec = 300
 }
 `
 

--- a/sakuracloud/structure_proxylb.go
+++ b/sakuracloud/structure_proxylb.go
@@ -28,6 +28,7 @@ func expandProxyLBCreateRequest(d *schema.ResourceData) *iaas.ProxyLBCreateReque
 		BindPorts:            expandProxyLBBindPorts(d),
 		Servers:              expandProxyLBServers(d),
 		Rules:                expandProxyLBRules(d),
+		LetsEncrypt:          expandProxyLBACMESetting(d),
 		StickySession:        expandProxyLBStickySession(d),
 		Gzip:                 expandProxyLBGzip(d),
 		BackendHttpKeepAlive: expandProxyLBBackendHttpKeepAlive(d),
@@ -50,6 +51,7 @@ func expandProxyLBUpdateRequest(d *schema.ResourceData) *iaas.ProxyLBUpdateReque
 		BindPorts:            expandProxyLBBindPorts(d),
 		Servers:              expandProxyLBServers(d),
 		Rules:                expandProxyLBRules(d),
+		LetsEncrypt:          expandProxyLBACMESetting(d),
 		StickySession:        expandProxyLBStickySession(d),
 		Gzip:                 expandProxyLBGzip(d),
 		BackendHttpKeepAlive: expandProxyLBBackendHttpKeepAlive(d),
@@ -412,6 +414,32 @@ func expandProxyLBCerts(d resourceValueGettable) *iaas.ProxyLBCertificates {
 		}
 
 		return cert
+	}
+	return nil
+}
+
+func flattenProxyLBACMESetting(proxyLB *iaas.ProxyLB) []interface{} {
+	var results []interface{}
+	if proxyLB.LetsEncrypt != nil {
+		results = []interface{}{
+			map[string]interface{}{
+				"enabled":           proxyLB.LetsEncrypt.Enabled,
+				"common_name":       proxyLB.LetsEncrypt.CommonName,
+				"subject_alt_names": proxyLB.LetsEncrypt.SubjectAltNames,
+			},
+		}
+	}
+	return results
+}
+
+func expandProxyLBACMESetting(d resourceValueGettable) *iaas.ProxyLBACMESetting {
+	if acmeSettings, ok := getListFromResource(d, "letsencrypt"); ok && len(acmeSettings) > 0 {
+		values := mapToResourceData(acmeSettings[0].(map[string]interface{}))
+		return &iaas.ProxyLBACMESetting{
+			CommonName:      values.Get("common_name").(string),
+			Enabled:         values.Get("enabled").(bool),
+			SubjectAltNames: expandSubjectAltNames(values),
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
#1172

エンハンスドLBにおいて、ACME（LetsEncrypt）設定が別リソースになっており、エンハンスドLBに変更を行うとACMEの設定が入っておらずnilで上書きされてしまってた不具合を修正。

そのためエンハンスドLBのschemaにletsencryptの設定を導入し、エンハンスドLBを更新する際にletsencryptの設定も登録するよう修正しました。