### PR TITLE
use jlaffaye/ftp instead of sacloud/ftps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.30.0
 	github.com/hashicorp/terraform-plugin-mux v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.39.0
+	github.com/jlaffaye/ftp v0.2.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sacloud/api-client-go v0.3.5
 	github.com/sacloud/apprun-api-go v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
+github.com/jlaffaye/ftp v0.2.0 h1:lXNvW7cBu7R/68bknOX3MrRIIqZ61zELs1P2RAiA3lg=
+github.com/jlaffaye/ftp v0.2.0/go.mod h1:is2Ds5qkhceAPy2xD6RLI6hmp/qysSoymZ+Z2uTnspI=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=

--- a/internal/ftps/ftps.go
+++ b/internal/ftps/ftps.go
@@ -16,11 +16,14 @@ package ftps
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
+	"time"
 
-	"github.com/sacloud/iaas-service-go/ftps"
+	"github.com/jlaffaye/ftp"
 )
 
 func UploadFile(ctx context.Context, user, pass, host, file string) error {
@@ -33,14 +36,36 @@ func UploadFile(ctx context.Context, user, pass, host, file string) error {
 	compCh := make(chan struct{})
 	errCh := make(chan error)
 
-	ftpClient := ftps.NewClient(user, pass, host)
 	go func() {
 		defer close(compCh)
 		defer close(errCh)
 
-		if err := ftpClient.UploadFile(filepath.Base(file), f); err != nil {
-			errCh <- err
+		log.Printf("[INFO] upload file to ftps %s", host)
+		conn, err := ftp.Dial(
+			fmt.Sprintf("%s:%d", host, 21),
+			ftp.DialWithTimeout(30*time.Minute),
+			ftp.DialWithExplicitTLS(&tls.Config{
+				ServerName: host,
+				MinVersion: tls.VersionTLS12,
+				MaxVersion: tls.VersionTLS13,
+			}))
+		if err != nil {
+			errCh <- fmt.Errorf("failed to connect to FTP server[%s]: %w", host, err)
+			return
 		}
+		defer conn.Quit() //nolint:errcheck
+
+		if err := conn.Login(user, pass); err != nil {
+			errCh <- fmt.Errorf("failed to login to FTP server[%s]: %w", host, err)
+			return
+		}
+
+		if err := conn.Stor(filepath.Base(file), f); err != nil {
+			errCh <- fmt.Errorf("failed to upload file[%s]: %w", host, err)
+			return
+		}
+
+		compCh <- struct{}{}
 	}()
 
 	select {


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

ftp ライブラリとして、sacloud/ftps の代わりに jlaffaye/ftp を利用するように変更します。

### ドキュメントの変更は必要ですか？

no