### PR TITLE
sakuracloud_container_registry.user を Set にする

### DIFF
--- a/sakuracloud/data_source_sakuracloud_container_registry.go
+++ b/sakuracloud/data_source_sakuracloud_container_registry.go
@@ -56,7 +56,7 @@ func dataSourceSakuraCloudContainerRegistry() *schema.Resource {
 				Description: "The FQDN for accessing the container registry. FQDN is built from `subdomain_label` + `.sakuracr.jp`",
 			},
 			"user": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -75,6 +75,13 @@ func dataSourceSakuraCloudContainerRegistry() *schema.Resource {
 						},
 					},
 				},
+				Set: schema.HashResource(&schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type: schema.TypeString,
+						},
+					},
+				}),
 			},
 			"icon_id":     schemaDataSourceIconID(resourceName),
 			"description": schemaDataSourceDescription(resourceName),

--- a/sakuracloud/resource_sakuracloud_container_registry.go
+++ b/sakuracloud/resource_sakuracloud_container_registry.go
@@ -75,7 +75,7 @@ func resourceSakuraCloudContainerRegistry() *schema.Resource {
 			"description": schemaResourceDescription(resourceName),
 			"tags":        schemaResourceTags(resourceName),
 			"user": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -101,6 +101,13 @@ func resourceSakuraCloudContainerRegistry() *schema.Resource {
 						},
 					},
 				},
+				Set: schema.HashResource(&schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type: schema.TypeString,
+						},
+					},
+				}),
 			},
 		},
 	}

--- a/sakuracloud/structure_container_registry.go
+++ b/sakuracloud/structure_container_registry.go
@@ -38,7 +38,7 @@ func expandContainerRegistryBuilder(d *schema.ResourceData, client *APIClient, s
 
 func expandContainerRegistryUsers(d *schema.ResourceData) []*registryBuilder.User {
 	var results []*registryBuilder.User
-	users := d.Get("user").([]interface{})
+	users := d.Get("user").(*schema.Set).List()
 	for _, raw := range users {
 		d := mapToResourceData(raw.(map[string]interface{}))
 		results = append(results, &registryBuilder.User{


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #1274 

### このPRはどういう変更を行いますか？

`sakuracloud_container_registry.user`を Set にします。これによりバックエンドの保存する順序に関係なく定義したユーザーが保存されるようにします。

### ドキュメントの変更は必要ですか？

必要ないと考えていますがメンテナの方の判断をお願いしたいです