### PR TITLE
sakuracloud_apprun_application: set ForceNew: true for name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sacloud/api-client-go v0.2.10
-	github.com/sacloud/apprun-api-go v0.2.1
+	github.com/sacloud/apprun-api-go v0.3.0
 	github.com/sacloud/autoscaler v0.16.1
 	github.com/sacloud/iaas-api-go v1.14.0
 	github.com/sacloud/iaas-service-go v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/sacloud/api-client-go v0.2.10 h1:+rv3jDohD+pkdYwOTBiB+jZsM0xK3AxadXRzhp3q66c=
 github.com/sacloud/api-client-go v0.2.10/go.mod h1:Jj3CTy2+O4bcMedVDXlbHuqqche85HEPuVXoQFhLaRc=
-github.com/sacloud/apprun-api-go v0.2.1 h1:ji5E3xjnXE3MjrOMK0+DXK22bYrGPDO0OETL/QniZFQ=
-github.com/sacloud/apprun-api-go v0.2.1/go.mod h1:XB88c3BsZ8TBKNqN6K5+t/sJK+cg1PRRh2a1g4KBAzc=
+github.com/sacloud/apprun-api-go v0.3.0 h1:KOV6NLDE97RZrB9cyFpAHZdHdPovdZAQB6970aHJSpM=
+github.com/sacloud/apprun-api-go v0.3.0/go.mod h1:exDPXQMJIShaelI5LtXI3Ns7HwRLnYI8QuGFMd+pESM=
 github.com/sacloud/autoscaler v0.16.1 h1:W13gjBwRvYKw4bi4BZjFUUJNHMMARy45cq/YY6Mg2bE=
 github.com/sacloud/autoscaler v0.16.1/go.mod h1:Ai9bYmf+pHXrjQoHxmz/ST9vemYmPGmxex+feN12Iqs=
 github.com/sacloud/ftps v1.2.0 h1:7UlSWd7cnm1J+sANz7IiBV9ffVcS+4g6ZV5UHVVbvaw=

--- a/sakuracloud/resource_sakuracloud_apprun_application.go
+++ b/sakuracloud/resource_sakuracloud_apprun_application.go
@@ -79,6 +79,7 @@ func resourceSakuraCloudApprunApplication() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The component name",
+							ForceNew:    true,
 						},
 						"max_cpu": {
 							Type:             schema.TypeString,
@@ -341,13 +342,11 @@ func resourceSakuraCloudApprunApplicationUpdate(ctx context.Context, d *schema.R
 		return diag.Errorf("could not read SakuraCloud Apprun Application[%s]: %s", d.Id(), err)
 	}
 
-	patchedName := d.Get("name").(string)
 	patchedTimeoutSeconds := d.Get("timeout_seconds").(int)
 	patchedPort := d.Get("port").(int)
 	patchedMinScale := d.Get("min_scale").(int)
 	patchedMaxScale := d.Get("max_scale").(int)
 	params := v1.PatchApplicationBody{
-		Name:           &patchedName,
 		TimeoutSeconds: &patchedTimeoutSeconds,
 		Port:           &patchedPort,
 		MinScale:       &patchedMinScale,

--- a/website/docs/r/apprun_application.md
+++ b/website/docs/r/apprun_application.md
@@ -68,7 +68,7 @@ resource "sakuracloud_apprun_application" "foobar" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of application.
+* `name` - (Required) The name of application. Changing this forces a new resource to be created.
 * `timeout_seconds` - (Required) The time limit between accessing the application's public URL, starting the instance, and receiving a response.
 * `port` - (Required) The port number where the application listens for requests.
 * `min_scale` - (Required) The minimum number of scales for the entire application.


### PR DESCRIPTION
AppRun API v1.1対応の一環として `sakuracloud_apprun_application`の`name`の変更を不可とし、変更した場合は再作成するようにする(ForceNew: true)

```
TF_ACC=1 SAKURACLOUD_APPEND_USER_AGENT="(Acceptance Test)" go test -v -run=Apprun -timeout 240m ./...
?   	github.com/sacloud/terraform-provider-sakuracloud	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/internal/defaults	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/internal/desc	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/internal/ftps	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/tools/hash	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/tools/tfdocgen/cmd/gen-sakuracloud-docs	[no test files]
?   	github.com/sacloud/terraform-provider-sakuracloud/version	[no test files]
=== RUN   TestAccSakuraCloudDataSourceApprunApplication_basic
--- PASS: TestAccSakuraCloudDataSourceApprunApplication_basic (16.67s)
=== RUN   TestAccSakuraCloudDataSourceApprunApplication_withCRUser
--- PASS: TestAccSakuraCloudDataSourceApprunApplication_withCRUser (14.01s)
=== RUN   TestAccSakuraCloudDataSourceApprunApplication_withProbe
--- PASS: TestAccSakuraCloudDataSourceApprunApplication_withProbe (15.04s)
=== RUN   TestAccSakuraCloudDataSourceApprunApplication_withTraffic
--- PASS: TestAccSakuraCloudDataSourceApprunApplication_withTraffic (14.32s)
=== RUN   TestAccSakuraCloudApprunApplication_basic
--- PASS: TestAccSakuraCloudApprunApplication_basic (19.74s)
=== RUN   TestAccSakuraCloudApprunApplication_withCRUser
--- PASS: TestAccSakuraCloudApprunApplication_withCRUser (11.97s)
=== RUN   TestAccSakuraCloudApprunApplication_withEnv
--- PASS: TestAccSakuraCloudApprunApplication_withEnv (12.39s)
=== RUN   TestAccSakuraCloudApprunApplication_withProbe
--- PASS: TestAccSakuraCloudApprunApplication_withProbe (19.43s)
=== RUN   TestAccSakuraCloudApprunApplication_withTraffic
--- PASS: TestAccSakuraCloudApprunApplication_withTraffic (21.24s)
=== RUN   TestAccImportSakuraCloudApprunApplication_basic
--- PASS: TestAccImportSakuraCloudApprunApplication_basic (13.86s)
=== RUN   TestAccImportSakuraCloudApprunApplication_withCRUser
--- PASS: TestAccImportSakuraCloudApprunApplication_withCRUser (16.54s)
PASS
ok  	github.com/sacloud/terraform-provider-sakuracloud/sakuracloud	175.721s
testing: warning: no tests to run
PASS
ok  	github.com/sacloud/terraform-provider-sakuracloud/tools/tfdocgen	0.760s [no tests to run]
```