### PR TITLE
proposal: `apprun_application`で"name"に差分が出た場合、バリデーションエラーとする

### DIFF
--- a/sakuracloud/resource_sakuracloud_apprun_application.go
+++ b/sakuracloud/resource_sakuracloud_apprun_application.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -246,6 +247,7 @@ func resourceSakuraCloudApprunApplication() *schema.Resource {
 				Description: "The public URL",
 			},
 		},
+		CustomizeDiff: resourceSakuraCloudApprunApplicationDiff,
 	}
 }
 
@@ -393,6 +395,13 @@ func resourceSakuraCloudApprunApplicationDelete(ctx context.Context, d *schema.R
 
 	if err := appOp.Delete(ctx, *application.Id); err != nil {
 		return diag.Errorf("deleting SakuraCloud Apprun Application[%s] is failed: %s", *application.Id, err)
+	}
+	return nil
+}
+
+func resourceSakuraCloudApprunApplicationDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	if len(d.Id()) != 0 && d.HasChange("name") {
+		return fmt.Errorf(`invalid diff found in SakuraCloud Apprun Application[%s]: “name” is immutable and cannot be updated`, d.Id())
 	}
 	return nil
 }


### PR DESCRIPTION
このPRでは `sakuracloud_apprun_application`の"name"に差分があった場合、planでバリデーションエラーとする変更を加えています

Close #1231

## 目的

- AppRun のAPIドキュメントに準拠するため
  - `PATCH applications/{id}`のインターフェイスに"name"が含まれておらず、変更が不可能な項目となっている

https://manual.sakura.ad.jp/sakura-apprun-api/spec.html#tag/%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3/operation/patchApplication

## Acceptance Tests

```sh
TF_ACC=1 go test -v -run=TestAccSakuraCloudApprunApplication ./...
?       github.com/sacloud/terraform-provider-sakuracloud       [no test files]
?       github.com/sacloud/terraform-provider-sakuracloud/internal/defaults     [no test files]
?       github.com/sacloud/terraform-provider-sakuracloud/internal/desc [no test files]
?       github.com/sacloud/terraform-provider-sakuracloud/internal/ftps [no test files]
?       github.com/sacloud/terraform-provider-sakuracloud/tools/hash    [no test files]
?       github.com/sacloud/terraform-provider-sakuracloud/tools/tfdocgen/cmd/gen-sakuracloud-docs       [no test files]
?       github.com/sacloud/terraform-provider-sakuracloud/version       [no test files]
=== RUN   TestAccSakuraCloudApprunApplication_basic
--- PASS: TestAccSakuraCloudApprunApplication_basic (13.03s)
=== RUN   TestAccSakuraCloudApprunApplication_withCRUser
--- PASS: TestAccSakuraCloudApprunApplication_withCRUser (6.81s)
=== RUN   TestAccSakuraCloudApprunApplication_withEnv
--- PASS: TestAccSakuraCloudApprunApplication_withEnv (7.44s)
=== RUN   TestAccSakuraCloudApprunApplication_withProbe
--- PASS: TestAccSakuraCloudApprunApplication_withProbe (13.68s)
=== RUN   TestAccSakuraCloudApprunApplication_withTraffic
--- PASS: TestAccSakuraCloudApprunApplication_withTraffic (14.33s)
=== RUN   TestAccSakuraCloudApprunApplication_diffInName
--- PASS: TestAccSakuraCloudApprunApplication_diffInName (7.99s)
PASS
ok      github.com/sacloud/terraform-provider-sakuracloud/sakuracloud   63.304s
testing: warning: no tests to run
PASS
ok      github.com/sacloud/terraform-provider-sakuracloud/tools/tfdocgen        0.007s [no tests to run]
```

## ローカルでの実行結果

```diff
resource sakuracloud_apprun_application "this" {
-   name            = "foo"
+   name            = "foobar"
  timeout_seconds = 60
  port            = 80
  min_scale       = 0
  max_scale       = 1
  components {
    name       = "foobar"
    max_cpu    = "0.1"
    max_memory = "256Mi"
    deploy_source {
      container_registry {
        image    = "foorbar.sakuracr.jp/foorbar:latest"
      }
    }
    probe {
      http_get {
        path = "/"
        port = 80
        headers {
          name  = "name"
          value = "value"
        }
        headers {
          name  = "name2"
          value = "value2"
        }
      }
    }
  }

  traffics {
    version_index = 0
    percent       = 100
  }
}
```

### plan

```sh
terraform plan                                                  
sakuracloud_apprun_application.this: Refreshing state... [id=<id>]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: invalid diff found in SakuraCloud Apprun Application[<id>]: “name” is immutable and cannot be updated
│
│   with sakuracloud_apprun_application.this,
│   on main.tf line 20, in resource "sakuracloud_apprun_application" "this":
│   20: resource sakuracloud_apprun_application "this" {
│
```

### apply

```sh
terraform apply
sakuracloud_apprun_application.this: Refreshing state... [id=<id>]
╷
│ Error: invalid diff found in SakuraCloud Apprun Application[<id>]: “name” is immutable and cannot be updated
│
│   with sakuracloud_apprun_application.this,
│   on main.tf line 20, in resource "sakuracloud_apprun_application" "this":
│   20: resource sakuracloud_apprun_application "this" {
│
╵
```