### PR TITLE
ウェブアクセラレーターのオリジンガードトークン制御機能 ＆ Let's Encrypt設定機能を追加

### DIFF
--- a/examples/webaccel/main.tf
+++ b/examples/webaccel/main.tf
@@ -7,6 +7,7 @@ resource "sakuracloud_webaccel" "foobar" {
     origin   = "docs.usacloud.jp"
     protocol = "https"
   }
+  origin_guard_token {}
   onetime_url_secrets = [
     "abc-0x123456"
   ]

--- a/sakuracloud/resource_sakuracloud_webaccel.go
+++ b/sakuracloud/resource_sakuracloud_webaccel.go
@@ -323,6 +323,7 @@ func resourceSakuraCloudWebAccelCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(e)
 	}
 	// logging
+	// Note: これ以降、いずれかの処理が失敗した場合にはサイトの作成を中断し、サイトを削除する
 	if hasLoggingConfig {
 		cfg, err := expandLoggingParameters(d)
 		if err != nil {
@@ -335,7 +336,7 @@ func resourceSakuraCloudWebAccelCreate(ctx context.Context, d *schema.ResourceDa
 	}
 	d.SetId(res.ID)
 
-	// いずれかの処理が失敗した場合、サイトの作成を中断し、サイトを削除する
+	// origin_guard_token
 	if _, ok := d.GetOk("origin_guard_token"); ok {
 		attr, err := mapFromSet(d, "origin_guard_token")
 		if err != nil {
@@ -514,7 +515,7 @@ func setWebAccelResourceData(d *schema.ResourceData, client *APIClient, data *we
 
 // setOriginGuardTokenParameters オリジンガードトークンを新規作成or更新して、値を`ResourceData`に代入する。
 // 第1引数の`ResourceData`には事前にIDを設定しておくこと。
-// rotate=false への切り戻しなど、APIコールを実施したくない場合は、opにnilを代入する。
+// rotate=true から false への切り戻しなど、APIコールを実施したくない場合は、opにnilを代入する。
 func setOriginGuardTokenParameters(d *schema.ResourceData, ctx context.Context, op webaccel.API) error {
 	if _, ok := d.GetOk("origin_guard_token"); !ok {
 		err := op.DeleteOriginGuardToken(ctx, d.Id())

--- a/sakuracloud/resource_sakuracloud_webaccel.go
+++ b/sakuracloud/resource_sakuracloud_webaccel.go
@@ -17,6 +17,7 @@ package sakuracloud
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/sakuracloud/resource_sakuracloud_webaccel.go
+++ b/sakuracloud/resource_sakuracloud_webaccel.go
@@ -504,6 +504,14 @@ func setWebAccelResourceData(d *schema.ResourceData, client *APIClient, data *we
 // setOriginGuardTokenParameters オリジンガードトークンを新規作成or更新して、値を`ResourceData`に代入する。
 // 第1引数の`ResourceData`には事前にIDを設定しておくこと。
 func setOriginGuardTokenParameters(d *schema.ResourceData, ctx context.Context, op webaccel.API) error {
+	if _, ok := d.GetOk("origin_guard_token"); !ok {
+		err := op.DeleteOriginGuardToken(ctx, d.Id())
+		if err != nil {
+			return err
+		}
+		d.Set("origin_guard_token", nil) // nolint:errcheck,gosec
+		return nil
+	}
 	originGuardTokenAttr := make(map[string]interface{})
 	param, err := mapFromSet(d, "origin_guard_token")
 	if err != nil {

--- a/sakuracloud/resource_sakuracloud_webaccel_acl_test.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_acl_test.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"github.com/sacloud/packages-go/testutil"
 	"os"
 	"testing"
 
@@ -24,15 +25,7 @@ import (
 )
 
 func TestAccResourceSakuraCloudWebAccelACL_basic(t *testing.T) {
-	envKeys := []string{
-		envWebAccelSiteName,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	testutil.PreCheckEnvsFunc(envWebAccelSiteName)(t)
 
 	siteName := os.Getenv(envWebAccelSiteName)
 

--- a/sakuracloud/resource_sakuracloud_webaccel_activation_test.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_activation_test.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"github.com/sacloud/packages-go/testutil"
 	"os"
 	"testing"
 
@@ -24,15 +25,7 @@ import (
 )
 
 func TestAccResourceSakuraCloudWebAccelActivation_Basic(t *testing.T) {
-	envKeys := []string{
-		envWebAccelSiteName,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	testutil.PreCheckEnvsFunc(envWebAccelSiteName)(t)
 
 	siteName := os.Getenv(envWebAccelSiteName)
 
@@ -54,15 +47,7 @@ func TestAccResourceSakuraCloudWebAccelActivation_Basic(t *testing.T) {
 }
 
 func TestAccResourceSakuraCloudWebAccelActivation_Update(t *testing.T) {
-	envKeys := []string{
-		envWebAccelSiteName,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	testutil.PreCheckEnvsFunc(envWebAccelSiteName)(t)
 
 	siteName := os.Getenv(envWebAccelSiteName)
 

--- a/sakuracloud/resource_sakuracloud_webaccel_certificate.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_certificate.go
@@ -102,7 +102,8 @@ func resourceSakuraCloudWebAccelCertificateCreate(ctx context.Context, d *schema
 	_, hasCertChain := d.GetOk("certificate_chain")
 	_, hasPrivKey := d.GetOk("private_key")
 
-	if hasCertChain && hasPrivKey {
+	switch {
+	case hasCertChain && hasPrivKey:
 		res, err := webaccel.NewOp(client.webaccelClient).CreateCertificate(ctx, siteID, &webaccel.CreateOrUpdateCertificateRequest{
 			CertificateChain: d.Get("certificate_chain").(string),
 			Key:              d.Get("private_key").(string),
@@ -112,9 +113,9 @@ func resourceSakuraCloudWebAccelCertificateCreate(ctx context.Context, d *schema
 		}
 
 		d.SetId(res.Current.SiteID)
-	} else if hasCertChain || hasPrivKey {
+	case hasCertChain || hasPrivKey:
 		return diag.Errorf("certificate_chain and private_key must be specified together")
-	} else {
+	default:
 		if v, ok := d.GetOk("lets_encrypt"); ok && v.(bool) {
 			err = webaccel.NewOp(client.webaccelClient).CreateAutoCertUpdate(ctx, siteID)
 			if err != nil {

--- a/sakuracloud/resource_sakuracloud_webaccel_certificate.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_certificate.go
@@ -36,14 +36,25 @@ func resourceSakuraCloudWebAccelCertificate() *schema.Resource {
 				Required: true,
 			},
 			"certificate_chain": {
-				Type:      schema.TypeString,
-				Required:  true,
-				Sensitive: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Certificate chain for the site. Required for own certificates.",
+				ConflictsWith: []string{"lets_encrypt"},
+				Sensitive:     true,
 			},
 			"private_key": {
-				Type:      schema.TypeString,
-				Required:  true,
-				Sensitive: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Private key for the site. Required for own certificates.",
+				ConflictsWith: []string{"lets_encrypt"},
+				Sensitive:     true,
+			},
+			"lets_encrypt": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Description:   "Whether the Let's Encrypt certificate auto renewal is enabled or not.",
+				ConflictsWith: []string{"private_key", "certificate_chain"},
+				Default:       false,
 			},
 			"serial_number": {
 				Type:     schema.TypeString,
@@ -86,15 +97,32 @@ func resourceSakuraCloudWebAccelCertificateCreate(ctx context.Context, d *schema
 
 	siteID := d.Get("site_id").(string)
 
-	res, err := webaccel.NewOp(client.webaccelClient).CreateCertificate(ctx, siteID, &webaccel.CreateOrUpdateCertificateRequest{
-		CertificateChain: d.Get("certificate_chain").(string),
-		Key:              d.Get("private_key").(string),
-	})
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	// NOTE: `lets_encrypt` argument は `certificate_chain`,`private_key`と相互に排他的。
+	// スキーマレベルでこれらの引数の競合を検出・防止する。
 
-	d.SetId(res.Current.SiteID)
+	// FIXME: 条件分岐を部分的に外側に切り出すなどして、可読性を向上させること。
+	if _, ok := d.GetOk("certificate_chain"); ok {
+		if _, ok = d.GetOk("private_key"); ok {
+			res, err := webaccel.NewOp(client.webaccelClient).CreateCertificate(ctx, siteID, &webaccel.CreateOrUpdateCertificateRequest{
+				CertificateChain: d.Get("certificate_chain").(string),
+				Key:              d.Get("private_key").(string),
+			})
+			if err != nil {
+				return diag.FromErr(err)
+			}
+
+			d.SetId(res.Current.SiteID)
+		} else {
+			return diag.Errorf("certificate_chain and private_key must be specified together")
+		}
+	} else if _, ok := d.GetOk("private_key"); ok {
+		return diag.Errorf("certificate_chain and private_key must be specified together")
+	} else if _, ok := d.GetOk("lets_encrypt"); ok {
+		err = webaccel.NewOp(client.webaccelClient).CreateAutoCertUpdate(ctx, siteID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
 	return resourceSakuraCloudWebAccelCertificateRead(ctx, d, meta)
 }
 
@@ -106,21 +134,26 @@ func resourceSakuraCloudWebAccelCertificateRead(ctx context.Context, d *schema.R
 
 	siteID := d.Id()
 
-	certs, err := webaccel.NewOp(client.webaccelClient).ReadCertificate(ctx, siteID)
-	if err != nil {
-		if iaas.IsNotFoundError(err) {
+	if v, ok := d.GetOk("lets_encrypt"); ok {
+		// Note: Let'sEncrypt の有効化状態を取得する処理がwebaccel-api-goに存在しないため、便宜的にテンプレート上の状態を無条件でResourceDataに代入する。
+		// [詳細] https://github.com/sacloud/webaccel-api-go/issues/70
+		return setWebAccelCertificateLetsEncryptResourceData(d, siteID, v.(bool))
+	} else {
+		certs, err := webaccel.NewOp(client.webaccelClient).ReadCertificate(ctx, siteID)
+		if err != nil {
+			if iaas.IsNotFoundError(err) {
+				d.SetId("")
+				return nil
+			}
+			return diag.Errorf("could not read SakuraCloud WebAccelCert[%s]: %s", d.Id(), err)
+		}
+
+		if certs.Current == nil {
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("could not read SakuraCloud WebAccelCert[%s]: %s", d.Id(), err)
+		return setWebAccelCertificateResourceData(d, client, certs.Current)
 	}
-
-	if certs.Current == nil {
-		d.SetId("")
-		return nil
-	}
-
-	return setWebAccelCertificateResourceData(d, client, certs.Current)
 }
 
 func resourceSakuraCloudWebAccelCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -139,6 +172,12 @@ func resourceSakuraCloudWebAccelCertificateUpdate(ctx context.Context, d *schema
 			return diag.FromErr(err)
 		}
 		d.SetId(res.Current.SiteID)
+	} else if d.HasChange("lets_encrypt") {
+		if v := d.Get("lets_encrypt").(bool); v {
+			err = webaccel.NewOp(client.webaccelClient).CreateAutoCertUpdate(ctx, siteID)
+		} else {
+			err = webaccel.NewOp(client.webaccelClient).DeleteAutoCertUpdate(ctx, siteID)
+		}
 	}
 
 	return resourceSakuraCloudWebAccelCertificateRead(ctx, d, meta)
@@ -173,5 +212,11 @@ func setWebAccelCertificateResourceData(d *schema.ResourceData, client *APIClien
 		return diag.FromErr(err)
 	}
 	d.Set("sha256_fingerprint", data.SHA256Fingerprint) //nolint
+	return nil
+}
+
+func setWebAccelCertificateLetsEncryptResourceData(d *schema.ResourceData, siteId string, isEnabled bool) diag.Diagnostics {
+	d.Set("site_id", siteId)         //nolint
+	d.Set("lets_encrypt", isEnabled) //nolint
 	return nil
 }

--- a/sakuracloud/resource_sakuracloud_webaccel_certificate.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_certificate.go
@@ -200,7 +200,7 @@ func resourceSakuraCloudWebAccelCertificateDelete(ctx context.Context, d *schema
 	siteID := d.Get("site_id").(string)
 
 	// Note: テンプレートが`lets_encrypt=false`に変更されている場合には、削除処理が失敗する
-	if _, isLetsEncrypt := d.GetOk("lets_encrypt"); isLetsEncrypt {
+	if _, hasLetsEncrypt := d.GetOk("lets_encrypt"); hasLetsEncrypt {
 		err = webaccel.NewOp(client.webaccelClient).DeleteAutoCertUpdate(ctx, siteID)
 		if err != nil {
 			return diag.Errorf("deleting SakuraCloud WebAccelCert[%s] (Let's Encrypt) is failed: %s", d.Id(), err)

--- a/sakuracloud/resource_sakuracloud_webaccel_certificate_test.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_certificate_test.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"github.com/sacloud/packages-go/testutil"
 	"os"
 	"regexp"
 	"testing"
@@ -32,19 +33,13 @@ const (
 )
 
 func TestAccResourceSakuraCloudWebAccelCertificate_basic(t *testing.T) {
-	envKeys := []string{
+	testutil.PreCheckEnvsFunc(
 		envWebAccelSiteName,
 		envWebAccelCertificateCrt,
 		envWebAccelCertificateKey,
 		envWebAccelCertificateCrtUpd,
 		envWebAccelCertificateKeyUpd,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	)(t)
 
 	siteName := os.Getenv(envWebAccelSiteName)
 	crt := os.Getenv(envWebAccelCertificateCrt)
@@ -90,15 +85,9 @@ func TestAccResourceSakuraCloudWebAccelCertificate_basic(t *testing.T) {
 }
 
 func TestAccResourceSakuraCloudWebAccelCertificate_LetsEncrypt(t *testing.T) {
-	envKeys := []string{
-		envWebAccelSiteName,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	skipIfFakeModeEnabled(t)
+
+	testutil.PreCheckEnvsFunc(envWebAccelSiteName)(t)
 
 	siteName := os.Getenv(envWebAccelSiteName)
 	regexpNotEmpty := regexp.MustCompile(".+")
@@ -138,17 +127,11 @@ func TestAccResourceSakuraCloudWebAccelCertificate_LetsEncrypt(t *testing.T) {
 }
 
 func TestAccResourceSakuraCloudWebAccelCertificate_InvalidConfigs(t *testing.T) {
-	envKeys := []string{
+	testutil.PreCheckEnvsFunc(
 		envWebAccelSiteName,
 		envWebAccelCertificateCrt,
 		envWebAccelCertificateKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	)(t)
 
 	crt := os.Getenv(envWebAccelCertificateCrt)
 	key := os.Getenv(envWebAccelCertificateKey)

--- a/sakuracloud/resource_sakuracloud_webaccel_certificate_test.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_certificate_test.go
@@ -122,9 +122,17 @@ func TestAccResourceSakuraCloudWebAccelCertificate_LetsEncrypt(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("sakuracloud_webaccel_certificate.foobar", "id", regexpNotEmpty),
 					resource.TestMatchResourceAttr("sakuracloud_webaccel_certificate.foobar", "site_id", regexpNotEmpty),
-					resource.TestCheckResourceAttr("sakuracloud_webaccel_certificate.foobar", "lets_encrypt", "true"),
+					resource.TestCheckResourceAttr("sakuracloud_webaccel_certificate.foobar", "lets_encrypt", "false"),
 				),
 			},
+			//{
+			//	Config: testAccCheckSakuraCloudWebAccelCertificateFreeCertConfig(siteName, true),
+			//	Check: resource.ComposeTestCheckFunc(
+			//		resource.TestMatchResourceAttr("sakuracloud_webaccel_certificate.foobar", "id", regexpNotEmpty),
+			//		resource.TestMatchResourceAttr("sakuracloud_webaccel_certificate.foobar", "site_id", regexpNotEmpty),
+			//		resource.TestCheckResourceAttr("sakuracloud_webaccel_certificate.foobar", "lets_encrypt", "true"),
+			//	),
+			//},
 		},
 	})
 }

--- a/sakuracloud/resource_sakuracloud_webaccel_certificate_test.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_certificate_test.go
@@ -110,29 +110,28 @@ func TestAccResourceSakuraCloudWebAccelCertificate_LetsEncrypt(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
+				Config:      testAccCheckSakuraCloudWebAccelCertificateFreeCertConfig(siteName, false),
+				ExpectError: regexp.MustCompile("must be true for the creation"),
+				Destroy:     false,
+			},
+			{
 				Config: testAccCheckSakuraCloudWebAccelCertificateFreeCertConfig(siteName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("sakuracloud_webaccel_certificate.foobar", "id", regexpNotEmpty),
 					resource.TestMatchResourceAttr("sakuracloud_webaccel_certificate.foobar", "site_id", regexpNotEmpty),
 					resource.TestCheckResourceAttr("sakuracloud_webaccel_certificate.foobar", "lets_encrypt", "true"),
 				),
+				Destroy: false,
 			},
 			{
-				Config: testAccCheckSakuraCloudWebAccelCertificateFreeCertConfig(siteName, false),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("sakuracloud_webaccel_certificate.foobar", "id", regexpNotEmpty),
-					resource.TestMatchResourceAttr("sakuracloud_webaccel_certificate.foobar", "site_id", regexpNotEmpty),
-					resource.TestCheckResourceAttr("sakuracloud_webaccel_certificate.foobar", "lets_encrypt", "false"),
-				),
+				Config:      testAccCheckSakuraCloudWebAccelCertificateFreeCertConfig(siteName, false),
+				ExpectError: regexp.MustCompile("must not be false"),
+				Destroy:     false,
 			},
-			//{
-			//	Config: testAccCheckSakuraCloudWebAccelCertificateFreeCertConfig(siteName, true),
-			//	Check: resource.ComposeTestCheckFunc(
-			//		resource.TestMatchResourceAttr("sakuracloud_webaccel_certificate.foobar", "id", regexpNotEmpty),
-			//		resource.TestMatchResourceAttr("sakuracloud_webaccel_certificate.foobar", "site_id", regexpNotEmpty),
-			//		resource.TestCheckResourceAttr("sakuracloud_webaccel_certificate.foobar", "lets_encrypt", "true"),
-			//	),
-			//},
+			{
+				Config:  testAccCheckSakuraCloudWebAccelCertificateFreeCertConfig(siteName, true),
+				Destroy: true,
+			},
 		},
 	})
 }

--- a/sakuracloud/resource_sakuracloud_webaccel_test.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_test.go
@@ -333,11 +333,8 @@ func TestAccSakuraCloudResourceWebAccel_WebOriginWithOriginGuard(t *testing.T) {
 	}
 
 	siteName := "your-site-name"
-	// domainName := os.Getenv(envWebAccelDomainName)
 	origin := os.Getenv(envWebAccelOrigin)
 	regexpNotEmpty := regexp.MustCompile(".+")
-	//FIXME: ローテーション処理でトークンが変更されることを検証(できればする)
-	//tmpTokenValue := ""
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -500,7 +497,7 @@ resource sakuracloud_webaccel "foobar" {
 }
 `
 	if hasRotateField {
-		return fmt.Sprintf(tmpl, siteName, origin, origin, "rotate = true")
+		return fmt.Sprintf(tmpl, siteName, origin, origin, "\n    rotate = true\n")
 	} else {
 		return fmt.Sprintf(tmpl, siteName, origin, origin, "")
 	}

--- a/sakuracloud/resource_sakuracloud_webaccel_test.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_test.go
@@ -371,6 +371,19 @@ func TestAccSakuraCloudResourceWebAccel_WebOriginWithOriginGuard(t *testing.T) {
 					resource.TestCheckResourceAttr("sakuracloud_webaccel.foobar", "origin_parameters.0.origin", origin),
 					resource.TestMatchResourceAttr("sakuracloud_webaccel.foobar", "origin_guard_token.0.token", regexpNotEmpty),
 					resource.TestCheckResourceAttr("sakuracloud_webaccel.foobar", "origin_guard_token.0.rotate", "false"),
+					resource.TestCheckResourceAttrSet("sakuracloud_webaccel.foobar", "origin_guard_token.0.token"),
+				),
+			},
+			{
+				Config:      testAccCheckSakuraCloudWebAccelWebOriginConfigBasic(siteName, origin),
+				ExpectError: regexpNotEmpty,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sakuracloud_webaccel.foobar", "name", siteName),
+					resource.TestCheckResourceAttr("sakuracloud_webaccel.foobar", "origin_parameters.0.type", "web"),
+					resource.TestCheckResourceAttr("sakuracloud_webaccel.foobar", "origin_parameters.0.origin", origin),
+					// Note: It fails the absence of a token, but it does not check the removal of the token in real.
+					// FIXME: So you require the manual check of the token absence to ensure the valid behavior.
+					resource.TestCheckResourceAttrSet("sakuracloud_webaccel.foobar", "origin_guard_token.0.token"),
 				),
 			},
 		},

--- a/sakuracloud/resource_sakuracloud_webaccel_test.go
+++ b/sakuracloud/resource_sakuracloud_webaccel_test.go
@@ -16,6 +16,7 @@ package sakuracloud
 
 import (
 	"fmt"
+	"github.com/sacloud/packages-go/testutil"
 	"os"
 	"regexp"
 	"strings"
@@ -28,15 +29,7 @@ import (
 func TestAccSakuraCloudResourceWebAccel_WebOrigin(t *testing.T) {
 	skipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	testutil.PreCheckEnvsFunc(envWebAccelOrigin)(t)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -69,15 +62,7 @@ func TestAccSakuraCloudResourceWebAccel_WebOrigin(t *testing.T) {
 func TestAccSakuraCloudResourceWebAccel_WebOriginWithOneTimeUrlSecrets(t *testing.T) {
 	skipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	testutil.PreCheckEnvsFunc(envWebAccelOrigin)(t)
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)
@@ -105,15 +90,7 @@ func TestAccSakuraCloudResourceWebAccel_WebOriginWithOneTimeUrlSecrets(t *testin
 func TestAccSakuraCloudResourceWebAccel_WebOriginWithCORS(t *testing.T) {
 	skipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	testutil.PreCheckEnvsFunc(envWebAccelOrigin)(t)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -145,20 +122,14 @@ func TestAccSakuraCloudResourceWebAccel_WebOriginWithCORS(t *testing.T) {
 func TestAccSakuraCloudResourceWebAccel_Update(t *testing.T) {
 	skipIfFakeModeEnabled(t)
 
-	envKeys := []string{
+	testutil.PreCheckEnvsFunc(
 		envWebAccelOrigin,
 		envObjectStorageEndpoint,
 		envObjectStorageRegion,
 		envObjectStorageBucketName,
 		envObjectStorageAccessKeyId,
 		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	)(t)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -228,20 +199,14 @@ func TestAccSakuraCloudResourceWebAccel_Update(t *testing.T) {
 func TestAccSakuraCloudResourceWebAccel_BucketOrigin(t *testing.T) {
 	skipIfFakeModeEnabled(t)
 
-	envKeys := []string{
+	testutil.PreCheckEnvsFunc(
 		envWebAccelOrigin,
 		envObjectStorageEndpoint,
 		envObjectStorageRegion,
 		envObjectStorageBucketName,
 		envObjectStorageAccessKeyId,
 		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	)(t)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -278,18 +243,12 @@ func TestAccSakuraCloudResourceWebAccel_BucketOrigin(t *testing.T) {
 func TestAccSakuraCloudResourceWebAccel_Logging(t *testing.T) {
 	skipIfFakeModeEnabled(t)
 
-	envKeys := []string{
+	testutil.PreCheckEnvsFunc(
 		envWebAccelOrigin,
 		envObjectStorageBucketName,
 		envObjectStorageAccessKeyId,
 		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	)(t)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -322,15 +281,7 @@ func TestAccSakuraCloudResourceWebAccel_Logging(t *testing.T) {
 func TestAccSakuraCloudResourceWebAccel_WebOriginWithOriginGuard(t *testing.T) {
 	skipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is requilred. skip", k)
-			return
-		}
-	}
+	testutil.PreCheckEnvsFunc(envWebAccelOrigin)(t)
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)
@@ -440,10 +391,8 @@ func TestAccSakuraCloudResourceWebAccel_WebOriginWithOriginGuard(t *testing.T) {
 }
 
 func TestAccSakuraCloudResourceWebAccel_InvalidConfigurations(t *testing.T) {
-	if os.Getenv(envWebAccelOrigin) == "" {
-		t.Skipf("ENV %q is requilred. skip", envWebAccelOrigin)
-		return
-	}
+	testutil.PreCheckEnvsFunc(envWebAccelOrigin)(t)
+
 	origin := os.Getenv(envWebAccelOrigin)
 	for name, tc := range testAccCheckSakuraCloudWebAccelInvalidConfigs(origin) {
 		t.Logf("test for invalid configuration: %s", name)

--- a/website/docs/r/webaccel.md
+++ b/website/docs/r/webaccel.md
@@ -24,6 +24,7 @@ resource "sakuracloud_webaccel" "foobar" {
     origin   = "docs.usacloud.jp"
     protocol = "https"
   }
+  origin_guard_token {}
   logging {
     s3_bucket_name = "example-bucket"
     s3_access_key_id = "xxxxxxxxxxxxxxx"
@@ -74,6 +75,12 @@ An `origin_parameters` block supports following parameters:
 
 ---
 
+An `origin_guard_token` block supports following parameters:
+
+* `rotate` - Whether the origin guard token is immediately rotated or not. false by default.
+
+---
+
 A `logging` block supports following parameters:
 
 * `s3_bucket_name` - The bucket name for the log destination. In present, a bucket on the sakura object storage is supported.
@@ -96,16 +103,23 @@ A `logging` block supports following parameters:
 
 An `origin_parameters` block provides following attributes:
 
-* `type` - (Required) The origin type. Either of `web` or `bucket`.
-* `origin` - (Required) The origin hostname or IPv4 address.
-* `protocol` - (Required) Origin access protocol. Either of `http` or `https`.
-* `host_header` - (Optional) HTTP Host header for the origin access.
-* `s3_endpoint` - (Required) S3 endpoint without protocol scheme. Specify `s3.isk01.sakurastorage.jp` for the sakura object storage.
-* `s3_region` - (Required) S3 region. Specify `jp-north-1` for the sakura object storage.
+* `type` - The origin type. Either of `web` or `bucket`.
+* `origin` - The origin hostname or IPv4 address.
+* `protocol` - Origin access protocol. Either of `http` or `https`.
+* `host_header` - HTTP Host header for the origin access.
+* `s3_endpoint` - S3 endpoint without protocol scheme. Specify `s3.isk01.sakurastorage.jp` for the sakura object storage.
+* `s3_region` - S3 region. Specify `jp-north-1` for the sakura object storage.
 * `s3_bucket_name` - The origin bucket name. Bucket prefix is not supported at now.
 * `s3_access_key_id` - The S3 access key ID for the bucket.
 * `s3_secret_access_key` - The S3 secret access key for the bucket.
-* `s3_doc_index` - (Optional) Whether the document indexing is enabled or not. `false` by default.
+* `s3_doc_index` - Whether the document indexing is enabled or not. `false` by default.
+
+---
+
+An `origin_guard_token` block provides following attributes:
+
+* `token` - The origin guard token value
+* `rotate` - Whether the origin guard token is immediately rotated or not, for the applying the template 
 
 ---
 

--- a/website/docs/r/webaccel.md
+++ b/website/docs/r/webaccel.md
@@ -119,7 +119,7 @@ An `origin_parameters` block provides following attributes:
 An `origin_guard_token` block provides following attributes:
 
 * `token` - The origin guard token value
-* `rotate` - Whether the origin guard token is immediately rotated or not, for the applying the template 
+* `rotate` - Whether the origin guard token is immediately rotated or not. It must not be `true` for the creation. `false` by default.
 
 ---
 

--- a/website/docs/r/webaccel_certificate.md
+++ b/website/docs/r/webaccel_certificate.md
@@ -28,8 +28,9 @@ resource sakuracloud_webaccel_certificate "foobar" {
 
 ## Argument Reference
 
-* `certificate_chain` - (Required) .
-* `private_key` - (Required) .
+* `certificate_chain` - (Optional) Certificate chain for the site (mutually exclusive with `lets_encrypt`, used with `private_key`).
+* `private_key` - (Optional) Private key for the site (mutually exclusive with `lets_encrypt`, used with `certificate_chain`).
+* `lets_encrypt` - (Optional) `true` for enabling lets_encrypt certificate auto renewal  (mutually exclusive with `certificate_chain` or `private_key`).
 * `site_id` - (Required) .
 
 ## Attribute Reference
@@ -42,3 +43,4 @@ resource sakuracloud_webaccel_certificate "foobar" {
 * `serial_number` - .
 * `sha256_fingerprint` - .
 * `subject_common_name` - .
+* `lets_encrypt` - .


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #1258 

### このPRはどういう変更を行いますか？

* `resource_sakuracloud_webaccel`で、オリジンガードトークンを発行・更新する機能を追加します
* `resource_sakuracloud_certificate`で、Let's Encrypt証明書自動更新を有効化 ・無効化 する機能を追加します。

(以下追記) 

* 2025年7月時点のAPI仕様においては、 Let's Encryptがサイトで有効化されているかどうかを取得する処理が[実装できなかったため](https://github.com/sacloud/webaccel-api-go/issues/70)、いったん有効化のみをサポートする構成としました。
* オリジンガードトークンはCreate/Update時の値のみを保持し、Read処理では何もしない作りとなっています。

### ドキュメントの変更は必要ですか？

必要です。

### Additional info

* ~~現状、test & lint 通過していません。通過次第`draft`解除します。~~
* [本件](https://github.com/sacloud/terraform-provider-sakuracloud/issues/1258#issuecomment-2960821347)についてですが、`origin_guard_token`ブロックのパラメタについては、現時点で`rorate`方式を採用しています。