### PR TITLE
fix: avoid perpetual diff for webaccel domain and cors_rules

### DIFF
--- a/sakuracloud/resource_sakuracloud_webaccel.go
+++ b/sakuracloud/resource_sakuracloud_webaccel.go
@@ -462,7 +462,9 @@ func setWebAccelResourceData(d *schema.ResourceData, client *APIClient, data *we
 func setWebAccelSiteResourceData(d *schema.ResourceData, client *APIClient, data *webaccel.Site) diag.Diagnostics {
 	d.Set("name", data.Name)                                              //nolint:errcheck,gosec
 	d.Set("domain_type", data.DomainType)                                 //nolint:errcheck,gosec
-	d.Set("domain", data.Domain)                                          //nolint:errcheck,gosec
+	if _, ok := d.GetOk("domain"); ok {
+		d.Set("domain", data.Domain) //nolint:errcheck,gosec
+	}
 	d.Set("subdomain", data.Subdomain)                                    //nolint:errcheck,gosec
 	d.Set("cname_record_value", data.Subdomain+".")                       //nolint:errcheck,gosec
 	d.Set("txt_record_value", fmt.Sprintf("webaccel=%s", data.Subdomain)) //nolint:errcheck,gosec

--- a/sakuracloud/resource_sakuracloud_webaccel.go
+++ b/sakuracloud/resource_sakuracloud_webaccel.go
@@ -462,7 +462,7 @@ func setWebAccelResourceData(d *schema.ResourceData, client *APIClient, data *we
 func setWebAccelSiteResourceData(d *schema.ResourceData, client *APIClient, data *webaccel.Site) diag.Diagnostics {
 	d.Set("name", data.Name)                                              //nolint:errcheck,gosec
 	d.Set("domain_type", data.DomainType)                                 //nolint:errcheck,gosec
-	if _, ok := d.GetOk("domain"); ok {
+	if data.DomainType == "own_domain" {
 		d.Set("domain", data.Domain) //nolint:errcheck,gosec
 	}
 	d.Set("subdomain", data.Subdomain)                                    //nolint:errcheck,gosec

--- a/sakuracloud/resource_sakuracloud_webaccel.go
+++ b/sakuracloud/resource_sakuracloud_webaccel.go
@@ -460,10 +460,12 @@ func setWebAccelResourceData(d *schema.ResourceData, client *APIClient, data *we
 	return setWebAccelSiteResourceData(d, client, data)
 }
 func setWebAccelSiteResourceData(d *schema.ResourceData, client *APIClient, data *webaccel.Site) diag.Diagnostics {
-	d.Set("name", data.Name)                                              //nolint:errcheck,gosec
-	d.Set("domain_type", data.DomainType)                                 //nolint:errcheck,gosec
+	d.Set("name", data.Name)              //nolint:errcheck,gosec
+	d.Set("domain_type", data.DomainType) //nolint:errcheck,gosec
 	if data.DomainType == "own_domain" {
 		d.Set("domain", data.Domain) //nolint:errcheck,gosec
+	} else {
+		d.Set("domain", "") //nolint:errcheck,gosec
 	}
 	d.Set("subdomain", data.Subdomain)                                    //nolint:errcheck,gosec
 	d.Set("cname_record_value", data.Subdomain+".")                       //nolint:errcheck,gosec

--- a/sakuracloud/resource_sakuracloud_webaccel.go
+++ b/sakuracloud/resource_sakuracloud_webaccel.go
@@ -465,7 +465,7 @@ func setWebAccelSiteResourceData(d *schema.ResourceData, client *APIClient, data
 	if data.DomainType == "own_domain" {
 		d.Set("domain", data.Domain) //nolint:errcheck,gosec
 	} else {
-		d.Set("domain", "") //nolint:errcheck,gosec
+		d.Set("domain", nil) //nolint:errcheck,gosec
 	}
 	d.Set("subdomain", data.Subdomain)                                    //nolint:errcheck,gosec
 	d.Set("cname_record_value", data.Subdomain+".")                       //nolint:errcheck,gosec

--- a/sakuracloud/structure_webaccel.go
+++ b/sakuracloud/structure_webaccel.go
@@ -91,13 +91,9 @@ func flattenWebAccelCorsRules(data []*webaccel.CORSRule) ([]interface{}, error) 
 			return nil, nil
 		}
 		corsRuleParams := make(map[string]interface{})
-		switch {
-		case rule.AllowsAnyOrigin:
-			corsRuleParams["allow_all"] = rule.AllowsAnyOrigin
-		case len(rule.AllowedOrigins) > 0:
+		corsRuleParams["allow_all"] = rule.AllowsAnyOrigin
+		if len(rule.AllowedOrigins) > 0 {
 			corsRuleParams["allowed_origins"] = rule.AllowedOrigins
-		default:
-			corsRuleParams["allow_all"] = false
 		}
 		return []interface{}{corsRuleParams}, nil
 	default:

--- a/sakuracloud/structure_webaccel_test.go
+++ b/sakuracloud/structure_webaccel_test.go
@@ -346,6 +346,7 @@ func TestFlattenWebAccelCorsRules(t *testing.T) {
 			},
 			[]interface{}{
 				map[string]interface{}{
+					"allow_all":       false,
 					"allowed_origins": []string{"origin1", "origin2"},
 				},
 			},


### PR DESCRIPTION
## 背景

closes #1382

#1380 の対応中にwebaccel のテストで意図せず差分が出る問題を見つけたため修正。


## 変更内容

| 対象 | 変更内容 | 理由 |
|---|---|---|
| domain (resource) | Read 時に config で domain が指定されている場合のみ state に書き込む | subdomain タイプのサイトでは API が自動生成した domain を返すが、Config では指定されていないため、plan で domain = "xxx.user.webaccel.jp" -> null の perpetual diff が発生していた |
| cors_rules (resource) | flattenWebAccelCorsRules で常に allow_all を明示的に set | allowed_origins のみ指定した場合、allow_all が省略されていたため TypeSet の hash 不一致で perpetual diff が発生していた |

## テスト

一部SKIPされていますが今回の修正と関係ない部分だったので無視しました

```
TF_ACC=1 SAKURACLOUD_APPEND_USER_AGENT="(Acceptance Test)" go test -v -run="WebAccel_" -timeout 240m ./...
?       github.com/sacloud/terraform-provider-sakuracloud       [no test files]
?       github.com/sacloud/terraform-provider-sakuracloud/internal/defaults     [no test files]
?       github.com/sacloud/terraform-provider-sakuracloud/internal/desc [no test files]
?       github.com/sacloud/terraform-provider-sakuracloud/internal/ftps [no test files]
=== RUN   TestAccSakuraCloudDataSourceWebAccel_ByName
    data_source_sakuracloud_webaccel_test.go:44: ENV "SAKURACLOUD_WEBACCEL_SITE_NAME" is requilred. skip
--- SKIP: TestAccSakuraCloudDataSourceWebAccel_ByName (0.00s)
=== RUN   TestAccSakuraCloudDataSourceWebAccel_ByDomain
    data_source_sakuracloud_webaccel_test.go:84: ENV "SAKURACLOUD_WEBACCEL_DOMAIN_NAME" is requilred. skip
--- SKIP: TestAccSakuraCloudDataSourceWebAccel_ByDomain (0.00s)
=== RUN   TestAccSakuraCloudResourceWebAccel_WebOrigin
--- PASS: TestAccSakuraCloudResourceWebAccel_WebOrigin (10.56s)
=== RUN   TestAccSakuraCloudResourceWebAccel_OwnDomain
    resource_sakuracloud_webaccel_test.go:78: ENV "SAKURACLOUD_WEBACCEL_DOMAIN_NAME" is requilred. skip
--- SKIP: TestAccSakuraCloudResourceWebAccel_OwnDomain (0.00s)
=== RUN   TestAccSakuraCloudResourceWebAccel_WebOriginWithOneTimeUrlSecrets
--- PASS: TestAccSakuraCloudResourceWebAccel_WebOriginWithOneTimeUrlSecrets (7.87s)
=== RUN   TestAccSakuraCloudResourceWebAccel_WebOriginWithCORS
--- PASS: TestAccSakuraCloudResourceWebAccel_WebOriginWithCORS (9.44s)
=== RUN   TestAccSakuraCloudResourceWebAccel_Update
    resource_sakuracloud_webaccel_test.go:200: ENV "SAKURASTORAGE_REGION" is requilred. skip
--- SKIP: TestAccSakuraCloudResourceWebAccel_Update (0.00s)
=== RUN   TestAccSakuraCloudResourceWebAccel_BucketOrigin
    resource_sakuracloud_webaccel_test.go:283: ENV "SAKURASTORAGE_REGION" is requilred. skip
--- SKIP: TestAccSakuraCloudResourceWebAccel_BucketOrigin (0.00s)
=== RUN   TestAccSakuraCloudResourceWebAccel_Logging
    resource_sakuracloud_webaccel_test.go:331: ENV "SAKURASTORAGE_ACCESS_KEY" is requilred. skip
--- SKIP: TestAccSakuraCloudResourceWebAccel_Logging (0.00s)
=== RUN   TestAccSakuraCloudResourceWebAccel_InvalidConfigurations
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: own-domain-without-domain
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: valid
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: unknown-argument
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: invalid-domain-type
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: lacking-bucket-origin-params
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: missing-logging-bucket-secret
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: invalid-cors-configuration
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: invalid-request-protocol
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: no-origin-params
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: invalid-origin-type
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: lacking-web-origin-params
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: mismatched-bucket-origin-type-and-params
    resource_sakuracloud_webaccel_test.go:371: test for invalid configuration: invalid-compression
--- PASS: TestAccSakuraCloudResourceWebAccel_InvalidConfigurations (75.24s)
PASS
ok      github.com/sacloud/terraform-provider-sakuracloud/sakuracloud   103.696s
```