### PR TITLE
Update GitHub Actions matrix to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-24.04, ubuntu-22.04]
+        os: [macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04, ubuntu-22.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-22.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-24.04, ubuntu-22.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
サポートが終了したUbuntu 20.04の代わりにUbuntu 24.04を利用するようにした

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/ 