### PR TITLE
sakuracloud_apprun_application: added status and public_url

### DIFF
--- a/sakuracloud/resource_sakuracloud_apprun_application.go
+++ b/sakuracloud/resource_sakuracloud_apprun_application.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/sacloud/apprun-api-go"
 	v1 "github.com/sacloud/apprun-api-go/apis/v1"
 	"github.com/sacloud/terraform-provider-sakuracloud/internal/desc"
@@ -235,6 +234,16 @@ func resourceSakuraCloudApprunApplication() *schema.Resource {
 					},
 				},
 			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The application status",
+			},
+			"public_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The public URL",
+			},
 		},
 	}
 }
@@ -397,6 +406,8 @@ func setApprunApplicationResourceData(d *schema.ResourceData, application *v1.Ap
 	d.Set("max_scale", application.MaxScale)
 	d.Set("components", flattenApprunApplicationComponents(d, application, true))
 	d.Set("traffics", flattenApprunApplicationTraffics(traffics, versions))
+	d.Set("status", *application.Status)
+	d.Set("public_url", *application.PublicUrl)
 
 	return nil
 }

--- a/sakuracloud/resource_sakuracloud_apprun_application_test.go
+++ b/sakuracloud/resource_sakuracloud_apprun_application_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -52,6 +53,8 @@ func TestAccSakuraCloudApprunApplication_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "256Mi"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestMatchResourceAttr(resourceName, "status", regexp.MustCompile(".+")),
+					resource.TestMatchResourceAttr(resourceName, "public_url", regexp.MustCompile(".+")),
 				),
 			},
 			{
@@ -294,6 +297,10 @@ func TestAccImportSakuraCloudApprunApplication_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateCheck:  checkFn,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"status",
+					"public_url",
+				},
 			},
 		},
 	})
@@ -341,6 +348,8 @@ func TestAccImportSakuraCloudApprunApplication_withCRUser(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"components.0.deploy_source.0.container_registry.0.password",
+					"status",
+					"public_url",
 				},
 			},
 		},


### PR DESCRIPTION
#1200 の補完

apprun_applicationではデータソースにだけstatusとpublic_urlが定義されている。

https://github.com/sacloud/terraform-provider-sakuracloud/blob/57d7d745837ef97a98721d6446258568efb7623a/sakuracloud/data_source_sakuracloud_apprun_application.go#L198-L207

リソースの側に定義しない理由は特になさそうなためデータソースと同様に定義を追加する。