### PR TITLE
deprecate: mark sakuracloud_apprun_application as deprecated

### DIFF
--- a/sakuracloud/data_source_sakuracloud_apprun_application.go
+++ b/sakuracloud/data_source_sakuracloud_apprun_application.go
@@ -25,7 +25,8 @@ import (
 
 func dataSourceSakuraCloudApprunApplication() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceSakuraCloudApprunApplicationRead,
+		DeprecationMessage: "The sakuracloud_apprun_application data source is deprecated. Use the sakura_apprun_shared resource in the sakura provider instead.",
+		ReadContext:        dataSourceSakuraCloudApprunApplicationRead,
 
 		Schema: map[string]*schema.Schema{
 			// input/condition

--- a/sakuracloud/resource_sakuracloud_apprun_application.go
+++ b/sakuracloud/resource_sakuracloud_apprun_application.go
@@ -29,10 +29,11 @@ import (
 
 func resourceSakuraCloudApprunApplication() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSakuraCloudApprunApplicationCreate,
-		UpdateContext: resourceSakuraCloudApprunApplicationUpdate,
-		ReadContext:   resourceSakuraCloudApprunApplicationRead,
-		DeleteContext: resourceSakuraCloudApprunApplicationDelete,
+		DeprecationMessage: "The sakuracloud_apprun_application resource is deprecated. Use the sakura_apprun_shared resource in the sakura provider instead.",
+		CreateContext:      resourceSakuraCloudApprunApplicationCreate,
+		UpdateContext:      resourceSakuraCloudApprunApplicationUpdate,
+		ReadContext:        resourceSakuraCloudApprunApplicationRead,
+		DeleteContext:      resourceSakuraCloudApprunApplicationDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/website/docs/d/apprun_application.md
+++ b/website/docs/d/apprun_application.md
@@ -8,6 +8,8 @@ description: |-
 
 # Data Source: sakuracloud_apprun_application
 
+~> **Deprecated:** This data source is deprecated. Use the `sakura_apprun_shared` resource in the `sakura` provider instead.
+
 Get information about an existing AppRun Application.
 
 ## Argument Reference

--- a/website/docs/r/apprun_application.md
+++ b/website/docs/r/apprun_application.md
@@ -8,6 +8,8 @@ description: |-
 
 # sakuracloud_apprun_application
 
+~> **Deprecated:** This resource is deprecated. Use the `sakura_apprun_shared` resource in the `sakura` provider instead.
+
 Manages a SakuraCloud AppRun Application.
 
 ## Example Usage


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

`sakuracloud_apprun_application` リソースおよびデータソースを非推奨にします。
代わりに `sakura` プロバイダーの `sakura_apprun_shared` リソースの利用を推奨します。

変更内容:
- `resource_sakuracloud_apprun_application.go` に `DeprecationMessage` を追加
- `data_source_sakuracloud_apprun_application.go` に `DeprecationMessage` を追加
- リソースおよびデータソースのドキュメントに非推奨の注記を追加

### ドキュメントの変更は必要ですか？

ドキュメントに非推奨の注記を追加済みです。