### PR TITLE
Sensitiveフィールドの扱いを改善(v2)

### DIFF
--- a/sakuracloud/data_source_sakuracloud_simple_monitor.go
+++ b/sakuracloud/data_source_sakuracloud_simple_monitor.go
@@ -106,6 +106,7 @@ func dataSourceSakuraCloudSimpleMonitor() *schema.Resource {
 						"password": {
 							Type:        schema.TypeString,
 							Computed:    true,
+							Sensitive:   true,
 							Description: "The password for basic auth used when checking by HTTP/HTTPS",
 						},
 						"port": {

--- a/sakuracloud/data_source_sakuracloud_webaccel.go
+++ b/sakuracloud/data_source_sakuracloud_webaccel.go
@@ -287,11 +287,17 @@ func dataSourceSakuraCloudWebAccelLogUploadConfigRead(ctx context.Context, d *sc
 	}
 	webAccelOp := webaccel.NewOp(client.webaccelClient)
 	logCfg, err := webAccelOp.ReadLogUploadConfig(ctx, siteId)
-	logCfg.AccessKeyID = ""
-	logCfg.SecretAccessKey = ""
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.Set("logging", flattenWebAccelLogUploadConfigData(logCfg, d)) //nolint:errcheck,gosec
+	if logCfg == nil || logCfg.Bucket == "" {
+		d.Set("logging", nil) //nolint:errcheck,gosec
+		return nil
+	}
+	logCfg.AccessKeyID = ""
+	logCfg.SecretAccessKey = ""
+	// DataSourceではstateからの復元を抑止するため空の resourceValueGettable を渡す
+	emptyValue := &resourceMapValue{value: map[string]interface{}{}}
+	d.Set("logging", flattenWebAccelLogUploadConfigData(logCfg, emptyValue)) //nolint:errcheck,gosec
 	return nil
 }

--- a/sakuracloud/data_source_sakuracloud_webaccel.go
+++ b/sakuracloud/data_source_sakuracloud_webaccel.go
@@ -292,6 +292,6 @@ func dataSourceSakuraCloudWebAccelLogUploadConfigRead(ctx context.Context, d *sc
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.Set("logging", flattenWebAccelLogUploadConfigData(logCfg)) //nolint:errcheck,gosec
+	d.Set("logging", flattenWebAccelLogUploadConfigData(logCfg, d)) //nolint:errcheck,gosec
 	return nil
 }

--- a/sakuracloud/resource_sakuracloud_archive.go
+++ b/sakuracloud/resource_sakuracloud_archive.go
@@ -216,5 +216,6 @@ func setArchiveResourceData(d *schema.ResourceData, client *APIClient, data *iaa
 	d.Set("zone", getZone(d, client))                               //nolint
 	d.Set("source_archive_id", d.Get("source_archive_id").(string)) //nolint
 	d.Set("source_disk_id", d.Get("source_disk_id").(string))       //nolint
+	d.Set("source_shared_key", d.Get("source_shared_key").(string)) //nolint:errcheck,gosec // 機密情報をAPIレスポンスから保存しないためconfig値を復元
 	return diag.FromErr(d.Set("tags", flattenTags(data.Tags)))
 }

--- a/sakuracloud/resource_sakuracloud_archive.go
+++ b/sakuracloud/resource_sakuracloud_archive.go
@@ -216,6 +216,6 @@ func setArchiveResourceData(d *schema.ResourceData, client *APIClient, data *iaa
 	d.Set("zone", getZone(d, client))                               //nolint
 	d.Set("source_archive_id", d.Get("source_archive_id").(string)) //nolint
 	d.Set("source_disk_id", d.Get("source_disk_id").(string))       //nolint
-	d.Set("source_shared_key", d.Get("source_shared_key").(string)) //nolint:errcheck,gosec // 機密情報をAPIレスポンスから保存しないためconfig値を復元
+	d.Set("source_shared_key", d.Get("source_shared_key").(string)) //nolint
 	return diag.FromErr(d.Set("tags", flattenTags(data.Tags)))
 }

--- a/sakuracloud/resource_sakuracloud_archive.go
+++ b/sakuracloud/resource_sakuracloud_archive.go
@@ -216,6 +216,5 @@ func setArchiveResourceData(d *schema.ResourceData, client *APIClient, data *iaa
 	d.Set("zone", getZone(d, client))                               //nolint
 	d.Set("source_archive_id", d.Get("source_archive_id").(string)) //nolint
 	d.Set("source_disk_id", d.Get("source_disk_id").(string))       //nolint
-	d.Set("source_shared_key", d.Get("source_shared_key").(string)) //nolint
 	return diag.FromErr(d.Set("tags", flattenTags(data.Tags)))
 }

--- a/sakuracloud/resource_sakuracloud_archive_test.go
+++ b/sakuracloud/resource_sakuracloud_archive_test.go
@@ -162,6 +162,11 @@ func TestAccSakuraCloudArchive_fromShared(t *testing.T) {
 						"sakuracloud_archive_share.share", "share_key"),
 				),
 			},
+			{
+				// 機密フィールド(source_shared_key)のRead時復元によりperpetual diffが出ないことを確認
+				Config:   buildConfigWithArgs(testAccSakuraCloudArchive_fromShared, rand),
+				PlanOnly: true,
+			},
 		},
 	})
 }

--- a/sakuracloud/resource_sakuracloud_archive_test.go
+++ b/sakuracloud/resource_sakuracloud_archive_test.go
@@ -251,6 +251,7 @@ func TestAccImportSakuraCloudArchive_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"archive_file",
 					"hash",
+					"source_shared_key",
 				},
 			},
 		},

--- a/sakuracloud/resource_sakuracloud_local_router.go
+++ b/sakuracloud/resource_sakuracloud_local_router.go
@@ -280,7 +280,7 @@ func setLocalRouterResourceData(ctx context.Context, d *schema.ResourceData, cli
 	if err := d.Set("network_interface", flattenLocalRouterNetworkInterface(data)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("peer", flattenLocalRouterPeers(data)); err != nil {
+	if err := d.Set("peer", flattenLocalRouterPeers(data, d)); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("static_route", flattenLocalRouterStaticRoutes(data)); err != nil {

--- a/sakuracloud/resource_sakuracloud_local_router_test.go
+++ b/sakuracloud/resource_sakuracloud_local_router_test.go
@@ -304,7 +304,6 @@ func TestAccSakuraCloudLocalRouter_peering(t *testing.T) {
 				Config: buildConfigWithArgs(testAccSakuraCloudLocalRouter_peering, rand),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName1, "id", resourceName2, "peer.0.peer_id"),
-					resource.TestCheckResourceAttrPair(resourceName1, "secret_keys.0", resourceName2, "peer.0.secret_key"),
 					resource.TestCheckResourceAttr(resourceName2, "peer.0.description", "description"),
 				),
 			},

--- a/sakuracloud/resource_sakuracloud_local_router_test.go
+++ b/sakuracloud/resource_sakuracloud_local_router_test.go
@@ -308,6 +308,11 @@ func TestAccSakuraCloudLocalRouter_peering(t *testing.T) {
 				),
 			},
 			{
+				// 機密フィールド(secret_key)のRead時復元によりperpetual diffが出ないことを確認
+				Config:   buildConfigWithArgs(testAccSakuraCloudLocalRouter_peering, rand),
+				PlanOnly: true,
+			},
+			{
 				Config: buildConfigWithArgs(testAccSakuraCloudLocalRouter_peeringDisconnect, rand),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName1, "peer.#", "0"),

--- a/sakuracloud/resource_sakuracloud_simple_monitor.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor.go
@@ -140,6 +140,7 @@ func resourceSakuraCloudSimpleMonitor() *schema.Resource {
 						"password": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Sensitive:   true,
 							Description: "The password for basic auth used when checking by HTTP/HTTPS",
 						},
 						"port": {
@@ -362,7 +363,7 @@ func setSimpleMonitorResourceData(ctx context.Context, d *schema.ResourceData, c
 	d.Set("notify_slack_enabled", data.NotifySlackEnabled.Bool())      //nolint
 	d.Set("notify_slack_webhook", data.SlackWebhooksURL)               //nolint
 	d.Set("notify_interval", flattenSimpleMonitorNotifyInterval(data)) //nolint
-	if err := d.Set("health_check", flattenSimpleMonitorHealthCheck(data)); err != nil {
+	if err := d.Set("health_check", flattenSimpleMonitorHealthCheck(data, d)); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("monitoring_suite", flattenSimpleMonitorMonitoringSuite(data)); err != nil {

--- a/sakuracloud/resource_sakuracloud_simple_monitor_test.go
+++ b/sakuracloud/resource_sakuracloud_simple_monitor_test.go
@@ -83,6 +83,11 @@ func TestAccSakuraCloudSimpleMonitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "monitoring_suite.0.enabled", "false"),
 				),
 			},
+			{
+				// 機密フィールド(password)のRead時復元によりperpetual diffが出ないことを確認
+				Config:   buildConfigWithArgs(testAccSakuraCloudSimpleMonitor_update, zone, testAccSlackWebhook),
+				PlanOnly: true,
+			},
 		},
 	})
 }

--- a/sakuracloud/resource_sakuracloud_vpc_router.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router.go
@@ -844,7 +844,7 @@ func setVPCRouterResourceData(ctx context.Context, d *schema.ResourceData, zone 
 	if err := d.Set("firewall", flattenVPCRouterFirewalls(data)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("l2tp", flattenVPCRouterL2TP(data)); err != nil {
+	if err := d.Set("l2tp", flattenVPCRouterL2TP(data, d)); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("pptp", flattenVPCRouterPPTP(data)); err != nil {
@@ -865,7 +865,7 @@ func setVPCRouterResourceData(ctx context.Context, d *schema.ResourceData, zone 
 	if err := d.Set("port_forwarding", flattenVPCRouterPortForwardings(data)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("site_to_site_vpn", flattenVPCRouterSiteToSiteConfig(data)); err != nil {
+	if err := d.Set("site_to_site_vpn", flattenVPCRouterSiteToSiteConfig(data, d)); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("site_to_site_vpn_parameter", flattenVPCRouterSiteToSiteParameter(data)); err != nil {

--- a/sakuracloud/resource_sakuracloud_vpc_router_test.go
+++ b/sakuracloud/resource_sakuracloud_vpc_router_test.go
@@ -194,6 +194,11 @@ func TestAccSakuraCloudVPCRouter_Full(t *testing.T) {
 				),
 			},
 			{
+				// 機密フィールド(pre_shared_secret)のRead時復元によりperpetual diffが出ないことを確認
+				Config:   buildConfigWithArgs(testAccSakuraCloudVPCRouter_complete, rand),
+				PlanOnly: true,
+			},
+			{
 				Config: buildConfigWithArgs(testAccSakuraCloudVPCRouter_completeUpdate, rand),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraCloudVPCRouterExists(resourceName, &vpcRouter),

--- a/sakuracloud/resource_sakuracloud_webaccel.go
+++ b/sakuracloud/resource_sakuracloud_webaccel.go
@@ -499,7 +499,7 @@ func setWebAccelSiteResourceData(d *schema.ResourceData, client *APIClient, data
 }
 
 func setWebAccelResourceLogUploadConfigData(d *schema.ResourceData, client *APIClient, data *webaccel.LogUploadConfig) diag.Diagnostics {
-	err := d.Set("logging", flattenWebAccelLogUploadConfigData(data))
+	err := d.Set("logging", flattenWebAccelLogUploadConfigData(data, d))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/sakuracloud/structure_local_router.go
+++ b/sakuracloud/structure_local_router.go
@@ -102,21 +102,29 @@ func expandLocalRouterPeers(d resourceValueGettable) []*iaas.LocalRouterPeer {
 	return results
 }
 
-func flattenLocalRouterPeers(data *iaas.LocalRouter) []interface{} {
+func flattenLocalRouterPeers(data *iaas.LocalRouter, d resourceValueGettable) []interface{} {
+	configPeers := map[string]string{}
+	if values, ok := getListFromResource(d, "peer"); ok {
+		for _, raw := range values {
+			v := mapToResourceData(raw.(map[string]interface{}))
+			configPeers[stringOrDefault(v, "peer_id")] = stringOrDefault(v, "secret_key")
+		}
+	}
+
 	var results []interface{}
 	for _, peer := range data.Peers {
-		results = append(results, flattenLocalRouterPeer(peer))
+		secretKey := ""
+		if v, ok := configPeers[peer.ID.String()]; ok {
+			secretKey = v
+		}
+		results = append(results, map[string]interface{}{
+			"peer_id":     peer.ID.String(),
+			"secret_key":  secretKey,
+			"enabled":     peer.Enabled,
+			"description": peer.Description,
+		})
 	}
 	return results
-}
-
-func flattenLocalRouterPeer(data *iaas.LocalRouterPeer) interface{} {
-	return map[string]interface{}{
-		"peer_id":     data.ID.String(),
-		"secret_key":  data.SecretKey,
-		"enabled":     data.Enabled,
-		"description": data.Description,
-	}
 }
 
 func expandLocalStaticRoutes(d resourceValueGettable) []*iaas.LocalRouterStaticRoute {

--- a/sakuracloud/structure_local_router_test.go
+++ b/sakuracloud/structure_local_router_test.go
@@ -1,0 +1,141 @@
+// Copyright 2016-2025 terraform-provider-sakuracloud authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sakuracloud
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+//nolint:gosec // Test uses dummy credential values
+func TestFlattenLocalRouterPeers(t *testing.T) {
+	tt := []struct {
+		Name           string
+		InputData      *iaas.LocalRouter
+		InputConfig    resourceValueGettable
+		ExpectedOutput []interface{}
+	}{
+		{
+			Name: "restores secret_key from config",
+			InputData: &iaas.LocalRouter{
+				Peers: []*iaas.LocalRouterPeer{
+					{
+						ID:          types.StringID("123456789012"),
+						Enabled:     true,
+						Description: "peer1",
+						SecretKey:   "api-secret-key", // API may return this but should not be used
+					},
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{
+					"peer": []interface{}{
+						map[string]interface{}{
+							"peer_id":    "123456789012",
+							"secret_key": "config-secret-key",
+						},
+					},
+				},
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"peer_id":     "123456789012",
+					"secret_key":  "config-secret-key",
+					"enabled":     true,
+					"description": "peer1",
+				},
+			},
+		},
+		{
+			Name: "empty secret_key when peer not in config",
+			InputData: &iaas.LocalRouter{
+				Peers: []*iaas.LocalRouterPeer{
+					{
+						ID:          types.StringID("123456789012"),
+						Enabled:     true,
+						Description: "peer1",
+						SecretKey:   "api-secret-key",
+					},
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{},
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"peer_id":     "123456789012",
+					"secret_key":  "",
+					"enabled":     true,
+					"description": "peer1",
+				},
+			},
+		},
+		{
+			Name: "multiple peers with mixed config presence",
+			InputData: &iaas.LocalRouter{
+				Peers: []*iaas.LocalRouterPeer{
+					{
+						ID:          types.StringID("123456789012"),
+						Enabled:     true,
+						Description: "peer1",
+						SecretKey:   "api-secret-1",
+					},
+					{
+						ID:          types.StringID("999999999999"),
+						Enabled:     false,
+						Description: "peer2",
+						SecretKey:   "api-secret-2",
+					},
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{
+					"peer": []interface{}{
+						map[string]interface{}{
+							"peer_id":    "123456789012",
+							"secret_key": "config-secret-1",
+						},
+					},
+				},
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"peer_id":     "123456789012",
+					"secret_key":  "config-secret-1",
+					"enabled":     true,
+					"description": "peer1",
+				},
+				map[string]interface{}{
+					"peer_id":     "999999999999",
+					"secret_key":  "",
+					"enabled":     false,
+					"description": "peer2",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := flattenLocalRouterPeers(tc.InputData, tc.InputConfig)
+			if !reflect.DeepEqual(res, tc.ExpectedOutput) {
+				t.Fatalf("FAILED %s: got: %v\nwant: %v", tc.Name, res, tc.ExpectedOutput)
+			}
+		})
+	}
+}

--- a/sakuracloud/structure_simple_monitor.go
+++ b/sakuracloud/structure_simple_monitor.go
@@ -86,9 +86,19 @@ func flattenSimpleMonitorNotifyInterval(simpleMonitor *iaas.SimpleMonitor) int {
 	return interval / 60 / 60
 }
 
-func flattenSimpleMonitorHealthCheck(simpleMonitor *iaas.SimpleMonitor) []interface{} {
+func flattenSimpleMonitorHealthCheck(simpleMonitor *iaas.SimpleMonitor, d resourceValueGettable) []interface{} {
 	healthCheck := map[string]interface{}{}
 	hc := simpleMonitor.HealthCheck
+
+	// Get password from config to avoid storing API response in state
+	var password string
+	if values, ok := getListFromResource(d, "health_check"); ok && len(values) > 0 {
+		conf := values[0].(map[string]interface{})
+		if v, ok := conf["password"].(string); ok {
+			password = v
+		}
+	}
+
 	switch hc.Protocol {
 	case types.SimpleMonitorProtocols.HTTP:
 		healthCheck["path"] = hc.Path
@@ -97,7 +107,7 @@ func flattenSimpleMonitorHealthCheck(simpleMonitor *iaas.SimpleMonitor) []interf
 		healthCheck["host_header"] = hc.Host
 		healthCheck["port"] = hc.Port.Int()
 		healthCheck["username"] = hc.BasicAuthUsername
-		healthCheck["password"] = hc.BasicAuthPassword
+		healthCheck["password"] = password
 	case types.SimpleMonitorProtocols.HTTPS:
 		healthCheck["path"] = hc.Path
 		healthCheck["status"] = hc.Status.Int()
@@ -106,7 +116,7 @@ func flattenSimpleMonitorHealthCheck(simpleMonitor *iaas.SimpleMonitor) []interf
 		healthCheck["port"] = hc.Port.Int()
 		healthCheck["sni"] = hc.SNI.Bool()
 		healthCheck["username"] = hc.BasicAuthUsername
-		healthCheck["password"] = hc.BasicAuthPassword
+		healthCheck["password"] = password
 		healthCheck["http2"] = hc.HTTP2
 	case types.SimpleMonitorProtocols.TCP, types.SimpleMonitorProtocols.SSH, types.SimpleMonitorProtocols.SMTP, types.SimpleMonitorProtocols.POP3:
 		healthCheck["port"] = hc.Port.Int()

--- a/sakuracloud/structure_simple_monitor_test.go
+++ b/sakuracloud/structure_simple_monitor_test.go
@@ -1,0 +1,154 @@
+// Copyright 2016-2025 terraform-provider-sakuracloud authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sakuracloud
+
+import (
+	"testing"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+func TestFlattenSimpleMonitorHealthCheck(t *testing.T) {
+	tt := []struct {
+		Name           string
+		InputMonitor   *iaas.SimpleMonitor
+		InputConfig    resourceValueGettable
+		ExpectPassword string
+		ExpectContains string
+		ExpectPath     string
+	}{
+		{
+			Name: "restores password from config for http protocol",
+			InputMonitor: &iaas.SimpleMonitor{
+				HealthCheck: &iaas.SimpleMonitorHealthCheck{
+					Protocol:          types.SimpleMonitorProtocols.HTTP,
+					Path:              "/",
+					Status:            types.StringNumber(200),
+					ContainsString:    "ok",
+					Host:              "usacloud.jp",
+					Port:              types.StringNumber(80),
+					BasicAuthUsername: "foo",
+					BasicAuthPassword: "api-password",
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{
+					"health_check": []interface{}{
+						map[string]interface{}{
+							"password": "config-password",
+						},
+					},
+				},
+			},
+			ExpectPassword: "config-password",
+			ExpectContains: "ok",
+			ExpectPath:     "/",
+		},
+		{
+			Name: "restores password from config for https protocol",
+			InputMonitor: &iaas.SimpleMonitor{
+				HealthCheck: &iaas.SimpleMonitorHealthCheck{
+					Protocol:          types.SimpleMonitorProtocols.HTTPS,
+					Path:              "/",
+					Status:            types.StringNumber(200),
+					ContainsString:    "ok",
+					Host:              "usacloud.jp",
+					Port:              types.StringNumber(443),
+					SNI:               types.StringFlag(true),
+					BasicAuthUsername: "foo",
+					BasicAuthPassword: "api-password",
+					HTTP2:             types.StringFlag(true),
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{
+					"health_check": []interface{}{
+						map[string]interface{}{
+							"password": "config-password",
+						},
+					},
+				},
+			},
+			ExpectPassword: "config-password",
+			ExpectContains: "ok",
+			ExpectPath:     "/",
+		},
+		{
+			Name: "empty password when not in config",
+			InputMonitor: &iaas.SimpleMonitor{
+				HealthCheck: &iaas.SimpleMonitorHealthCheck{
+					Protocol:          types.SimpleMonitorProtocols.HTTP,
+					Path:              "/",
+					Status:            types.StringNumber(200),
+					ContainsString:    "",
+					Host:              "",
+					Port:              types.StringNumber(0),
+					BasicAuthUsername: "foo",
+					BasicAuthPassword: "api-password",
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{},
+			},
+			ExpectPassword: "",
+			ExpectPath:     "/",
+		},
+		{
+			Name: "tcp protocol does not include password",
+			InputMonitor: &iaas.SimpleMonitor{
+				HealthCheck: &iaas.SimpleMonitorHealthCheck{
+					Protocol: types.SimpleMonitorProtocols.TCP,
+					Port:     types.StringNumber(22),
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{},
+			},
+			ExpectPassword: "NO_PASSWORD_KEY",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := flattenSimpleMonitorHealthCheck(tc.InputMonitor, tc.InputConfig)
+			if len(res) != 1 {
+				t.Fatalf("expected 1 element got: %d", len(res))
+			}
+			got := res[0].(map[string]interface{})
+
+			// Verify password restoration behavior
+			if tc.ExpectPassword == "NO_PASSWORD_KEY" {
+				if _, ok := got["password"]; ok {
+					t.Fatalf("password key should not exist for %s protocol", tc.InputMonitor.HealthCheck.Protocol)
+				}
+			} else {
+				if got["password"] != tc.ExpectPassword {
+					t.Fatalf("password mismatch: got: %v want: %v", got["password"], tc.ExpectPassword)
+				}
+			}
+
+			// Verify other fields are correctly set
+			if tc.ExpectPath != "" {
+				if got["path"] != tc.ExpectPath {
+					t.Fatalf("path mismatch: got: %v want: %v", got["path"], tc.ExpectPath)
+				}
+			}
+			if got["protocol"] != tc.InputMonitor.HealthCheck.Protocol {
+				t.Fatalf("protocol mismatch: got: %v want: %v", got["protocol"], tc.InputMonitor.HealthCheck.Protocol)
+			}
+		})
+	}
+}

--- a/sakuracloud/structure_vpc_router.go
+++ b/sakuracloud/structure_vpc_router.go
@@ -522,12 +522,17 @@ func expandVPCRouterL2TP(d resourceValueGettable) *iaas.VPCRouterL2TPIPsecServer
 	return nil
 }
 
-func flattenVPCRouterL2TP(vpcRouter *iaas.VPCRouter) []interface{} {
+func flattenVPCRouterL2TP(vpcRouter *iaas.VPCRouter, d resourceValueGettable) []interface{} {
 	var l2tp []interface{}
 	if vpcRouter.Settings.L2TPIPsecServerEnabled.Bool() {
 		s := vpcRouter.Settings.L2TPIPsecServer
+		preSharedSecret := ""
+		if values, ok := getListFromResource(d, "l2tp"); ok && len(values) > 0 {
+			l2tpData := mapToResourceData(values[0].(map[string]interface{}))
+			preSharedSecret = stringOrDefault(l2tpData, "pre_shared_secret")
+		}
 		l2tp = append(l2tp, map[string]interface{}{
-			"pre_shared_secret": s.PreSharedSecret,
+			"pre_shared_secret": preSharedSecret,
 			"range_start":       s.RangeStart,
 			"range_stop":        s.RangeStop,
 		})
@@ -687,14 +692,22 @@ func expandVPCRouterSiteToSiteParameterESP(d resourceValueGettable) *iaas.VPCRou
 	return nil
 }
 
-func flattenVPCRouterSiteToSiteConfig(vpcRouter *iaas.VPCRouter) []interface{} {
+func flattenVPCRouterSiteToSiteConfig(vpcRouter *iaas.VPCRouter, d resourceValueGettable) []interface{} {
 	var s2sSettings []interface{}
 	if vpcRouter.Settings.SiteToSiteIPsecVPN != nil {
+		configPreSharedSecrets := map[string]string{}
+		if values, ok := getListFromResource(d, "site_to_site_vpn"); ok {
+			for _, raw := range values {
+				v := mapToResourceData(raw.(map[string]interface{}))
+				configPreSharedSecrets[stringOrDefault(v, "peer")] = stringOrDefault(v, "pre_shared_secret")
+			}
+		}
 		for _, s := range vpcRouter.Settings.SiteToSiteIPsecVPN.Config {
+			preSharedSecret := configPreSharedSecrets[s.Peer]
 			s2sSettings = append(s2sSettings, map[string]interface{}{
 				"local_prefix":      stringListToSet(s.LocalPrefix),
 				"peer":              s.Peer,
-				"pre_shared_secret": s.PreSharedSecret,
+				"pre_shared_secret": preSharedSecret,
 				"remote_id":         s.RemoteID,
 				"routes":            stringListToSet(s.Routes),
 			})

--- a/sakuracloud/structure_vpc_router_test.go
+++ b/sakuracloud/structure_vpc_router_test.go
@@ -1,0 +1,229 @@
+// Copyright 2016-2025 terraform-provider-sakuracloud authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sakuracloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+func TestFlattenVPCRouterL2TP(t *testing.T) {
+	tt := []struct {
+		Name           string
+		InputVPCRouter *iaas.VPCRouter
+		InputConfig    resourceValueGettable
+		ExpectedOutput []interface{}
+	}{
+		{
+			Name: "restores pre_shared_secret from config",
+			InputVPCRouter: &iaas.VPCRouter{
+				Settings: &iaas.VPCRouterSetting{
+					L2TPIPsecServerEnabled: types.StringTrue,
+					L2TPIPsecServer: &iaas.VPCRouterL2TPIPsecServer{
+						PreSharedSecret: "api-secret",
+						RangeStart:      "192.168.11.21",
+						RangeStop:       "192.168.11.30",
+					},
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{
+					"l2tp": []interface{}{
+						map[string]interface{}{
+							"pre_shared_secret": "config-secret",
+						},
+					},
+				},
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"pre_shared_secret": "config-secret",
+					"range_start":       "192.168.11.21",
+					"range_stop":        "192.168.11.30",
+				},
+			},
+		},
+		{
+			Name: "empty pre_shared_secret when not in config",
+			InputVPCRouter: &iaas.VPCRouter{
+				Settings: &iaas.VPCRouterSetting{
+					L2TPIPsecServerEnabled: types.StringTrue,
+					L2TPIPsecServer: &iaas.VPCRouterL2TPIPsecServer{
+						PreSharedSecret: "api-secret",
+						RangeStart:      "192.168.11.21",
+						RangeStop:       "192.168.11.30",
+					},
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{},
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"pre_shared_secret": "",
+					"range_start":       "192.168.11.21",
+					"range_stop":        "192.168.11.30",
+				},
+			},
+		},
+		{
+			Name: "disabled L2TP returns empty",
+			InputVPCRouter: &iaas.VPCRouter{
+				Settings: &iaas.VPCRouterSetting{
+					L2TPIPsecServerEnabled: types.StringFalse,
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{},
+			},
+			ExpectedOutput: nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := flattenVPCRouterL2TP(tc.InputVPCRouter, tc.InputConfig)
+			if len(res) != len(tc.ExpectedOutput) {
+				t.Fatalf("FAILED %s: length mismatch got: %d want: %d", tc.Name, len(res), len(tc.ExpectedOutput))
+			}
+			for i := range res {
+				got := res[i].(map[string]interface{})
+				want := tc.ExpectedOutput[i].(map[string]interface{})
+				for k, v := range want {
+					if got[k] != v {
+						t.Fatalf("FAILED %s[%d].%s: got: %v want: %v", tc.Name, i, k, got[k], v)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFlattenVPCRouterSiteToSiteConfig(t *testing.T) {
+	tt := []struct {
+		Name           string
+		InputVPCRouter *iaas.VPCRouter
+		InputConfig    resourceValueGettable
+		ExpectEnabled  bool
+		ExpectPeer     string
+		ExpectSecret   string
+	}{
+		{
+			Name: "restores pre_shared_secret from config by peer",
+			InputVPCRouter: &iaas.VPCRouter{
+				Settings: &iaas.VPCRouterSetting{
+					SiteToSiteIPsecVPN: &iaas.VPCRouterSiteToSiteIPsecVPN{
+						Config: []*iaas.VPCRouterSiteToSiteIPsecVPNConfig{
+							{
+								Peer:            "8.8.8.8",
+								PreSharedSecret: "api-secret",
+								RemoteID:        "8.8.8.8",
+								Routes:          []string{"10.0.0.0/8"},
+								LocalPrefix:     []string{"192.168.21.0/24"},
+							},
+						},
+					},
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{
+					"site_to_site_vpn": []interface{}{
+						map[string]interface{}{
+							"peer":              "8.8.8.8",
+							"pre_shared_secret": "config-secret",
+						},
+					},
+				},
+			},
+			ExpectEnabled: true,
+			ExpectPeer:    "8.8.8.8",
+			ExpectSecret:  "config-secret",
+		},
+		{
+			Name: "empty pre_shared_secret when peer not in config",
+			InputVPCRouter: &iaas.VPCRouter{
+				Settings: &iaas.VPCRouterSetting{
+					SiteToSiteIPsecVPN: &iaas.VPCRouterSiteToSiteIPsecVPN{
+						Config: []*iaas.VPCRouterSiteToSiteIPsecVPNConfig{
+							{
+								Peer:            "8.8.8.8",
+								PreSharedSecret: "api-secret",
+								RemoteID:        "8.8.8.8",
+								Routes:          []string{"10.0.0.0/8"},
+								LocalPrefix:     []string{"192.168.21.0/24"},
+							},
+						},
+					},
+				},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{},
+			},
+			ExpectEnabled: true,
+			ExpectPeer:    "8.8.8.8",
+			ExpectSecret:  "",
+		},
+		{
+			Name: "no site_to_site_vpn settings returns empty",
+			InputVPCRouter: &iaas.VPCRouter{
+				Settings: &iaas.VPCRouterSetting{},
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{},
+			},
+			ExpectEnabled: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := flattenVPCRouterSiteToSiteConfig(tc.InputVPCRouter, tc.InputConfig)
+			if !tc.ExpectEnabled {
+				if len(res) != 0 {
+					t.Fatalf("FAILED %s: expected empty got: %d elements", tc.Name, len(res))
+				}
+				return
+			}
+			if len(res) != 1 {
+				t.Fatalf("FAILED %s: expected 1 element got: %d", tc.Name, len(res))
+			}
+			got := res[0].(map[string]interface{})
+			if got["peer"] != tc.ExpectPeer {
+				t.Fatalf("FAILED %s peer: got: %v want: %v", tc.Name, got["peer"], tc.ExpectPeer)
+			}
+			if got["pre_shared_secret"] != tc.ExpectSecret {
+				t.Fatalf("FAILED %s pre_shared_secret: got: %v want: %v", tc.Name, got["pre_shared_secret"], tc.ExpectSecret)
+			}
+			if got["remote_id"] != "8.8.8.8" {
+				t.Fatalf("FAILED %s remote_id: got: %v want: %v", tc.Name, got["remote_id"], "8.8.8.8")
+			}
+			for _, key := range []string{"routes", "local_prefix"} {
+				if _, ok := got[key]; !ok {
+					t.Fatalf("FAILED %s: missing key %s", tc.Name, key)
+				}
+				set, ok := got[key].(*schema.Set)
+				if !ok {
+					t.Fatalf("FAILED %s: %s is not *schema.Set", tc.Name, key)
+				}
+				if set.Len() != 1 {
+					t.Fatalf("FAILED %s: %s set length mismatch", tc.Name, key)
+				}
+			}
+		})
+	}
+}

--- a/sakuracloud/structure_webaccel.go
+++ b/sakuracloud/structure_webaccel.go
@@ -107,7 +107,7 @@ func flattenWebAccelCorsRules(data []*webaccel.CORSRule) ([]interface{}, error) 
 	}
 }
 
-func flattenWebAccelLogUploadConfigData(data *webaccel.LogUploadConfig) []interface{} {
+func flattenWebAccelLogUploadConfigData(data *webaccel.LogUploadConfig, d resourceValueGettable) []interface{} {
 	loggingParams := make(map[string]interface{})
 	if data.Status == "enabled" {
 		loggingParams["enabled"] = true
@@ -115,8 +115,20 @@ func flattenWebAccelLogUploadConfigData(data *webaccel.LogUploadConfig) []interf
 		loggingParams["enabled"] = false
 	}
 	loggingParams["s3_bucket_name"] = data.Bucket
-	loggingParams["s3_access_key_id"] = data.AccessKeyID
-	loggingParams["s3_secret_access_key"] = data.SecretAccessKey
+
+	// NOTE: access key/secret cannot be fetched from remote reliably
+	presetLoggingParams, _ := mapFromSet(d, "logging")
+	if presetLoggingParams != nil {
+		if v, ok := presetLoggingParams.GetOk("s3_access_key_id"); ok {
+			loggingParams["s3_access_key_id"] = v.(string)
+		}
+		if v, ok := presetLoggingParams.GetOk("s3_secret_access_key"); ok {
+			loggingParams["s3_secret_access_key"] = v.(string)
+		}
+	} else {
+		loggingParams["s3_access_key_id"] = ""
+		loggingParams["s3_secret_access_key"] = ""
+	}
 	return []interface{}{loggingParams}
 }
 

--- a/sakuracloud/structure_webaccel_test.go
+++ b/sakuracloud/structure_webaccel_test.go
@@ -469,3 +469,91 @@ func TestExpandWebAccelCORSParameters(t *testing.T) {
 		})
 	}
 }
+
+func TestFlattenWebAccelLogUploadConfigData(t *testing.T) {
+	loggingSetHasher := func(_ interface{}) int { return 0 }
+	makeLoggingSet := func(m map[string]interface{}) *schema.Set {
+		return schema.NewSet(loggingSetHasher, []interface{}{m})
+	}
+
+	tt := []struct {
+		Name           string
+		InputData      *webaccel.LogUploadConfig
+		InputConfig    resourceValueGettable
+		ExpectedOutput []interface{}
+	}{
+		{
+			Name: "restores access key/secret from config when enabled",
+			InputData: &webaccel.LogUploadConfig{
+				Status: "enabled",
+				Bucket: "my-bucket",
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{
+					"logging": makeLoggingSet(map[string]interface{}{
+						"s3_access_key_id":     "config-key-id",
+						"s3_secret_access_key": "config-secret",
+					}),
+				},
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"enabled":              true,
+					"s3_bucket_name":       "my-bucket",
+					"s3_access_key_id":     "config-key-id",
+					"s3_secret_access_key": "config-secret",
+				},
+			},
+		},
+		{
+			Name: "restores access key/secret from config when disabled",
+			InputData: &webaccel.LogUploadConfig{
+				Status: "disabled",
+				Bucket: "my-bucket",
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{
+					"logging": makeLoggingSet(map[string]interface{}{
+						"s3_access_key_id":     "config-key-id",
+						"s3_secret_access_key": "config-secret",
+					}),
+				},
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"enabled":              false,
+					"s3_bucket_name":       "my-bucket",
+					"s3_access_key_id":     "config-key-id",
+					"s3_secret_access_key": "config-secret",
+				},
+			},
+		},
+		{
+			Name: "empty strings when no config present",
+			InputData: &webaccel.LogUploadConfig{
+				Status: "enabled",
+				Bucket: "my-bucket",
+			},
+			InputConfig: &resourceMapValue{
+				value: map[string]interface{}{},
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"enabled":              true,
+					"s3_bucket_name":       "my-bucket",
+					"s3_access_key_id":     "",
+					"s3_secret_access_key": "",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := flattenWebAccelLogUploadConfigData(tc.InputData, tc.InputConfig)
+			if !reflect.DeepEqual(res, tc.ExpectedOutput) {
+				t.Fatalf("FAILED %s: got: %v\nwant: %v", tc.Name, res, tc.ExpectedOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 背景

Terraform Provider Sakura (v3) の PR  sacloud/terraform-provider-sakura#234  と同等の変更を、Terraform Plugin SDK v2 の制約の中で実現します。

## Terraform Plugin SDK v2 の制約

SDK v2 には WriteOnly 属性が存在しないため、`_wo` サフィックスによる WriteOnly 版フィールドの提供はできません。
そのため、既存のフィールド名で以下の対応を行っています：

- `Sensitive: true` をスキーマに設定（CLI出力でのマスク）
- Read 関数で API レスポンスの機密フィールドを state に書き戻さず、代わりに config（設定値）をそのまま復元

## 変更対象（Resource）

| リソース | フィールド | 変更内容 |
|---|---|---|
| `sakuracloud_local_router` | `peer[].secret_key` | Read 時に config 値を復元 |
| `sakuracloud_vpc_router` | `l2tp[].pre_shared_secret` | `Sensitive: true` 追加 + Read 時に config 値を復元 |
| `sakuracloud_vpc_router` | `site_to_site_vpn[].pre_shared_secret` | `Sensitive: true` 追加 + Read 時に config 値を復元 |
| `sakuracloud_simple_monitor` | `health_check[].password` | `Sensitive: true` 追加 + Read 時に config 値を復元 |
| `sakuracloud_webaccel` | `logging[].s3_access_key_id` | Read 時に config 値を復元 |
| `sakuracloud_webaccel` | `logging[].s3_secret_access_key` | Read 時に config 値を復元 |

## 変更対象（Data Source）

| Data Source | フィールド | 変更内容 |
|---|---|---|
| `sakuracloud_simple_monitor` | `health_check[].password` | `Sensitive: true` を追加 |
| `sakuracloud_webaccel` | `logging[].s3_access_key_id` | 既存実装と同じく Read 時に空文字を設定 |
| `sakuracloud_webaccel` | `logging[].s3_secret_access_key` | 既存実装と同じく Read 時に空文字を設定 |

## 注意点

- `archive.source_shared_key` は `ForceNew: true` かつ Read 時に state へ書き戻さないため、Import 時は `source_shared_key` が空になります（既存テストの `ImportStateVerifyIgnore` に追加済み）