### PR TITLE
deprecate: mark container_registry access_level as deprecated

### DIFF
--- a/sakuracloud/data_source_sakuracloud_container_registry.go
+++ b/sakuracloud/data_source_sakuracloud_container_registry.go
@@ -33,8 +33,9 @@ func dataSourceSakuraCloudContainerRegistry() *schema.Resource {
 			filterAttrName: filterSchema(&filterSchemaOption{}),
 			"name":         schemaDataSourceName(resourceName),
 			"access_level": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "The access_level field is deprecated. Future versions will not support public access settings, and this field will be removed.",
 				Description: desc.Sprintf(
 					"The level of access that allow to users. This will be one of [%s]",
 					types.ContainerRegistryAccessLevelStrings,

--- a/sakuracloud/resource_sakuracloud_container_registry.go
+++ b/sakuracloud/resource_sakuracloud_container_registry.go
@@ -44,8 +44,10 @@ func resourceSakuraCloudContainerRegistry() *schema.Resource {
 			"name": schemaResourceName(resourceName),
 			"access_level": {
 				Type:             schema.TypeString,
-				Required:         true,
+				Optional:         true,
+				Default:          types.ContainerRegistryAccessLevels.None.String(),
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(types.ContainerRegistryAccessLevelStrings, false)),
+				Deprecated:       "The access_level field is deprecated. Future versions will not support public access settings, and this field will be removed.",
 				Description: desc.Sprintf(
 					"The level of access that allow to users. This must be one of [%s]",
 					types.ContainerRegistryAccessLevelStrings,

--- a/sakuracloud/resource_sakuracloud_container_registry_test.go
+++ b/sakuracloud/resource_sakuracloud_container_registry_test.go
@@ -91,6 +91,72 @@ func TestAccSakuraCloudContainerRegistry_basic(t *testing.T) {
 	})
 }
 
+func TestAccSakuraCloudContainerRegistry_withoutAccessLevel(t *testing.T) {
+	resourceName := "sakuracloud_container_registry.foobar"
+	rand := randomName()
+	subDomainLabel := acctest.RandStringFromCharSet(60, acctest.CharSetAlpha)
+	password := randomPassword()
+
+	var reg iaas.ContainerRegistry
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraCloudContainerRegistryDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: buildConfigWithArgs(testAccSakuraCloudContainerRegistry_withoutAccessLevel, rand, subDomainLabel, password),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraCloudContainerRegistryExists(resourceName, &reg),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
+					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
+					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.name", "user1"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.permission", "all"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSakuraCloudContainerRegistry_accessLevelMigration(t *testing.T) {
+	resourceName := "sakuracloud_container_registry.foobar"
+	rand := randomName()
+	subDomainLabel := acctest.RandStringFromCharSet(60, acctest.CharSetAlpha)
+	password := randomPassword()
+
+	var reg iaas.ContainerRegistry
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraCloudContainerRegistryDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: buildConfigWithArgs(testAccSakuraCloudContainerRegistry_withReadonly, rand, subDomainLabel, password),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraCloudContainerRegistryExists(resourceName, &reg),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
+					resource.TestCheckResourceAttr(resourceName, "access_level", "readonly"),
+				),
+			},
+			{
+				Config: buildConfigWithArgs(testAccSakuraCloudContainerRegistry_withoutAccessLevel, rand, subDomainLabel, password),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraCloudContainerRegistryExists(resourceName, &reg),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
+					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckSakuraCloudContainerRegistryExists(n string, auto_backup *iaas.ContainerRegistry) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -170,6 +236,33 @@ resource "sakuracloud_container_registry" "foobar" {
 resource "sakuracloud_icon" "foobar" {
   name          = "{{ .arg0 }}"
   base64content = "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAACdBJREFUWMPNmHtw1NUVx8+5v9/+9rfJPpJNNslisgmIiCCgDQZR5GWnilUDPlpUqjOB2mp4qGM7tVOn/yCWh4AOVUprHRVB2+lMa0l88Kq10iYpNYPWkdeAmFjyEJPN7v5+v83ec/rH3Q1J2A2Z1hnYvz755ZzzvXPPveeee/GbC24FJmZGIYD5QgPpTBIAAICJLgJAwUQMAIDMfOEBUQchgJmAEC8CINLPThpfFCAG5orhogCBQiAAEyF8PQCATEQyxQzMzFIi4Ojdv86UEVF/f38ymezv7yciANR0zXAZhuHSdR0RRxNHZyJEBERmQvhfAAABIJlMJhIJt9t9TXX11GlTffleQGhvbz/4YeuRw4c13ZWfnycQR9ACQEShAyIxAxEKMXoAIVQ6VCzHcSzLmj937qqVK8aNrYKhv4bGxue3bvu8rc3n9+ualisyMzOltMjYccBqWanKdD5gBgAppZNMJhKJvlgs1heLxWL3fPfutU8/VVhYoGx7e3uJyOVyAcCEyy6bN2d266FDbW3thsuFI0gA4qy589PTOJC7EYEBbNu2ElYg4J9e/Y3p1dWBgN+l67csWKBC/mrbth07dnafOSMQp0y58pEVK2tm1ABAW9vn93zvgYRl5+XlAXMuCbxh3o3MDMyIguE8wADRaJ/H7Vp873119y8JBALDsrN8xcpXX3utoKDQNE1iiEV7ieSzmzYuXrwYAH7z4m83bNocDAZ1Tc8hQThrzjwYxY8BmCjaF/P78n+xZs0Ns64f+Ndnn53yevOLioo2btq8bsOGsvAYn9eHAoFZStnR0aFpWsObfxw/fvzp06fvXnyvZVmmx4M5hHQa3S4DwIRlm4Zr7dNPz7r+OgDo6el5bsuWtxrf6u7u9njygsHC9i/+U1Ia9ubnMzATA7MQIlRS8tnJk3/e1fDoI6vKysoqK8pbP/q323RDdi2hq/0ysHGyAwopU4lEfNXKlWo0Hx069MDSZcePHy8MBk3Tk0ylTnd1+wsKTNMERLUGlLtA1A3jyNEjagIKgsFk0gEM5NCSOst0+wEjAEvHtktKSuoeWAIAX3311f11Szs7OydcPtFwGYDp0sagWhoa7K4G5/f71TfHskEVdHXMn6M16CzLDcRkWfaM6dWm6QGAjZs2t7W1X1JeYRgGMzERMxOnNYa5O8mkrmkzr50JAKlUqq29Le2VQ0sACmYmIvU1OwAmLKt6ejUAyJTcu3dfQTCoaZqUkgEoY0ODvKRMSWbLsjo6O2fPmbuw9nYAOHjw4KdHjhqGoRqgLFpS6oNOE84JRDLVX1FeDgBd3V0pIrfLxZn5GGLMrE40y7YTCcula7W3167++c+UzfNbtzGRK+ObxR1RZyJARPUpNxBzPBYDAE3ThCYkETMjIPMQdwCwbNttGItqb6uqrJo2deqMGTVK8qWXX969+92SsjAi5hRF1BkQKJ3REUDXtE+PHL3ppptCoVBpcXFXVzdJqerFWWNmKaVt2T9YWldf//Dg6rL52efWrV/vCxQYLhdJmV2LmaUUkEkZZGbvXGBm0+P563vvqT/vW7LEcRwnmUxv7wFjZiYyDJdabQCQSsnt27d/6+YFT61Z4/UHBvZadi1mQBRERMwEMAIwkdttNh/8V2trKwB85647a2tv7+npTfb3y6HGKLREIvHKK6+my66ubd/x+p69+0KlZf5AQKV+BC0G0MaURwZGlxMAiam9vf3YsWNL7rsXAL694Oa2tvZPPvnEZRiozBABAIE1XfvggwMfffzxnXcsAoBrZ8zYs3+/pmm6ECNJIKrto4UvueQ8pxiRZduxWKympuauRQsnT56saRoAlIRCbzbsYmYhxGB7TdPcHk9LS3O4LHz1VVcFg8HmpubjJ0643W44/w8FS6kqW1YgKROW5VjWivr6P/3h93V1dYZhKNeD/2zp7elVjfAQLyKP2+0PFG5/NZ242XNm25bNRCNrKUjfy5gIzwXE/mQyEYs98dMnHnrw+yr6hx+2/qOp6djRo43vvGu4XJquZ3X3mO7OL8+cOnUqEolURSpUx53LeDDolDlE+ByQRNG+vlmzZ6vROI69fMWqN954Ix5PBAoLC4PBfK+XMqfSEHdEQJRS2ratyl1KSmLG3FoDoKcXFCIQDQOZTCLAQ8uWKtNlD/5w546dkaqqKq8XERDFQIkb7g6QSqUK/f5wOAwA0WgUiM+u/WxaChBRJxSgzsXhK5+sZDISiVxTUwMAjY2Nu3Y1RMZd6vXmAzCAIOB0uHP2SyqVisViCxcu9Pl8ANDc0oK6xswkxMg7mon0dGHMUqkg6Tjh0lLTdAPABwf+niKZ5zFRtRmQ8RrqyACyv783Gi0vL390eb0qqm+/szvPNNMzNGIFRnUvA0SAzOwNAiLJmU4zHo8DCgAgZgAETtswyX4pk8lkehP0pywrUTV27JaNGyqrKgHgha1bT548WRYOMwDk1hrIna46gbTAUBBCUwcqAFw6frwuRCqV0nUdmFB1MCRtx9E0bWwkEresRDzu9/nm3Th/Vf3DoVAIAJqbmtauXZfv9WpCpBd7Dq00EOGkKdNylCi0EgkhxP4971ZUVJw8ceK2RXd0dX9ZUFCgCaFyYTtOrC/22CMrf/LjH3V0dvX1RSsjEVemUDU3NS1d9uAXHR2lpaVqV4+iMIJWXFKKiEpgCCAKxI6OjuLioutmziwoLBxTFn7r7Xei0WhKSsdxYvF4PJ649Zabn1m/DhC93vxgMKiKuGUlntm46bHHHz/T0xsqKdEEZpYKZ9caJIpXTJmWfuVDofpPBcAMKKLRXoHwl727x106HgAOHDiw5ZcvHD5ymBiCwcJFtbXLM21GQ0ODZVm90ej77/9t3779XV2dBcEifyCgIcLQyCMBMU6cNCX3wQIkqbOzY+LlE373+s6KSER97untdSy7tKx0wHD16tVPPvkkAIDQvV6fz+fNz/emXzyAYVS5yqSsqLh4UM8GwwAFmqZ54sSJXY2NJSUlkyZNAgDTNL1er/Jvb29/uL7+1y++VFQcKg2PCYVCfr/XND1C01QnnytydkDECVdcqdpqtXGGgcqulHTmy+54PH71VdNunD+/sqoSEaPRaEtzy569exO2UxQM5nm9ynpQgrIEPA8w42UTJ6dLEkNWUI0KMTu2E4v3xftiSccGAKHpnrw8v8/vyfPoug4Zv1xxRgOIoDNJQAEMmfo9HNT9DxFN03QbRrCwCNQjHAp1gVc2mQKbM86oAFCA0GDQnSEXqMcGwPQjmND1zGgEAFBmNOeNMzIQSZ0GXvJHuJedPXRkLhiN+2hAVxUdz77yXWDQUdMGFUa40DC4Y/ya5vz/BMEkmVm9dl94QPwvNJB+oilXgHEAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTYtMDItMTBUMjE6MDg6MzMtMDg6MDB4P0OtAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2LTAyLTEwVDIxOjA4OjMzLTA4OjAwCWL7EQAAAABJRU5ErkJggg=="
+}
+`
+
+var testAccSakuraCloudContainerRegistry_withReadonly = `
+resource "sakuracloud_container_registry" "foobar" {
+  name            = "{{ .arg0 }}"
+  subdomain_label = "{{ .arg1 }}"
+  access_level    = "readonly"
+
+  user {
+    name       = "user1"
+    password   = "{{ .arg2 }}"
+    permission = "all"
+  }
+}
+`
+
+var testAccSakuraCloudContainerRegistry_withoutAccessLevel = `
+resource "sakuracloud_container_registry" "foobar" {
+  name            = "{{ .arg0 }}"
+  subdomain_label = "{{ .arg1 }}"
+
+  user {
+    name       = "user1"
+    password   = "{{ .arg2 }}"
+    permission = "all"
+  }
 }
 `
 


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

`sakuracloud_container_registry` の `access_level` 属性を非推奨にします。

- スキーマ上に `Deprecated` を追加し、Terraform CLI が非推奨警告を出力するようにしました
- `Required: true` → `Optional: true, Default: "none"` に変更し、未指定時はデフォルトで `"none"`（非公開）を使用するようにしました
  - Terraform Plugin SDK v2 の制約により、`Optional + Computed` では未指定時にstateの値を維持してしまうため、`Default` を使用しています
- これにより、新規コードでは `access_level` を省略可能になり、既存コードで `access_level` を削除すると `"none"` に変更されます

背景: コンテナレジストリの公開設定（Pullのみ）は廃止予定となり、今後は一律「非公開」での運用となります。
詳細: https://cloud.sakura.ad.jp/news/2026/05/27/container-registry-public-access-setting-discontinued/

参考: https://github.com/sacloud/terraform-provider-sakura/pull/264

### 元のPRとの違い

元のPR（terraform-provider-sakura/pull/264）は Terraform Plugin Framework を使用していますが、このリポジトリは Terraform Plugin SDK v2 を使用しています。

SDK v2 では `Optional + Computed` を組み合わせた場合、設定から属性を削除してもstateの値が維持されてしまい、意図した `"none"` への変更が行われません。そのため、このPRでは `Default: "none"` を使用して、省略時や削除時に確実に `"none"` が適用されるようにしています。

### ドキュメントの変更は必要ですか？

不要。examples/ および docs/ は `make generate-docs` で自動生成済みです。

<!-- for GitHub Copilot: レビューは日本語で実施してください -->
