### PR TITLE
ContainerRegistry: beta

### DIFF
--- a/sakuracloud/resource_sakuracloud_container_registry.go
+++ b/sakuracloud/resource_sakuracloud_container_registry.go
@@ -103,8 +103,6 @@ func resourceSakuraCloudContainerRegistry() *schema.Resource {
 				},
 			},
 		},
-
-		DeprecationMessage: "sakuracloud_container_registry is an experimental resource. Please note that you will need to update the tfstate manually if the resource schema is changed.",
 	}
 }
 

--- a/website/docs/d/container_registry.md
+++ b/website/docs/d/container_registry.md
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_container_registry"
-subcategory: "Lab"
+subcategory: "Global"
 description: |-
   Get information about an existing Container Registry.
 ---

--- a/website/docs/r/container_registry.md
+++ b/website/docs/r/container_registry.md
@@ -1,7 +1,7 @@
 ---
 layout: "sakuracloud"
 page_title: "SakuraCloud: sakuracloud_container_registry"
-subcategory: "Lab"
+subcategory: "Global"
 description: |-
   Manages a SakuraCloud Container Registry.
 ---

--- a/website/sakuracloud.erb
+++ b/website/sakuracloud.erb
@@ -212,6 +212,9 @@
               <a href="#">Data Sources</a>
               <ul class="nav nav-auto-expand">
                 <li>
+                  <a href="/docs/providers/sakuracloud/d/container_registry.html">sakuracloud_container_registry</a>
+                </li>
+                <li>
                   <a href="/docs/providers/sakuracloud/d/dns.html">sakuracloud_dns</a>
                 </li>
                 <li>
@@ -228,6 +231,9 @@
             <li>
               <a href="#">Resources</a>
               <ul class="nav nav-auto-expand">
+                <li>
+                  <a href="/docs/providers/sakuracloud/r/container_registry.html">sakuracloud_container_registry</a>
+                </li>
                 <li>
                   <a href="/docs/providers/sakuracloud/r/dns.html">sakuracloud_dns</a>
                 </li>
@@ -297,7 +303,6 @@
               <a href="#">Data Sources</a>
               <ul class="nav nav-auto-expand">
                 <li>
-                  <a href="/docs/providers/sakuracloud/d/container_registry.html">sakuracloud_container_registry</a>
                   <a href="/docs/providers/sakuracloud/d/enhanced_db.html">sakuracloud_enhanced_db</a>
                 </li>
               </ul>
@@ -306,7 +311,6 @@
               <a href="#">Resources</a>
               <ul class="nav nav-auto-expand">
                 <li>
-                  <a href="/docs/providers/sakuracloud/r/container_registry.html">sakuracloud_container_registry</a>
                   <a href="/docs/providers/sakuracloud/r/enhanced_db.html">sakuracloud_enhanced_db</a>
                 </li>
               </ul>


### PR DESCRIPTION
コンテナレジストリのベータ版リリースに伴いDeprecatedメッセージを除去し、マニュアルの表示位置をLabs -> グローバルに変更する。

https://cloud.sakura.ad.jp/news/2025/01/23/container-registry-beta/