### PR TITLE
GSLBのヘルスチェックでプロトコルがHTTP/HTTPSの場合にポートの指定ができない不具合修正

### DIFF
--- a/sakuracloud/data_source_sakuracloud_gslb.go
+++ b/sakuracloud/data_source_sakuracloud_gslb.go
@@ -73,7 +73,7 @@ func dataSourceSakuraCloudGSLB() *schema.Resource {
 						"port": {
 							Type:        schema.TypeInt,
 							Computed:    true,
-							Description: "The port number used when checking by TCP",
+							Description: "The port number used when checking by TCP/HTTP/HTTPS",
 						},
 					},
 				},

--- a/sakuracloud/data_source_sakuracloud_gslb_test.go
+++ b/sakuracloud/data_source_sakuracloud_gslb_test.go
@@ -37,6 +37,7 @@ func TestAccSakuraCloudDataSourceGSLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "http"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.delay_loop", "10"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.host_header", "usacloud.jp"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.status", "200"),
 					resource.TestCheckResourceAttr(resourceName, "sorry_server", "8.8.8.8"),
@@ -57,6 +58,7 @@ resource "sakuracloud_gslb" "foobar" {
     protocol    = "http"
     delay_loop  = 10
     host_header = "usacloud.jp"
+    port        = "80"
     path        = "/"
     status      = "200"
   }

--- a/sakuracloud/resource_sakuracloud_gslb.go
+++ b/sakuracloud/resource_sakuracloud_gslb.go
@@ -92,7 +92,7 @@ func resourceSakuraCloudGSLB() *schema.Resource {
 						"port": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Description: "The port number used when checking by TCP",
+							Description: "The port number used when checking by TCP/HTTP/HTTPS",
 						},
 					},
 				},

--- a/sakuracloud/resource_sakuracloud_gslb_test.go
+++ b/sakuracloud/resource_sakuracloud_gslb_test.go
@@ -51,6 +51,7 @@ func TestAccSakuraCloudGSLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "http"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.delay_loop", "10"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.host_header", "usacloud.jp"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.ip_address", "1.1.1.1"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.weight", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.enabled", "true"),
@@ -74,6 +75,7 @@ func TestAccSakuraCloudGSLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2-upd"),
 					resource.TestCheckResourceAttr(resourceName, "sorry_server", "8.8.4.4"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "https"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.delay_loop", "20"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.host_header", "usacloud.jp-upd"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.ip_address", "2.2.2.2"),
@@ -96,6 +98,7 @@ func TestAccSakuraCloudGSLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2-upd"),
 					resource.TestCheckResourceAttr(resourceName, "sorry_server", "8.8.4.4"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "https"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.delay_loop", "20"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.host_header", "usacloud.jp-upd"),
 					resource.TestCheckResourceAttr(resourceName, "server.#", "0"),
@@ -167,6 +170,7 @@ func TestAccImportSakuraCloudGSLB_basic(t *testing.T) {
 			"health_check.0.protocol":    "http",
 			"health_check.0.delay_loop":  "10",
 			"health_check.0.host_header": "usacloud.jp",
+			"health_check.0.port":        "80",
 			"health_check.0.path":        "/",
 			"health_check.0.status":      "200",
 			"weighted":                   "false",
@@ -212,6 +216,7 @@ resource "sakuracloud_gslb" "foobar" {
     protocol    = "http"
     delay_loop  = 10
     host_header = "usacloud.jp"
+    port        = "80"
     path        = "/"
     status      = "200"
   }
@@ -244,6 +249,7 @@ resource "sakuracloud_gslb" "foobar" {
     protocol    = "https"
     delay_loop  = 20
     host_header = "usacloud.jp-upd"
+    port        = "443"
     path        = "/"
     status      = "200"
   }
@@ -269,6 +275,7 @@ resource "sakuracloud_gslb" "foobar" {
     protocol    = "https"
     delay_loop  = 20
     host_header = "usacloud.jp-upd"
+    port        = "443"
     path        = "/"
     status      = "200"
   }

--- a/sakuracloud/structure_gslb.go
+++ b/sakuracloud/structure_gslb.go
@@ -33,6 +33,7 @@ func expandGSLBHealthCheckConf(d resourceValueGettable) *iaas.GSLBHealthCheck {
 		return &iaas.GSLBHealthCheck{
 			Protocol:     types.EGSLBHealthCheckProtocol(protocol),
 			HostHeader:   conf["host_header"].(string),
+			Port:     types.StringNumber(conf["port"].(int)),
 			Path:         conf["path"].(string),
 			ResponseCode: types.StringNumber(forceAtoI(conf["status"].(string))),
 		}
@@ -75,6 +76,7 @@ func flattenGSLBHealthCheck(data *iaas.GSLB) []interface{} {
 	switch data.HealthCheck.Protocol {
 	case types.GSLBHealthCheckProtocols.HTTP, types.GSLBHealthCheckProtocols.HTTPS:
 		healthCheck["host_header"] = data.HealthCheck.HostHeader
+		healthCheck["port"] = data.HealthCheck.Port
 		healthCheck["path"] = data.HealthCheck.Path
 		healthCheck["status"] = data.HealthCheck.ResponseCode.String()
 	case types.GSLBHealthCheckProtocols.TCP:

--- a/website/docs/d/gslb.md
+++ b/website/docs/d/gslb.md
@@ -63,7 +63,7 @@ A `health_check` block exports the following:
 * `delay_loop` - The interval in seconds between checks.
 * `host_header` - The value of host header send when checking by HTTP/HTTPS.
 * `path` - The path used when checking by HTTP/HTTPS.
-* `port` - The port number used when checking by TCP.
+* `port` - The port number used when checking by TCP/HTTP/HTTPS.
 * `protocol` - The protocol used for health checks. This will be one of [`http`/`https`/`tcp`/`ping`].
 * `status` - The response-code to expect when checking by HTTP/HTTPS.
 

--- a/website/docs/r/gslb.md
+++ b/website/docs/r/gslb.md
@@ -20,6 +20,7 @@ resource "sakuracloud_gslb" "foobar" {
     protocol    = "http"
     delay_loop  = 10
     host_header = "example.com"
+    port        = "80"
     path        = "/"
     status      = "200"
   }
@@ -58,7 +59,7 @@ A `health_check` block supports the following:
 * `delay_loop` - (Optional) The interval in seconds between checks. This must be in the range [`10`-`60`].
 * `host_header` - (Optional) The value of host header send when checking by HTTP/HTTPS.
 * `path` - (Optional) The path used when checking by HTTP/HTTPS.
-* `port` - (Optional) The port number used when checking by TCP.
+* `port` - (Optional) The port number used when checking by TCP/HTTP/HTTPS.
 * `status` - (Optional) The response-code to expect when checking by HTTP/HTTPS.
 
 ---


### PR DESCRIPTION
以下のIssueに対応
https://github.com/sacloud/terraform-provider-sakuracloud/issues/1179
