### PR TITLE
リソース名長エラーを修正

### DIFF
--- a/sakuracloud/resource_sakuracloud_container_registry.go
+++ b/sakuracloud/resource_sakuracloud_container_registry.go
@@ -60,7 +60,7 @@ func resourceSakuraCloudContainerRegistry() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 64)),
+				ValidateDiagFunc: validation.ToDiagFunc(isValidNameLengthBetween(1, 64)),
 				Description: desc.Sprintf(
 					"The label at the lowest of the FQDN used when be accessed from users. %s",
 					desc.Length(1, 64),

--- a/sakuracloud/resource_sakuracloud_container_registry.go
+++ b/sakuracloud/resource_sakuracloud_container_registry.go
@@ -60,7 +60,7 @@ func resourceSakuraCloudContainerRegistry() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(isValidNameLengthBetween(1, 64)),
+				ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(1, 64)),
 				Description: desc.Sprintf(
 					"The label at the lowest of the FQDN used when be accessed from users. %s",
 					desc.Length(1, 64),

--- a/sakuracloud/resource_sakuracloud_container_registry.go
+++ b/sakuracloud/resource_sakuracloud_container_registry.go
@@ -60,7 +60,7 @@ func resourceSakuraCloudContainerRegistry() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(1, 64)),
+				ValidateDiagFunc: isValidLengthBetween(1, 64),
 				Description: desc.Sprintf(
 					"The label at the lowest of the FQDN used when be accessed from users. %s",
 					desc.Length(1, 64),

--- a/sakuracloud/resource_sakuracloud_database.go
+++ b/sakuracloud/resource_sakuracloud_database.go
@@ -70,7 +70,7 @@ func resourceSakuraCloudDatabase() *schema.Resource {
 				Type:             schema.TypeString,
 				ForceNew:         true,
 				Required:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(3, 20)),
+				ValidateDiagFunc: isValidLengthBetween(3, 20),
 				Description:      desc.Sprintf("The name of default user on the database. %s", desc.Length(3, 20)),
 			},
 			"password": {

--- a/sakuracloud/resource_sakuracloud_proxylb.go
+++ b/sakuracloud/resource_sakuracloud_proxylb.go
@@ -333,7 +333,7 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 						"group": {
 							Type:             schema.TypeString,
 							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 10)),
+							ValidateDiagFunc: isValidLengthBetween(1, 10),
 							Description: desc.Sprintf(
 								"The name of load balancing group. This is used when using rule-based load balancing. %s",
 								desc.Length(1, 10),
@@ -391,7 +391,7 @@ func resourceSakuraCloudProxyLB() *schema.Resource {
 						"group": {
 							Type:             schema.TypeString,
 							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 10)),
+							ValidateDiagFunc: isValidLengthBetween(1, 10),
 							Description: desc.Sprintf(
 								"The name of load balancing group. When proxyLB received request which matched to `host` and `path`, proxyLB forwards the request to servers that having same group name. %s",
 								desc.Length(1, 10),

--- a/sakuracloud/resource_sakuracloud_server.go
+++ b/sakuracloud/resource_sakuracloud_server.go
@@ -179,7 +179,7 @@ func resourceSakuraCloudServer() *schema.Resource {
 						"password": {
 							Type:             schema.TypeString,
 							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(8, 64)),
+							ValidateDiagFunc: isValidLengthBetween(8, 64),
 							Sensitive:        true,
 							Description:      desc.Sprintf("The password of default user. %s", desc.Length(8, 64)),
 						},

--- a/sakuracloud/resource_sakuracloud_ssh_key_gen.go
+++ b/sakuracloud/resource_sakuracloud_ssh_key_gen.go
@@ -43,14 +43,14 @@ func resourceSakuraCloudSSHKeyGen() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(isValidNameLengthBetween(1, 64)),
+				ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(1, 64)),
 				Description:      desc.Sprintf("The name of the %s. %s", resourceName, desc.Length(1, 64)),
 			},
 			"description": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 512)),
+				ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(1, 512)),
 				Description:      desc.Sprintf("The description of the %s. %s", resourceName, desc.Length(1, 512)),
 			},
 			"pass_phrase": {

--- a/sakuracloud/resource_sakuracloud_ssh_key_gen.go
+++ b/sakuracloud/resource_sakuracloud_ssh_key_gen.go
@@ -43,14 +43,14 @@ func resourceSakuraCloudSSHKeyGen() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(1, 64)),
+				ValidateDiagFunc: isValidLengthBetween(1, 64),
 				Description:      desc.Sprintf("The name of the %s. %s", resourceName, desc.Length(1, 64)),
 			},
 			"description": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(1, 512)),
+				ValidateDiagFunc: isValidLengthBetween(1, 512),
 				Description:      desc.Sprintf("The description of the %s. %s", resourceName, desc.Length(1, 512)),
 			},
 			"pass_phrase": {

--- a/sakuracloud/resource_sakuracloud_ssh_key_gen.go
+++ b/sakuracloud/resource_sakuracloud_ssh_key_gen.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/terraform-provider-sakuracloud/internal/desc"
 )
@@ -57,7 +56,7 @@ func resourceSakuraCloudSSHKeyGen() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(8, 64)),
+				ValidateDiagFunc: isValidLengthBetween(8, 64),
 				Description: desc.Sprintf(
 					"The pass phrase of the private key. %s",
 					desc.Length(8, 64),

--- a/sakuracloud/resource_sakuracloud_ssh_key_gen.go
+++ b/sakuracloud/resource_sakuracloud_ssh_key_gen.go
@@ -43,7 +43,7 @@ func resourceSakuraCloudSSHKeyGen() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 64)),
+				ValidateDiagFunc: validation.ToDiagFunc(isValidNameLengthBetween(1, 64)),
 				Description:      desc.Sprintf("The name of the %s. %s", resourceName, desc.Length(1, 64)),
 			},
 			"description": {

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -298,7 +298,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 									"description": {
 										Type:             schema.TypeString,
 										Optional:         true,
-										ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(0, 512)),
+										ValidateDiagFunc: isValidLengthBetween(0, 512),
 										Description:      desc.Sprintf("The description of the expression. %s", desc.Length(0, 512)),
 									},
 								},
@@ -370,7 +370,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 						"description": {
 							Type:             schema.TypeString,
 							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(0, 512)),
+							ValidateDiagFunc: isValidLengthBetween(0, 512),
 							Description:      desc.Sprintf("The description of the port forwarding. %s", desc.Length(0, 512)),
 						},
 					},
@@ -591,7 +591,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 						"description": {
 							Type:             schema.TypeString,
 							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(0, 512)),
+							ValidateDiagFunc: isValidLengthBetween(0, 512),
 							Description:      desc.Sprintf("The description of the static nat. %s", desc.Length(0, 512)),
 						},
 					},

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -298,7 +298,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 									"description": {
 										Type:             schema.TypeString,
 										Optional:         true,
-										ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(0, 512)),
+										ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(0, 512)),
 										Description:      desc.Sprintf("The description of the expression. %s", desc.Length(0, 512)),
 									},
 								},
@@ -370,7 +370,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 						"description": {
 							Type:             schema.TypeString,
 							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(0, 512)),
+							ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(0, 512)),
 							Description:      desc.Sprintf("The description of the port forwarding. %s", desc.Length(0, 512)),
 						},
 					},
@@ -591,7 +591,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 						"description": {
 							Type:             schema.TypeString,
 							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(0, 512)),
+							ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(0, 512)),
 							Description:      desc.Sprintf("The description of the static nat. %s", desc.Length(0, 512)),
 						},
 					},

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -317,7 +317,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 							Type:             schema.TypeString,
 							Required:         true,
 							Sensitive:        true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(0, 40)),
+							ValidateDiagFunc: isValidLengthBetween(0, 40),
 							Description:      "The pre shared secret for L2TP/IPsec",
 						},
 						"range_start": {
@@ -458,7 +458,7 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 							Type:             schema.TypeString,
 							Required:         true,
 							Sensitive:        true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(0, 40)),
+							ValidateDiagFunc: isValidLengthBetween(0, 40),
 							Description:      desc.Sprintf("The pre shared secret for the VPN. %s", desc.Length(0, 40)),
 						},
 						"routes": {
@@ -651,14 +651,14 @@ func resourceSakuraCloudVPCRouter() *schema.Resource {
 						"name": {
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 20)),
+							ValidateDiagFunc: isValidLengthBetween(1, 20),
 							Description:      "The user name used to authenticate remote access",
 						},
 						"password": {
 							Type:             schema.TypeString,
 							Required:         true,
 							Sensitive:        true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 20)),
+							ValidateDiagFunc: isValidLengthBetween(1, 20),
 							Description:      "The password used to authenticate remote access",
 						},
 					},

--- a/sakuracloud/schema.go
+++ b/sakuracloud/schema.go
@@ -32,7 +32,7 @@ func schemaResourceName(resourceName string) *schema.Schema {
 	return &schema.Schema{
 		Type:             schema.TypeString,
 		Required:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(isValidNameLengthBetween(1, 64)),
+		ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(1, 64)),
 		Description:      desc.Sprintf("The name of the %s. %s", resourceName, desc.Length(1, 64)),
 	}
 }
@@ -99,7 +99,7 @@ func schemaResourceDescription(resourceName string) *schema.Schema {
 	return &schema.Schema{
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 512)),
+		ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(1, 512)),
 		Description:      desc.Sprintf("The description of the %s. %s", resourceName, desc.Length(1, 512)),
 	}
 }

--- a/sakuracloud/schema.go
+++ b/sakuracloud/schema.go
@@ -32,7 +32,7 @@ func schemaResourceName(resourceName string) *schema.Schema {
 	return &schema.Schema{
 		Type:             schema.TypeString,
 		Required:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 64)),
+		ValidateDiagFunc: validation.ToDiagFunc(isValidNameLengthBetween(1, 64)),
 		Description:      desc.Sprintf("The name of the %s. %s", resourceName, desc.Length(1, 64)),
 	}
 }

--- a/sakuracloud/schema.go
+++ b/sakuracloud/schema.go
@@ -32,7 +32,7 @@ func schemaResourceName(resourceName string) *schema.Schema {
 	return &schema.Schema{
 		Type:             schema.TypeString,
 		Required:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(1, 64)),
+		ValidateDiagFunc: isValidLengthBetween(1, 64),
 		Description:      desc.Sprintf("The name of the %s. %s", resourceName, desc.Length(1, 64)),
 	}
 }
@@ -99,7 +99,7 @@ func schemaResourceDescription(resourceName string) *schema.Schema {
 	return &schema.Schema{
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(isValidLengthBetween(1, 512)),
+		ValidateDiagFunc: isValidLengthBetween(1, 512),
 		Description:      desc.Sprintf("The description of the %s. %s", resourceName, desc.Length(1, 512)),
 	}
 }

--- a/sakuracloud/validators.go
+++ b/sakuracloud/validators.go
@@ -194,7 +194,7 @@ func validateHostName() schema.SchemaValidateDiagFunc {
 			}
 
 			return validation.All(
-				isValidNameLengthBetween(1, 64),
+				isValidLengthBetween(1, 64),
 				validateFormatFunc,
 			)(v, k)
 		}
@@ -210,7 +210,7 @@ func isValidHostName(hostname string) bool {
 	return regexp.MustCompile(`^(?i)([a-z0-9]+(-[a-z0-9]+)*)(\.[a-z0-9]+(-[a-z0-9]+)*)*$`).MatchString(hostname)
 }
 
-func isValidNameLengthBetween(minVal, maxVal int) schema.SchemaValidateFunc {
+func isValidLengthBetween(minVal, maxVal int) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (warnings []string, errors []error) {
 		v, ok := i.(string)
 

--- a/sakuracloud/validators.go
+++ b/sakuracloud/validators.go
@@ -193,8 +193,17 @@ func validateHostName() schema.SchemaValidateDiagFunc {
 				return warnings, errors
 			}
 
+			validateLengthFunc := func(v interface{}, k string) ([]string, []error) {
+				if value, ok := v.(string); ok {
+					if len(value) < 1 || len(value) > 64 {
+						return nil, []error{fmt.Errorf("hostname must be between 1 and 64 characters")}
+					}
+				}
+				return nil, nil
+			}
+
 			return validation.All(
-				isValidLengthBetween(1, 64),
+				validateLengthFunc,
 				validateFormatFunc,
 			)(v, k)
 		}
@@ -210,8 +219,8 @@ func isValidHostName(hostname string) bool {
 	return regexp.MustCompile(`^(?i)([a-z0-9]+(-[a-z0-9]+)*)(\.[a-z0-9]+(-[a-z0-9]+)*)*$`).MatchString(hostname)
 }
 
-func isValidLengthBetween(minVal, maxVal int) schema.SchemaValidateFunc {
-	return func(i interface{}, k string) (warnings []string, errors []error) {
+func isValidLengthBetween(minVal, maxVal int) schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(func(i interface{}, k string) (warnings []string, errors []error) {
 		v, ok := i.(string)
 
 		if !ok {
@@ -224,5 +233,5 @@ func isValidLengthBetween(minVal, maxVal int) schema.SchemaValidateFunc {
 		}
 
 		return warnings, errors
-	}
+	})
 }

--- a/sakuracloud/validators.go
+++ b/sakuracloud/validators.go
@@ -194,7 +194,7 @@ func validateHostName() schema.SchemaValidateDiagFunc {
 			}
 
 			return validation.All(
-				validation.StringLenBetween(1, 64),
+				isValidNameLengthBetween(1, 64),
 				validateFormatFunc,
 			)(v, k)
 		}
@@ -208,4 +208,21 @@ func isValidHostName(hostname string) bool {
 	}
 	// RFC952,RFC1123
 	return regexp.MustCompile(`^(?i)([a-z0-9]+(-[a-z0-9]+)*)(\.[a-z0-9]+(-[a-z0-9]+)*)*$`).MatchString(hostname)
+}
+
+func isValidNameLengthBetween(minVal, maxVal int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+			return warnings, errors
+		}
+
+		if len([]rune(v)) < minVal || len([]rune(v)) > maxVal {
+			errors = append(errors, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, minVal, maxVal, v))
+		}
+
+		return warnings, errors
+	}
 }

--- a/sakuracloud/validators_test.go
+++ b/sakuracloud/validators_test.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"testing"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -126,12 +127,12 @@ func Test_isValidLengthBetween(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, errors := validateFunc(tt.input, "test_field")
+			diagnostics := validateFunc(tt.input, cty.Path{cty.GetAttrStep{Name: "test_field"}})
 
 			if tt.want {
-				assert.NotEmpty(t, errors, "Expected validation errors but got none")
+				assert.NotEmpty(t, diagnostics, "Expected validation errors but got none")
 			} else {
-				assert.Empty(t, errors, "Expected no validation errors but got some")
+				assert.Empty(t, diagnostics, "Expected no validation errors but got some")
 			}
 		})
 	}

--- a/sakuracloud/validators_test.go
+++ b/sakuracloud/validators_test.go
@@ -78,3 +78,61 @@ func Test_isValidHostName(t *testing.T) {
 		})
 	}
 }
+
+func Test_isValidNameLengthBetween(t *testing.T) {
+	validateFunc := isValidNameLengthBetween(3, 64)
+
+	tests := []struct {
+		name  string
+		input interface{}
+		want  bool
+	}{
+		{
+			name:  "Valid string length within range",
+			input: "こんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちは",
+			want:  false,
+		},
+		{
+			name:  "String too short",
+			input: "こん",
+			want:  true,
+		},
+		{
+			name:  "String too long",
+			input: "こんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちは",
+			want:  true,
+		},
+		{
+			name:  "Empty string",
+			input: "",
+			want:  true,
+		},
+		{
+			name:  "Exact minimum length",
+			input: "こんに",
+			want:  false,
+		},
+		{
+			name:  "Exact maximum length",
+			input: "こんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにち",
+			want:  false,
+		},
+		{
+			name:  "Non-string input",
+			input: 12345,
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errors := validateFunc(tt.input, "test_field")
+
+			if tt.want {
+				assert.NotEmpty(t, errors, "Expected validation errors but got none")
+			} else {
+				assert.Empty(t, errors, "Expected no validation errors but got some")
+			}
+		})
+	}
+}

--- a/sakuracloud/validators_test.go
+++ b/sakuracloud/validators_test.go
@@ -79,8 +79,8 @@ func Test_isValidHostName(t *testing.T) {
 	}
 }
 
-func Test_isValidNameLengthBetween(t *testing.T) {
-	validateFunc := isValidNameLengthBetween(3, 64)
+func Test_isValidLengthBetween(t *testing.T) {
+	validateFunc := isValidLengthBetween(3, 64)
 
 	tests := []struct {
 		name  string


### PR DESCRIPTION
#1170 を修正。

リソース名をValidateする関数が文字数ではなくバイト数を見ていたため、文字が日本語の場合Validationの天井を超えてしまいエラーを返していました。

runeを使用して日本語を含む文字列を正しくValidateするように修正しました。