### PR TITLE
chore: bump apprun-api-go to v0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jlaffaye/ftp v0.2.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sacloud/api-client-go v0.3.5
-	github.com/sacloud/apprun-api-go v0.6.0
+	github.com/sacloud/apprun-api-go v0.7.1
 	github.com/sacloud/autoscaler v0.19.3
 	github.com/sacloud/iaas-api-go v1.28.0
 	github.com/sacloud/iaas-service-go v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sacloud/api-client-go v0.3.5 h1:0ALibvbC+6MBhN7t61k+RhguhiEQ8+NejqBjq1YpylM=
 github.com/sacloud/api-client-go v0.3.5/go.mod h1:akdcCOl6wszywa0YQ5X8cMnNgWTm+7N4EneODTdiH48=
-github.com/sacloud/apprun-api-go v0.6.0 h1:8/HAu6Vw2a01dCIRkaqrXw/U27wsLy8vekTDfrUN5MM=
-github.com/sacloud/apprun-api-go v0.6.0/go.mod h1:H400OqgfgYclHSO8m5ihPEgUdWnPVinnVlAaMksXS14=
+github.com/sacloud/apprun-api-go v0.7.1 h1:Kc0Xa9sveiXFRYJ0e9NtRRj9AI36yG5RFuQYjDNJ4Qo=
+github.com/sacloud/apprun-api-go v0.7.1/go.mod h1:0vQhVsP/5QWui5yJsYjV7cf35tESEHdv84dGSt6qZuE=
 github.com/sacloud/autoscaler v0.19.3 h1:FkBxc0mE8fvaWiOiz+TpFAT1TX8DRLXs8prsqaM2MF0=
 github.com/sacloud/autoscaler v0.19.3/go.mod h1:jTeHzdZHrWd/2mYtgEyyFDTqHu0EbMPNDzwj7mdl0MA=
 github.com/sacloud/go-http v0.1.9 h1:Xa5PY8/pb7XWhwG9nAeXSrYXPbtfBWqawgzxD5co3VE=

--- a/sakuracloud/data_source_sakuracloud_apprun_application_test.go
+++ b/sakuracloud/data_source_sakuracloud_apprun_application_test.go
@@ -42,7 +42,7 @@ func TestAccSakuraCloudDataSourceApprunApplication_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
 				),
 			},
 		},
@@ -71,8 +71,8 @@ func TestAccSakuraCloudDataSourceApprunApplication_withCRUser(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.server", "apprun-test.sakuracr.jp"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.server", "sakura-oss-dev.sakuracr.jp"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.username", "user"),
 				),
 			},
@@ -102,7 +102,7 @@ func TestAccSakuraCloudDataSourceApprunApplication_withProbe(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.probe.0.http_get.0.path", "/"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.probe.0.http_get.0.port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.probe.0.http_get.0.headers.0.name", "name1"),
@@ -137,7 +137,7 @@ func TestAccSakuraCloudDataSourceApprunApplication_withTraffic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
 					resource.TestCheckResourceAttr(resourceName, "traffics.0.version_index", "0"),
 					resource.TestCheckResourceAttr(resourceName, "traffics.0.percent", "100"),
 				),
@@ -185,7 +185,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
   }
@@ -209,8 +209,8 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
-        server   = "apprun-test.sakuracr.jp"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
         username = "user"
         password = "password"
       }
@@ -236,7 +236,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
     probe {
@@ -274,7 +274,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
   }
@@ -302,7 +302,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
   }

--- a/sakuracloud/resource_sakuracloud_apprun_application_test.go
+++ b/sakuracloud/resource_sakuracloud_apprun_application_test.go
@@ -52,7 +52,7 @@ func TestAccSakuraCloudApprunApplication_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
 					resource.TestMatchResourceAttr(resourceName, "status", regexp.MustCompile(".+")),
 					resource.TestMatchResourceAttr(resourceName, "public_url", regexp.MustCompile(".+")),
 				),
@@ -70,7 +70,7 @@ func TestAccSakuraCloudApprunApplication_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "2Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:tag1"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:tag1"),
 				),
 			},
 		},
@@ -102,8 +102,8 @@ func TestAccSakuraCloudApprunApplication_withCRUser(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.server", "apprun-test.sakuracr.jp"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.server", "sakura-oss-dev.sakuracr.jp"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.username", "user"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.password", "password"),
 				),
@@ -137,7 +137,7 @@ func TestAccSakuraCloudApprunApplication_withEnv(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.env.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.env.0.key", "key"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.env.0.value", "value"),
@@ -218,7 +218,7 @@ func TestAccSakuraCloudApprunApplication_withProbe(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.probe.0.http_get.0.path", "/"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.probe.0.http_get.0.port", "80"),
 				),
@@ -236,7 +236,7 @@ func TestAccSakuraCloudApprunApplication_withProbe(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.probe.0.http_get.0.path", "/"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.probe.0.http_get.0.port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.probe.0.http_get.0.headers.0.name", "name1"),
@@ -274,7 +274,7 @@ func TestAccSakuraCloudApprunApplication_withTraffic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
 					resource.TestCheckResourceAttr(resourceName, "traffics.0.version_index", "0"),
 					resource.TestCheckResourceAttr(resourceName, "traffics.0.percent", "100"),
 				),
@@ -292,7 +292,7 @@ func TestAccSakuraCloudApprunApplication_withTraffic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "apprun-test.sakuracr.jp/test1:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.0.container_registry.0.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
 					resource.TestCheckResourceAttr(resourceName, "traffics.0.version_index", "0"),
 					resource.TestCheckResourceAttr(resourceName, "traffics.0.percent", "1"),
 					resource.TestCheckResourceAttr(resourceName, "traffics.1.version_index", "1"),
@@ -374,7 +374,7 @@ func TestAccImportSakuraCloudApprunApplication_basic(t *testing.T) {
 			"components.0.name":       "compo1",
 			"components.0.max_cpu":    "0.5",
 			"components.0.max_memory": "1Gi",
-			"components.0.deploy_source.0.container_registry.0.image": "apprun-test.sakuracr.jp/test1:latest",
+			"components.0.deploy_source.0.container_registry.0.image": "sakura-oss-dev.sakuracr.jp/test:latest",
 		}
 
 		return compareStateMulti(s[0], expects)
@@ -421,7 +421,7 @@ func TestAccImportSakuraCloudApprunApplication_withCRUser(t *testing.T) {
 			"components.0.name":       "compo1",
 			"components.0.max_cpu":    "0.5",
 			"components.0.max_memory": "1Gi",
-			"components.0.deploy_source.0.container_registry.0.image":    "apprun-test.sakuracr.jp/test1:latest",
+			"components.0.deploy_source.0.container_registry.0.image":    "sakura-oss-dev.sakuracr.jp/test:latest",
 			"components.0.deploy_source.0.container_registry.0.username": "user",
 			"components.0.deploy_source.0.container_registry.0.password": "",
 		}
@@ -471,7 +471,7 @@ func TestAccImportSakuraCloudApprunApplication_withEnv(t *testing.T) {
 			"components.0.name":       "compo1",
 			"components.0.max_cpu":    "0.5",
 			"components.0.max_memory": "1Gi",
-			"components.0.deploy_source.0.container_registry.0.image": "apprun-test.sakuracr.jp/test1:latest",
+			"components.0.deploy_source.0.container_registry.0.image": "sakura-oss-dev.sakuracr.jp/test:latest",
 			"components.0.env.#":       "2",
 			"components.0.env.0.key":   "key",
 			"components.0.env.0.value": "value",
@@ -584,7 +584,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
   }
@@ -604,7 +604,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "2Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:tag1"
+        image    = "sakura-oss-dev.sakuracr.jp/test:tag1"
       }
     }
   }
@@ -624,8 +624,8 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
-        server   = "apprun-test.sakuracr.jp"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
         username = "user"
         password = "password"
       }
@@ -647,7 +647,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
     env {
@@ -679,7 +679,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
 		// Updated
@@ -714,7 +714,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
     probe {
@@ -740,7 +740,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
     probe {
@@ -774,7 +774,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
   }
@@ -798,7 +798,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
   }
@@ -826,7 +826,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
   }
@@ -853,7 +853,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
   }
@@ -884,7 +884,7 @@ resource "sakuracloud_apprun_application" "foobar" {
     max_memory = "1Gi"
     deploy_source {
       container_registry {
-        image    = "apprun-test.sakuracr.jp/test1:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
       }
     }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

- `apprun-api-go` を v0.6.0 から v0.7.1 にアップデート
- テストコード内のコンテナレジストリ参照を新しいレジストリ（`sakura-oss-dev.sakuracr.jp`）に更新

※ 本来は v0.8.0にしたいのですが、ogen対応などでbreaking-changeが入っているためまずはv0.7.1にしました
これで一旦リリースし、次回以降のリリース時にv0.8以降への対応をするようにします

### ドキュメントの変更は必要ですか？

不要