### PR TITLE
fix: SSH公開鍵が反映されない問題を修正

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sacloud/apprun-api-go v0.3.0
 	github.com/sacloud/autoscaler v0.16.1
 	github.com/sacloud/iaas-api-go v1.16.0
-	github.com/sacloud/iaas-service-go v1.12.0
+	github.com/sacloud/iaas-service-go v1.12.1
 	github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8
 	github.com/sacloud/packages-go v0.0.11
 	github.com/sacloud/simplemq-api-go v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.5.2 h1:aWv8eimFqWlsEiMrYZdPYl+FdHaBJSN4AWwGWfT1G2Y=
 github.com/hashicorp/go-plugin v1.5.2/go.mod h1:w1sAEES3g3PuV/RzUrgow20W2uErMly84hhD3um1WL4=
-github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
-github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -229,8 +227,6 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/sacloud/api-client-go v0.3.0 h1:NLA2BpZ5welAXBPxgmXSCjgn/k0ShDB0x5kmUHl7TJ4=
-github.com/sacloud/api-client-go v0.3.0/go.mod h1:v8ke3pxVQ9TCWEbMkfbLX8NMeGiPpE+uDwlgcUWfMgM=
 github.com/sacloud/api-client-go v0.3.2 h1:INbdSpQbyGN9Ai4hQ+Gbv3UQcgtRPG2tJrOmqT7HGl0=
 github.com/sacloud/api-client-go v0.3.2/go.mod h1:0p3ukcWYXRCc2AUWTl1aA+3sXLvurvvDqhRaLZRLBwo=
 github.com/sacloud/apprun-api-go v0.3.0 h1:KOV6NLDE97RZrB9cyFpAHZdHdPovdZAQB6970aHJSpM=
@@ -247,14 +243,12 @@ github.com/sacloud/iaas-api-go v1.16.0 h1:JUj7f5yHSSakhy0N8qsZ0a5IYpbUgsv4x5rN8p
 github.com/sacloud/iaas-api-go v1.16.0/go.mod h1:8BTuDTCTT6Ie08544+q5hT3GMyTf2DDxzt/XMuwmhgk=
 github.com/sacloud/iaas-api-go/trace/otel v0.0.0-20250609045333-f334fa253de9 h1:N5mFrEAFr/U6n7fjViB4nMxK4sMrg9PaxnnkpXGfbro=
 github.com/sacloud/iaas-api-go/trace/otel v0.0.0-20250609045333-f334fa253de9/go.mod h1:R8ZSCUzvcR6mnLQDPqioU0s2xrBdKvE/8oT1mhE0c0o=
-github.com/sacloud/iaas-service-go v1.12.0 h1:NMgT+ysSyUWQ30QMjK2RhoQx026VRa558u1aWwJsmrU=
-github.com/sacloud/iaas-service-go v1.12.0/go.mod h1:CjsQdN1z4HenfKgEwK8+HGLTCVkmlyoRN2ivqyXJNB4=
+github.com/sacloud/iaas-service-go v1.12.1 h1:zI6w+5svvZ+EVKNbAvT/PhfHz7VklbeWikex+KJ9ADM=
+github.com/sacloud/iaas-service-go v1.12.1/go.mod h1:CjsQdN1z4HenfKgEwK8+HGLTCVkmlyoRN2ivqyXJNB4=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8 h1:5piK7EELHKRxGqBjgVEHsdfsFwEzF/Kds/bMWLS6gCw=
 github.com/sacloud/iso9660wrap v0.0.0-20171031075302-eda21f77f6a8/go.mod h1:1jHHCa624cG5rODkWmourombJaNmkY9/SBHWhLJcg+w=
 github.com/sacloud/packages-go v0.0.11 h1:hrRWLmfPM9w7GBs6xb5/ue6pEMl8t1UuDKyR/KfteHo=
 github.com/sacloud/packages-go v0.0.11/go.mod h1:XNF5MCTWcHo9NiqWnYctVbASSSZR3ZOmmQORIzcurJ8=
-github.com/sacloud/simplemq-api-go v0.1.3 h1:MQnLYC91PjA0aKpShK+17tgWLQ99bXZNI2dAUXd+d4Q=
-github.com/sacloud/simplemq-api-go v0.1.3/go.mod h1:dtX2aGFcL4AJ5pN1yKukdII0uOe3FjjwdW3xYfyKCZE=
 github.com/sacloud/simplemq-api-go v0.2.0 h1:mXds9QMX3ICm3USNxx1//2Ae9pLpdffycHzrvKlHYfs=
 github.com/sacloud/simplemq-api-go v0.2.0/go.mod h1:AcGQQXuiMsMqgnzomrArqUYoijcSVZwnDx61At2Hvqc=
 github.com/sacloud/webaccel-api-go v1.3.0 h1:qu8QycooO64dkHdWPRdUn3eUf9BWpLASoh9uUo7oWZs=


### PR DESCRIPTION
### どのIssueを閉じますか？

from #1266 

### このPRはどういう変更を行いますか？

サーバ作成時にSSH公開鍵が反映されない問題の修正のために、対応版であるiaas-service-goのv1.12.1へアップグレードする

### ドキュメントの変更は必要ですか？

no

---
以下のようなtfファイルでサーバを作成後、authorized_keysが作成されることを確認しました。

```tf
data "sakuracloud_archive" "ubuntu" {
  os_type = "ubuntu"
}

resource "sakuracloud_disk" "example" {
  name              = "example"
  source_archive_id = data.sakuracloud_archive.ubuntu.id
}

resource "sakuracloud_server" "example" {
  name        = "example"
  disks       = [sakuracloud_disk.example.id]
  core        = 1
  memory      = 2

  network_interface {
    upstream = "shared"
  }

  disk_edit_parameter {
    hostname        = "example"
    password        = "****"
    ssh_keys = ["ssh-ed25519 xxx"]
  }
}
```

![image](https://github.com/user-attachments/assets/57fd2ad1-8f7c-440d-98a5-efa85996cb47)
