### PR TITLE
AppRunのenvをTypeSetに変更

### DIFF
--- a/sakuracloud/data_source_sakuracloud_apprun_application.go
+++ b/sakuracloud/data_source_sakuracloud_apprun_application.go
@@ -114,7 +114,7 @@ func dataSourceSakuraCloudApprunApplication() *schema.Resource {
 							},
 						},
 						"env": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Computed:    true,
 							Optional:    true,
 							Description: "The environment variables passed to components",
@@ -135,6 +135,13 @@ func dataSourceSakuraCloudApprunApplication() *schema.Resource {
 									},
 								},
 							},
+							Set: schema.HashResource(&schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type: schema.TypeString,
+									},
+								},
+							}),
 						},
 						"probe": {
 							Type:        schema.TypeList,

--- a/sakuracloud/resource_sakuracloud_apprun_application.go
+++ b/sakuracloud/resource_sakuracloud_apprun_application.go
@@ -140,7 +140,7 @@ func resourceSakuraCloudApprunApplication() *schema.Resource {
 							},
 						},
 						"env": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Optional:    true,
 							Description: "The environment variables passed to components",
 							Elem: &schema.Resource{
@@ -158,6 +158,13 @@ func resourceSakuraCloudApprunApplication() *schema.Resource {
 									},
 								},
 							},
+							Set: schema.HashResource(&schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type: schema.TypeString,
+									},
+								},
+							}),
 						},
 						"probe": {
 							Type:        schema.TypeList,

--- a/sakuracloud/resource_sakuracloud_apprun_application_test.go
+++ b/sakuracloud/resource_sakuracloud_apprun_application_test.go
@@ -129,6 +129,7 @@ func TestAccSakuraCloudApprunApplication_withEnv(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "256Mi"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.env.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.env.0.key", "key"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.env.0.value", "value"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.env.1.key", "key2"),
@@ -479,6 +480,10 @@ resource "sakuracloud_apprun_application" "foobar" {
     env {
       key   = "key"
       value = "value"
+    }
+    env {
+      key   = "key2"
+      value = "value2"
     }
     env {
       key   = "key2"


### PR DESCRIPTION
## 背景
https://github.com/sacloud/terraform-provider-sakuracloud/pull/1200 の続きとなります。

sakuracloud_apprun_application resourceにおいて、components.envが複数設定されている場合、実際には差分がないにも関わらず `terraform plan` でdiffが出てしまう問題の修正を行います。

### 問題の原因

AppRunのAPIではenvが複数ある場合 `/applications/{id}` でレスポンスされるenvの順序は保証されていません。
このためTerraform provider側でのenvの型が `schema.TypeList` の場合、順序が食い違った場合にplanでdiffが出てしまいます。

## 変更点

sakuracloud_apprun_application resourceの、components.envをTypeListからTypeSetに変更しました。

## 動作確認
- [x]  手元で実サーバーに対してAppRun関連のresource, datasourceのテストを実行してpassすること
